### PR TITLE
Prettier TUI: color palette, dividers, hover, settings page

### DIFF
--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -30,7 +30,10 @@ pub struct Config {
     pub time_format: String,
     /// The tmux session repomon manages agents in.
     pub tmux_session: String,
-    /// Optional accent color name (e.g. "cyan"); default monochrome.
+    /// Accent color for headers, the selected lane, section dividers, and dirty marks. A named
+    /// color (`cyan`, `green`, `magenta`, `amber`, …) or a `#rrggbb`/`#rgb` hex. Unset defaults to
+    /// cyan; `"mono"` (or `"none"`/`"off"`) turns all color off for the original monochrome look.
+    /// (Status colors — running=green, needs-you=amber, rate-limited=cyan — are fixed.)
     pub accent: Option<String>,
     /// The agent preselected in New Lane (a built-in kind like "claude-code" or a custom
     /// name). `None` falls back to the first listed agent.

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -30,6 +30,17 @@ fn to_value<T: serde::Serialize>(v: T) -> Result<Value, RpcError> {
     serde_json::to_value(v).map_err(internal)
 }
 
+/// The editable subset of the config exposed to the Settings view.
+fn config_json(cfg: &repomon_core::config::Config) -> Value {
+    json!({
+        "accent": cfg.accent,
+        "auto_continue": cfg.auto_continue,
+        "auto_continue_message": cfg.auto_continue_message,
+        "default_agent": cfg.default_agent,
+        "worktree_template": cfg.worktree_template,
+    })
+}
+
 #[derive(Deserialize)]
 struct RepoAdd {
     path: String,
@@ -128,6 +139,10 @@ struct ConfigSet {
     auto_continue: Option<bool>,
     #[serde(default)]
     auto_continue_message: Option<String>,
+    #[serde(default)]
+    default_agent: Option<String>,
+    #[serde(default)]
+    worktree_template: Option<String>,
 }
 #[derive(Deserialize)]
 struct AgentAdopt {
@@ -494,11 +509,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         }
         "config.get" => {
             let cfg = ctx.config.read().await;
-            Ok(json!({
-                "accent": cfg.accent,
-                "auto_continue": cfg.auto_continue,
-                "auto_continue_message": cfg.auto_continue_message,
-            }))
+            Ok(config_json(&cfg))
         }
         "config.set" => {
             let p: ConfigSet = parse(params)?;
@@ -514,17 +525,19 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 if let Some(m) = p.auto_continue_message {
                     cfg.auto_continue_message = m;
                 }
+                if let Some(d) = p.default_agent {
+                    cfg.default_agent = Some(d);
+                }
+                if let Some(w) = p.worktree_template {
+                    cfg.worktree_template = w;
+                }
                 if let Err(e) = cfg.save_to(&ctx.config_path) {
                     *cfg = prev;
                     return Err(internal(e));
                 }
             }
             let cfg = ctx.config.read().await;
-            Ok(json!({
-                "accent": cfg.accent,
-                "auto_continue": cfg.auto_continue,
-                "auto_continue_message": cfg.auto_continue_message,
-            }))
+            Ok(config_json(&cfg))
         }
         "agent.spawn" => {
             let p: AgentSpawn = parse(params)?;

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -119,6 +119,16 @@ struct AgentSetDefault {
     #[serde(default)]
     name: Option<String>,
 }
+/// A partial config update from the Settings view — only the present fields are applied.
+#[derive(Deserialize)]
+struct ConfigSet {
+    #[serde(default)]
+    accent: Option<String>,
+    #[serde(default)]
+    auto_continue: Option<bool>,
+    #[serde(default)]
+    auto_continue_message: Option<String>,
+}
 #[derive(Deserialize)]
 struct AgentAdopt {
     lane_id: repomon_core::model::LaneId,
@@ -481,6 +491,40 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 json!({ "default": p.name }),
             );
             Ok(Value::Null)
+        }
+        "config.get" => {
+            let cfg = ctx.config.read().await;
+            Ok(json!({
+                "accent": cfg.accent,
+                "auto_continue": cfg.auto_continue,
+                "auto_continue_message": cfg.auto_continue_message,
+            }))
+        }
+        "config.set" => {
+            let p: ConfigSet = parse(params)?;
+            {
+                let mut cfg = ctx.config.write().await;
+                let prev = cfg.clone();
+                if let Some(a) = p.accent {
+                    cfg.accent = Some(a);
+                }
+                if let Some(b) = p.auto_continue {
+                    cfg.auto_continue = b;
+                }
+                if let Some(m) = p.auto_continue_message {
+                    cfg.auto_continue_message = m;
+                }
+                if let Err(e) = cfg.save_to(&ctx.config_path) {
+                    *cfg = prev;
+                    return Err(internal(e));
+                }
+            }
+            let cfg = ctx.config.read().await;
+            Ok(json!({
+                "accent": cfg.accent,
+                "auto_continue": cfg.auto_continue,
+                "auto_continue_message": cfg.auto_continue_message,
+            }))
         }
         "agent.spawn" => {
             let p: AgentSpawn = parse(params)?;

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -85,6 +85,19 @@ fn is_double_click(
     matches!(prev, Some((t, l)) if l == lane && now.duration_since(t) < DOUBLE_CLICK)
 }
 
+/// Editable settings shown in the Settings view (a subset of the daemon config).
+#[derive(Default)]
+pub struct Settings {
+    pub accent: String,
+    pub auto_continue: bool,
+    pub auto_continue_message: String,
+}
+
+/// Accent choices the Settings view cycles through (`mono` = no color).
+const ACCENTS: &[&str] = &[
+    "cyan", "green", "magenta", "amber", "blue", "red", "white", "mono",
+];
+
 pub struct App {
     pub client: DaemonClient,
     pub theme: Theme,
@@ -137,6 +150,10 @@ pub struct App {
     pub ac_off: HashSet<LaneId>,
     /// Active tile in the babysit grid.
     pub grid_active: usize,
+    /// Settings view state.
+    pub settings: Settings,
+    pub settings_idx: usize,
+    pub settings_editing: bool,
     pub timeline: Option<TimelineData>,
     pub timeline_zoom: Zoom,
     pub sessions: Vec<WorkSession>,
@@ -213,6 +230,9 @@ impl App {
             hover_lane: None,
             ac_off: HashSet::new(),
             grid_active: 0,
+            settings: Settings::default(),
+            settings_idx: 0,
+            settings_editing: false,
             timeline: None,
             timeline_zoom: Zoom::Day,
             sessions: Vec::new(),
@@ -334,7 +354,8 @@ impl App {
             | View::Sessions
             | View::Search
             | View::AddRepo
-            | View::Agents => Vec::new(),
+            | View::Agents
+            | View::Settings => Vec::new(),
         }
     }
 
@@ -562,6 +583,7 @@ impl App {
             View::Sessions => self.sessions_key(key).await,
             View::AddRepo => self.addrepo_key(key).await,
             View::Agents => self.agents_key(key).await,
+            View::Settings => self.settings_key(key).await,
             _ if self.filtering => self.filter_key(key),
             _ => {
                 if let Some(action) = keybinds::nav(key) {
@@ -763,6 +785,111 @@ impl App {
     }
 
     /// Key handling for the agent manager: a list of agents plus an add/edit form.
+    async fn load_settings(&mut self) {
+        self.settings_idx = 0;
+        self.settings_editing = false;
+        if let Ok(v) = self.client.call("config.get", None).await {
+            self.apply_settings_value(&v);
+        }
+    }
+
+    fn apply_settings_value(&mut self, v: &serde_json::Value) {
+        if let Some(a) = v.get("accent") {
+            self.settings.accent = a
+                .as_str()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "cyan".to_string());
+        }
+        if let Some(b) = v.get("auto_continue").and_then(|x| x.as_bool()) {
+            self.settings.auto_continue = b;
+        }
+        if let Some(m) = v.get("auto_continue_message").and_then(|x| x.as_str()) {
+            self.settings.auto_continue_message = m.to_string();
+        }
+    }
+
+    /// Persist the current settings to the daemon config and apply the accent live.
+    async fn save_settings(&mut self) {
+        let params = json!({
+            "accent": self.settings.accent,
+            "auto_continue": self.settings.auto_continue,
+            "auto_continue_message": self.settings.auto_continue_message,
+        });
+        match self.client.call("config.set", Some(params)).await {
+            Ok(v) => self.apply_settings_value(&v),
+            Err(e) => self.status = format!("settings save failed: {e}"),
+        }
+        // Re-theme the whole TUI from the new accent immediately.
+        self.theme = Theme::from_accent(Some(&self.settings.accent));
+    }
+
+    async fn settings_key(&mut self, key: KeyEvent) {
+        if self.settings_editing {
+            match key.code {
+                KeyCode::Char(c) => self.settings.auto_continue_message.push(c),
+                KeyCode::Backspace => {
+                    self.settings.auto_continue_message.pop();
+                }
+                KeyCode::Enter => {
+                    self.settings_editing = false;
+                    self.save_settings().await;
+                }
+                KeyCode::Esc => {
+                    self.settings_editing = false;
+                    self.load_settings().await; // discard the in-progress edit
+                }
+                _ => {}
+            }
+            return;
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.settings_idx = self.settings_idx.saturating_sub(1)
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.settings_idx = (self.settings_idx + 1).min(2)
+            }
+            KeyCode::Left => self.adjust_setting(false).await,
+            KeyCode::Right => self.adjust_setting(true).await,
+            KeyCode::Char(' ') | KeyCode::Enter => self.activate_setting().await,
+            KeyCode::Esc => self.view = View::Fleet,
+            KeyCode::Char('q') => self.should_quit = true,
+            _ => {}
+        }
+    }
+
+    async fn adjust_setting(&mut self, forward: bool) {
+        match self.settings_idx {
+            0 => {
+                let n = ACCENTS.len();
+                let cur = ACCENTS
+                    .iter()
+                    .position(|a| *a == self.settings.accent)
+                    .unwrap_or(0);
+                let next = if forward {
+                    (cur + 1) % n
+                } else {
+                    (cur + n - 1) % n
+                };
+                self.settings.accent = ACCENTS[next].to_string();
+                self.save_settings().await;
+            }
+            1 => {
+                self.settings.auto_continue = !self.settings.auto_continue;
+                self.save_settings().await;
+            }
+            _ => {}
+        }
+    }
+
+    async fn activate_setting(&mut self) {
+        match self.settings_idx {
+            0 | 1 => self.adjust_setting(true).await,
+            2 => self.settings_editing = true,
+            _ => {}
+        }
+    }
+
     async fn agents_key(&mut self, key: KeyEvent) {
         if self.ag_editing {
             match key.code {
@@ -1698,7 +1825,8 @@ impl App {
                     | View::Sessions
                     | View::Search
                     | View::AddRepo
-                    | View::Agents => self.view = View::Fleet,
+                    | View::Agents
+                    | View::Settings => self.view = View::Fleet,
                     View::Fleet => self.should_quit = true,
                 }
             }
@@ -1718,6 +1846,7 @@ impl App {
                         self.load_browse(cwd).await;
                     }
                     View::Agents => self.enter_agents(None).await,
+                    View::Settings => self.load_settings().await,
                     _ => {}
                 }
             }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -89,14 +89,19 @@ fn is_double_click(
 #[derive(Default)]
 pub struct Settings {
     pub accent: String,
+    pub default_agent: String,
     pub auto_continue: bool,
     pub auto_continue_message: String,
+    pub worktree_template: String,
 }
 
 /// Accent choices the Settings view cycles through (`mono` = no color).
 const ACCENTS: &[&str] = &[
     "cyan", "green", "magenta", "amber", "blue", "red", "white", "mono",
 ];
+
+/// Number of editable rows in the Settings view.
+const SETTINGS_COUNT: usize = 5;
 
 pub struct App {
     pub client: DaemonClient,
@@ -154,6 +159,8 @@ pub struct App {
     pub settings: Settings,
     pub settings_idx: usize,
     pub settings_editing: bool,
+    /// Screen row of the first settings item (for click hit-testing), set during render.
+    pub settings_geom: std::cell::Cell<u16>,
     pub timeline: Option<TimelineData>,
     pub timeline_zoom: Zoom,
     pub sessions: Vec<WorkSession>,
@@ -233,6 +240,7 @@ impl App {
             settings: Settings::default(),
             settings_idx: 0,
             settings_editing: false,
+            settings_geom: std::cell::Cell::new(0),
             timeline: None,
             timeline_zoom: Zoom::Day,
             sessions: Vec::new(),
@@ -556,6 +564,12 @@ impl App {
                         MouseEventKind::Up(MouseButton::Left) => self.copy_selection(),
                         _ => {}
                     },
+                    // Settings: a click selects + activates the row under the cursor.
+                    View::Settings => {
+                        if let MouseEventKind::Down(MouseButton::Left) = me.kind {
+                            self.settings_click(me.row).await;
+                        }
+                    }
                     // Grid/Fleet/Split: a left-click focuses the clicked lane (double-click opens
                     // its real terminal, a click on empty space blurs); the wheel still navigates.
                     _ => match me.kind {
@@ -788,17 +802,19 @@ impl App {
     async fn load_settings(&mut self) {
         self.settings_idx = 0;
         self.settings_editing = false;
+        self.load_agents().await; // populate nl_agents for the default-agent picker
         if let Ok(v) = self.client.call("config.get", None).await {
             self.apply_settings_value(&v);
         }
     }
 
     fn apply_settings_value(&mut self, v: &serde_json::Value) {
+        let s = |x: &serde_json::Value| x.as_str().map(|t| t.to_string());
         if let Some(a) = v.get("accent") {
-            self.settings.accent = a
-                .as_str()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "cyan".to_string());
+            self.settings.accent = s(a).unwrap_or_else(|| "cyan".to_string());
+        }
+        if let Some(d) = v.get("default_agent") {
+            self.settings.default_agent = s(d).unwrap_or_default();
         }
         if let Some(b) = v.get("auto_continue").and_then(|x| x.as_bool()) {
             self.settings.auto_continue = b;
@@ -806,14 +822,24 @@ impl App {
         if let Some(m) = v.get("auto_continue_message").and_then(|x| x.as_str()) {
             self.settings.auto_continue_message = m.to_string();
         }
+        if let Some(w) = v.get("worktree_template").and_then(|x| x.as_str()) {
+            self.settings.worktree_template = w.to_string();
+        }
     }
 
     /// Persist the current settings to the daemon config and apply the accent live.
     async fn save_settings(&mut self) {
+        let default_agent = if self.settings.default_agent.is_empty() {
+            serde_json::Value::Null
+        } else {
+            json!(self.settings.default_agent)
+        };
         let params = json!({
             "accent": self.settings.accent,
+            "default_agent": default_agent,
             "auto_continue": self.settings.auto_continue,
             "auto_continue_message": self.settings.auto_continue_message,
+            "worktree_template": self.settings.worktree_template,
         });
         match self.client.call("config.set", Some(params)).await {
             Ok(v) => self.apply_settings_value(&v),
@@ -823,12 +849,27 @@ impl App {
         self.theme = Theme::from_accent(Some(&self.settings.accent));
     }
 
+    /// The text field edited by the current row, if it's a text setting.
+    fn settings_edit_field(&mut self) -> Option<&mut String> {
+        match self.settings_idx {
+            3 => Some(&mut self.settings.auto_continue_message),
+            4 => Some(&mut self.settings.worktree_template),
+            _ => None,
+        }
+    }
+
     async fn settings_key(&mut self, key: KeyEvent) {
         if self.settings_editing {
             match key.code {
-                KeyCode::Char(c) => self.settings.auto_continue_message.push(c),
+                KeyCode::Char(c) => {
+                    if let Some(f) = self.settings_edit_field() {
+                        f.push(c);
+                    }
+                }
                 KeyCode::Backspace => {
-                    self.settings.auto_continue_message.pop();
+                    if let Some(f) = self.settings_edit_field() {
+                        f.pop();
+                    }
                 }
                 KeyCode::Enter => {
                     self.settings_editing = false;
@@ -847,7 +888,7 @@ impl App {
                 self.settings_idx = self.settings_idx.saturating_sub(1)
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.settings_idx = (self.settings_idx + 1).min(2)
+                self.settings_idx = (self.settings_idx + 1).min(SETTINGS_COUNT - 1)
             }
             KeyCode::Left => self.adjust_setting(false).await,
             KeyCode::Right => self.adjust_setting(true).await,
@@ -858,23 +899,34 @@ impl App {
         }
     }
 
+    /// Click on a settings row (from the mouse): select it and activate it.
+    async fn settings_click(&mut self, row: u16) {
+        let first = self.settings_geom.get();
+        if row >= first {
+            let idx = (row - first) as usize;
+            if idx < SETTINGS_COUNT {
+                self.settings_idx = idx;
+                self.activate_setting().await;
+            }
+        }
+    }
+
     async fn adjust_setting(&mut self, forward: bool) {
         match self.settings_idx {
             0 => {
-                let n = ACCENTS.len();
-                let cur = ACCENTS
-                    .iter()
-                    .position(|a| *a == self.settings.accent)
-                    .unwrap_or(0);
-                let next = if forward {
-                    (cur + 1) % n
-                } else {
-                    (cur + n - 1) % n
-                };
-                self.settings.accent = ACCENTS[next].to_string();
+                self.settings.accent = cycle(ACCENTS, &self.settings.accent, forward);
                 self.save_settings().await;
             }
             1 => {
+                let names: Vec<String> = self.nl_agents.iter().map(|a| a.name.clone()).collect();
+                if !names.is_empty() {
+                    let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+                    self.settings.default_agent =
+                        cycle(&refs, &self.settings.default_agent, forward);
+                    self.save_settings().await;
+                }
+            }
+            2 => {
                 self.settings.auto_continue = !self.settings.auto_continue;
                 self.save_settings().await;
             }
@@ -884,8 +936,8 @@ impl App {
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0 | 1 => self.adjust_setting(true).await,
-            2 => self.settings_editing = true,
+            0..=2 => self.adjust_setting(true).await,
+            3..=4 => self.settings_editing = true,
             _ => {}
         }
     }
@@ -1972,6 +2024,21 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     ratatui::restore();
     outcome?;
     Ok(app.cd_target)
+}
+
+/// Cycle `current` to the next/previous option (wrapping). Returns `current` if `options` is empty.
+fn cycle(options: &[&str], current: &str, forward: bool) -> String {
+    if options.is_empty() {
+        return current.to_string();
+    }
+    let n = options.len();
+    let cur = options.iter().position(|o| *o == current).unwrap_or(0);
+    let next = if forward {
+        (cur + 1) % n
+    } else {
+        (cur + n - 1) % n
+    };
+    options[next].to_string()
 }
 
 fn enable_mouse() {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -130,6 +130,8 @@ pub struct App {
     pub click_zones: RefCell<Vec<ClickZone>>,
     /// Last left-click (time + lane) for double-click detection.
     last_click: Option<(std::time::Instant, LaneId)>,
+    /// The lane the mouse is currently hovering (highlighted on render). `None` = not over a lane.
+    pub hover_lane: Option<LaneId>,
     /// Lanes where the user disabled auto-continue this session (echoes the daemon's set so the
     /// `C` key can toggle without a round-trip).
     pub ac_off: HashSet<LaneId>,
@@ -208,6 +210,7 @@ impl App {
             focus_geom: std::cell::Cell::new((0, 0, 0)),
             click_zones: RefCell::new(Vec::new()),
             last_click: None,
+            hover_lane: None,
             ac_off: HashSet::new(),
             grid_active: 0,
             timeline: None,
@@ -509,6 +512,11 @@ impl App {
             Event::Key(key) => key,
             Event::Mouse(me) => {
                 use ratatui::crossterm::event::{MouseButton, MouseEventKind};
+                // Bare movement just updates the hovered lane (highlighted on render).
+                if matches!(me.kind, MouseEventKind::Moved) {
+                    self.update_hover(me.column, me.row);
+                    return;
+                }
                 // In Focus the wheel scrolls the agent's output and a drag selects lines (copied
                 // to the clipboard on release); elsewhere the wheel moves the cursor.
                 match self.view {
@@ -1043,6 +1051,16 @@ impl App {
                 self.grid_active = gi;
             }
         }
+    }
+
+    /// Update the hovered lane from the mouse position by hit-testing the recorded click zones.
+    fn update_hover(&mut self, col: u16, row: u16) {
+        self.hover_lane = self
+            .click_zones
+            .borrow()
+            .iter()
+            .find(|z| z.rect.contains(Position { x: col, y: row }))
+            .map(|z| z.lane);
     }
 
     /// A left-click in Grid/Fleet/Split. Hit-test the lane regions recorded during render: a click
@@ -1829,7 +1847,12 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
 
 fn enable_mouse() {
     use ratatui::crossterm::event::EnableMouseCapture;
-    let _ = ratatui::crossterm::execute!(std::io::stdout(), EnableMouseCapture);
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    let _ = ratatui::crossterm::execute!(out, EnableMouseCapture);
+    // Also request any-motion tracking (mode 1003) so bare hover — no button — is reported.
+    let _ = out.write_all(b"\x1b[?1003h");
+    let _ = out.flush();
 }
 
 /// Discard any terminal input still buffered after returning from a tmux attach — mouse-tracking
@@ -1845,7 +1868,11 @@ fn drain_pending_input() {
 
 fn disable_mouse() {
     use ratatui::crossterm::event::DisableMouseCapture;
-    let _ = ratatui::crossterm::execute!(std::io::stdout(), DisableMouseCapture);
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    let _ = out.write_all(b"\x1b[?1003l"); // stop any-motion tracking
+    let _ = out.flush();
+    let _ = ratatui::crossterm::execute!(out, DisableMouseCapture);
 }
 
 async fn event_loop(

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -25,6 +25,8 @@ pub enum View {
     AddRepo,
     /// Manage agent launch commands (add/edit/delete customs, set the default).
     Agents,
+    /// Settings: accent color, auto-continue, etc.
+    Settings,
 }
 
 /// A user intent derived from a key press in navigation mode.
@@ -70,6 +72,7 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('g') => Some(Action::JumpNeedsYou),
         KeyCode::Char('a') => Some(Action::Goto(View::AddRepo)),
         KeyCode::Char('A') => Some(Action::Goto(View::Agents)),
+        KeyCode::Char(',') => Some(Action::Goto(View::Settings)),
         KeyCode::Char('s') => Some(Action::StopAgent),
         KeyCode::Char('p') => Some(Action::Pin),
         KeyCode::Char('m') => Some(Action::Merge),

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -111,6 +111,10 @@ impl Theme {
             _ => s,
         }
     }
+    /// Mouse-hover highlight — bold, distinct from the reverse-video selection.
+    pub fn hover(&self) -> Style {
+        Style::default().add_modifier(Modifier::BOLD)
+    }
     /// Accent foreground (dividers, dirty marks, active markers), else plain.
     pub fn accented(&self) -> Style {
         match (self.colored, self.accent) {

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -111,9 +111,15 @@ impl Theme {
             _ => s,
         }
     }
-    /// Mouse-hover highlight — bold, distinct from the reverse-video selection.
+    /// Mouse-hover highlight — bold plus a subtle row background (when colored), distinct from the
+    /// reverse-video selection. (Needs a terminal that reports mouse motion; not all do.)
     pub fn hover(&self) -> Style {
-        Style::default().add_modifier(Modifier::BOLD)
+        let s = Style::default().add_modifier(Modifier::BOLD);
+        if self.colored {
+            s.bg(Color::Indexed(236))
+        } else {
+            s
+        }
     }
     /// Accent foreground (dividers, dirty marks, active markers), else plain.
     pub fn accented(&self) -> Style {

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -1,7 +1,11 @@
-//! Brutalist monochrome theme: single-char status glyphs, light/heavy rules, and the one
-//! reserved accent slot (default `None`, wired up in Phase 4). No color in Phase 1.
+//! Theme: a tasteful semantic color palette over the flat, brutalist layout. The status colors are
+//! fixed (running=green, needs-you=amber, rate-limited=cyan, muted=gray) so meaning stays
+//! consistent; the one configurable hue is the **accent** (headers, selection, dividers, dirty
+//! marks) — any named color or `#hex`, default cyan. `accent = "mono"` turns color off for the
+//! original monochrome look.
 
 use ratatui::style::{Color, Modifier, Style};
+use repomon_core::model::AgentStatus;
 
 // Status glyphs.
 pub const DIRTY: &str = "●";
@@ -16,26 +20,72 @@ pub const DOWN: char = '↓';
 pub const HEAVY: char = '━';
 pub const LIGHT: char = '─';
 
-// Density blocks, low to high (timeline, Phase 3).
+// Density blocks, low to high (timeline).
 pub const DENSITY: [&str; 6] = [" ", "▁", "░", "▒", "▓", "█"];
 
-/// The theme. The accent slot is reserved; rendering stays monochrome until Phase 4.
-#[derive(Debug, Clone, Copy, Default)]
+// Fixed semantic colors — named ANSI so they respect the terminal's own palette.
+const RUNNING: Color = Color::Green;
+const NEEDS_YOU: Color = Color::Yellow;
+const RATE_LIMIT: Color = Color::Cyan;
+const MUTED: Color = Color::DarkGray;
+
+/// The theme: a configurable accent plus the fixed semantic palette. `colored = false` is the
+/// monochrome escape hatch (`accent = "mono"`), reproducing the original no-color look.
+#[derive(Debug, Clone, Copy)]
 pub struct Theme {
     pub accent: Option<Color>,
+    colored: bool,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme::from_accent(None)
+    }
 }
 
 impl Theme {
-    /// Build a theme from an optional accent color name (config-driven).
+    /// Build a theme from the optional `accent` config value: `"mono"`/`"none"`/`"off"` → no
+    /// color; a named color or `#hex` → that accent; unset → the default cyan accent.
     pub fn from_accent(name: Option<&str>) -> Self {
-        Theme {
-            accent: name.and_then(color_from_name),
+        match name.map(|n| n.trim().to_lowercase()) {
+            Some(n) if matches!(n.as_str(), "mono" | "none" | "off") => Theme {
+                accent: None,
+                colored: false,
+            },
+            Some(n) => Theme {
+                accent: Some(color_from_name(&n).unwrap_or(Color::Cyan)),
+                colored: true,
+            },
+            None => Theme {
+                accent: Some(Color::Cyan),
+                colored: true,
+            },
         }
     }
 
-    /// Selected row: reverse video, nothing else.
+    /// Whether color is enabled (false = the monochrome escape hatch).
+    pub fn colored(&self) -> bool {
+        self.colored
+    }
+
+    /// A foreground color, or plain when color is off.
+    fn fg(&self, c: Color) -> Style {
+        if self.colored {
+            Style::default().fg(c)
+        } else {
+            Style::default()
+        }
+    }
+
+    // --- structural ---
+
+    /// Selected row: reverse video, tinted by the accent when colored.
     pub fn selected(&self) -> Style {
-        Style::default().add_modifier(Modifier::REVERSED)
+        let s = Style::default().add_modifier(Modifier::REVERSED);
+        match (self.colored, self.accent) {
+            (true, Some(c)) => s.fg(c),
+            _ => s,
+        }
     }
     pub fn bold(&self) -> Style {
         Style::default().add_modifier(Modifier::BOLD)
@@ -43,26 +93,64 @@ impl Theme {
     pub fn dim(&self) -> Style {
         Style::default().add_modifier(Modifier::DIM)
     }
-    /// Header/title style: bold, tinted with the accent if one is configured.
-    pub fn header_style(&self) -> Style {
-        let s = Style::default().add_modifier(Modifier::BOLD);
-        match self.accent {
-            Some(c) => s.fg(c),
-            None => s,
+    /// Secondary text (times, footer, hints): gray when colored, dim otherwise.
+    pub fn muted(&self) -> Style {
+        if self.colored {
+            Style::default().fg(MUTED)
+        } else {
+            Style::default().add_modifier(Modifier::DIM)
         }
     }
-    /// Accent style if an accent is configured, else plain.
+    /// Header/title: bold, tinted with the accent when colored.
+    pub fn header_style(&self) -> Style {
+        let s = Style::default().add_modifier(Modifier::BOLD);
+        match (self.colored, self.accent) {
+            (true, Some(c)) => s.fg(c),
+            _ => s,
+        }
+    }
+    /// Accent foreground (dividers, dirty marks, active markers), else plain.
     pub fn accented(&self) -> Style {
-        match self.accent {
-            Some(c) => Style::default().fg(c),
-            None => Style::default(),
+        match (self.colored, self.accent) {
+            (true, Some(c)) => Style::default().fg(c),
+            _ => Style::default(),
+        }
+    }
+
+    // --- semantic status colors (plain when mono) ---
+
+    pub fn running(&self) -> Style {
+        self.fg(RUNNING)
+    }
+    pub fn needs_you(&self) -> Style {
+        self.fg(NEEDS_YOU)
+    }
+    pub fn rate_limited(&self) -> Style {
+        self.fg(RATE_LIMIT)
+    }
+    pub fn idle(&self) -> Style {
+        self.muted()
+    }
+
+    /// The style for an agent status — used by badges, glyphs, and mode lines.
+    pub fn status(&self, status: AgentStatus) -> Style {
+        match status {
+            AgentStatus::Running => self.running(),
+            AgentStatus::Waiting => self.needs_you(),
+            AgentStatus::RateLimited => self.rate_limited(),
+            _ => self.idle(),
         }
     }
 }
 
-/// Map a config color name to a ratatui color. Unknown names stay monochrome.
+/// Map a config color value to a ratatui color: a named ANSI color or a `#rrggbb`/`#rgb` hex.
+/// Unknown names return `None` (the caller falls back to the default accent).
 fn color_from_name(name: &str) -> Option<Color> {
-    match name.trim().to_lowercase().as_str() {
+    let n = name.trim().to_lowercase();
+    if let Some(hex) = n.strip_prefix('#') {
+        return parse_hex(hex);
+    }
+    match n.as_str() {
         "red" => Some(Color::Red),
         "green" => Some(Color::Green),
         "yellow" => Some(Color::Yellow),
@@ -71,6 +159,59 @@ fn color_from_name(name: &str) -> Option<Color> {
         "cyan" => Some(Color::Cyan),
         "white" => Some(Color::White),
         "gray" | "grey" => Some(Color::Gray),
+        "orange" | "amber" => Some(Color::Rgb(0xff, 0xb8, 0x6c)),
         _ => None,
+    }
+}
+
+/// Parse `rrggbb` or `rgb` (no leading `#`) into a truecolor.
+fn parse_hex(hex: &str) -> Option<Color> {
+    let h: String = match hex.len() {
+        6 => hex.to_string(),
+        3 => hex.chars().flat_map(|c| [c, c]).collect(),
+        _ => return None,
+    };
+    let r = u8::from_str_radix(&h[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&h[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&h[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mono_disables_color() {
+        let t = Theme::from_accent(Some("mono"));
+        assert!(!t.colored());
+        // No foreground color in any semantic style.
+        assert_eq!(t.running().fg, None);
+        assert_eq!(t.needs_you().fg, None);
+        assert_eq!(t.muted().fg, None);
+        assert_eq!(t.header_style().fg, None);
+        assert_eq!(t.selected().fg, None);
+    }
+
+    #[test]
+    fn default_is_colored_cyan() {
+        let t = Theme::from_accent(None);
+        assert!(t.colored());
+        assert_eq!(t.accent, Some(Color::Cyan));
+        assert_eq!(t.running().fg, Some(Color::Green));
+        assert_eq!(t.header_style().fg, Some(Color::Cyan));
+    }
+
+    #[test]
+    fn accent_accepts_names_and_hex() {
+        assert_eq!(Theme::from_accent(Some("green")).accent, Some(Color::Green));
+        assert_eq!(
+            Theme::from_accent(Some("#ff8800")).accent,
+            Some(Color::Rgb(0xff, 0x88, 0x00))
+        );
+        // Unknown name → default cyan, still colored.
+        let t = Theme::from_accent(Some("chartreuse"));
+        assert!(t.colored());
+        assert_eq!(t.accent, Some(Color::Cyan));
     }
 }

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -19,6 +19,8 @@ pub const DOWN: char = '↓';
 // Horizontal rules.
 pub const HEAVY: char = '━';
 pub const LIGHT: char = '─';
+// Vertical rule (column divider).
+pub const VLIGHT: char = '│';
 
 // Density blocks, low to high (timeline).
 pub const DENSITY: [&str; 6] = [" ", "▁", "░", "▒", "▓", "█"];

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -377,8 +377,18 @@ fn render_split(f: &mut Frame, app: &App) {
         ]),
         rows[0],
     );
-    let body = Layout::horizontal([Constraint::Length(26), Constraint::Min(0)]).split(rows[1]);
+    // Sidebar │ detail/output, separated by a vertical rule.
+    let body = Layout::horizontal([
+        Constraint::Length(26),
+        Constraint::Length(1),
+        Constraint::Min(0),
+    ])
+    .split(rows[1]);
     f.render_widget(Paragraph::new(sidebar_lines(app, body[0])), body[0]);
+    let divider: Vec<Line> = (0..body[1].height)
+        .map(|_| Line::from(Span::styled(theme::VLIGHT.to_string(), app.theme.muted())))
+        .collect();
+    f.render_widget(Paragraph::new(divider), body[1]);
     // Live agent output if there is any, otherwise the lane's git detail.
     let id = app.selected_lane().map(|l| l.id);
     let has_output = id
@@ -386,14 +396,14 @@ fn render_split(f: &mut Frame, app: &App) {
         .map(|p| !p.raw.trim().is_empty())
         .unwrap_or(false);
     let right = if has_output {
-        output_tail(app, id, body[1].height as usize)
+        output_tail(app, id, body[2].height as usize)
     } else {
         detail_lines(app)
     };
-    f.render_widget(Paragraph::new(right), body[1]);
+    f.render_widget(Paragraph::new(right), body[2]);
     // Clicking the pane focuses the selected agent for typing (double-click → real terminal).
     if let Some(id) = id {
-        click_zone(app, body[1], id, true);
+        click_zone(app, body[2], id, true);
     }
 
     // INSERT here forwards keystrokes straight to the selected agent (no need to zoom).
@@ -526,26 +536,22 @@ fn render_grid(f: &mut Frame, app: &App) {
 
     let active = app.grid_active.min(n - 1);
 
-    // Two columns; rows as needed for the visible tiles.
+    // Two columns (when wide enough); rows as needed — with a vertical/horizontal rule between
+    // tiles so each live pane reads as its own box.
     let cols = if area.width >= 80 { 2 } else { 1 };
     let tile_rows = n.div_ceil(cols);
-    let row_constraints: Vec<Constraint> = (0..tile_rows)
-        .map(|_| Constraint::Ratio(1, tile_rows as u32))
-        .collect();
-    let grid_rows = Layout::vertical(row_constraints).split(rows[1]);
+    let grid_rows = Layout::vertical(interleaved(tile_rows)).split(rows[1]);
 
-    for (r, row_area) in grid_rows.iter().enumerate() {
-        let col_constraints: Vec<Constraint> = (0..cols)
-            .map(|_| Constraint::Ratio(1, cols as u32))
-            .collect();
-        let cells = Layout::horizontal(col_constraints).split(*row_area);
-        for (c, cell) in cells.iter().enumerate() {
+    for r in 0..tile_rows {
+        let cells = Layout::horizontal(interleaved(cols)).split(grid_rows[r * 2]);
+        for c in 0..cols {
             let idx = r * cols + c;
             if idx >= n {
                 continue;
             }
+            let cell = cells[c * 2];
             let lane = app.lanes.iter().find(|l| l.id == ids[idx]);
-            click_zone(app, *cell, ids[idx], true);
+            click_zone(app, cell, ids[idx], true);
             f.render_widget(
                 Paragraph::new(tile_lines(
                     app,
@@ -555,7 +561,22 @@ fn render_grid(f: &mut Frame, app: &App) {
                     idx == active,
                     idx == active && app.focus_insert,
                 )),
-                *cell,
+                cell,
+            );
+            // Vertical rule between this tile and the next column's tile.
+            if c + 1 < cols && idx + 1 < n {
+                let vd = cells[c * 2 + 1];
+                let vline: Vec<Line> = (0..vd.height)
+                    .map(|_| Line::from(Span::styled(theme::VLIGHT.to_string(), app.theme.muted())))
+                    .collect();
+                f.render_widget(Paragraph::new(vline), vd);
+            }
+        }
+        // Horizontal rule between this row of tiles and the next.
+        if r + 1 < tile_rows {
+            f.render_widget(
+                Paragraph::new(rule(grid_rows[r * 2 + 1].width, false, app)),
+                grid_rows[r * 2 + 1],
             );
         }
     }
@@ -1152,6 +1173,20 @@ fn section_header(width: u16, title: &str, rest: &str, right: &str, app: &App) -
         Span::raw(" ".repeat(pad)),
         Span::styled(right.to_string(), app.theme.muted()),
     ])
+}
+
+/// Layout constraints for `count` equal cells separated by single-cell dividers:
+/// `[Fill(1), Length(1), Fill(1), …]`. The cell at logical index `i` is at split index `i * 2`,
+/// the divider after it at `i * 2 + 1`.
+fn interleaved(count: usize) -> Vec<Constraint> {
+    let mut v = Vec::new();
+    for i in 0..count {
+        if i > 0 {
+            v.push(Constraint::Length(1));
+        }
+        v.push(Constraint::Fill(1));
+    }
+    v
 }
 
 fn rule(width: u16, heavy: bool, app: &App) -> Line<'static> {

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -16,7 +16,7 @@ use crate::keybinds::View;
 use crate::theme;
 
 const FLEET_KEYS: &str =
-    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · d del  ·  / filter · g needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
+    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · g needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
@@ -53,6 +53,7 @@ pub fn render(f: &mut Frame, app: &App) {
         View::Search => render_search(f, app),
         View::AddRepo => render_addrepo(f, app),
         View::Agents => render_agents(f, app),
+        View::Settings => render_settings(f, app),
     }
 }
 
@@ -145,6 +146,77 @@ fn render_agents(f: &mut Frame, app: &App) {
     }
     f.render_widget(Paragraph::new(lines), rows[1]);
     f.render_widget(footer(AGENTS_KEYS, app), rows[2]);
+}
+
+const SETTINGS_KEYS: &str = "↑↓ select  ·  ←/→ change · space/↵ toggle/edit  ·  esc back";
+const SETTINGS_EDIT_KEYS: &str = "type the continue message  ·  ↵ save · esc cancel";
+
+/// The settings view: accent color (cycles, live preview), auto-continue on/off, and the
+/// continue message — each persisted to `~/.config/repomon/config.toml` via the daemon.
+fn render_settings(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    f.render_widget(
+        Paragraph::new(vec![
+            header_line(area.width, "REPOMON · SETTINGS", &fmt_clock(), app),
+            rule(area.width, true, app),
+        ]),
+        rows[0],
+    );
+
+    let s = &app.settings;
+    let auto = if s.auto_continue { "on" } else { "off" };
+    let msg_cur = if app.settings_editing { "_" } else { "" };
+    let items: [(&str, String, &str); 3] = [
+        ("accent", s.accent.clone(), "←/→ cycle · live preview"),
+        ("auto-continue", auto.to_string(), "space toggles"),
+        (
+            "continue message",
+            format!("{}{msg_cur}", s.auto_continue_message),
+            "↵ edit",
+        ),
+    ];
+    let mut lines = vec![Line::raw("")];
+    for (i, (name, value, hint)) in items.iter().enumerate() {
+        let selected = i == app.settings_idx;
+        let marker = if selected { "▸" } else { " " };
+        let row = if selected {
+            Line::from(Span::styled(
+                format!("  {marker} {name:<18}{value:<14}  {hint}"),
+                app.theme.selected(),
+            ))
+        } else {
+            Line::from(vec![
+                Span::raw(format!("  {marker} ")),
+                Span::styled(format!("{name:<18}"), app.theme.muted()),
+                Span::styled(format!("{value:<14}"), app.theme.accented()),
+                Span::styled(format!("  {hint}"), app.theme.muted()),
+            ])
+        };
+        lines.push(row);
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        "  accent: cyan/green/magenta/amber/blue/red/white, a #hex in config.toml, or mono"
+            .to_string(),
+        app.theme.muted(),
+    )));
+    if !app.status.is_empty() {
+        lines.push(Line::raw(""));
+        lines.push(Line::raw(format!("  {}", app.status)));
+    }
+    f.render_widget(Paragraph::new(lines), rows[1]);
+    let keys = if app.settings_editing {
+        SETTINGS_EDIT_KEYS
+    } else {
+        SETTINGS_KEYS
+    };
+    f.render_widget(footer(keys, app), rows[2]);
 }
 
 const ADDREPO_KEYS: &str =

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -148,7 +148,7 @@ fn render_agents(f: &mut Frame, app: &App) {
     f.render_widget(footer(AGENTS_KEYS, app), rows[2]);
 }
 
-const SETTINGS_KEYS: &str = "↑↓ select  ·  ←/→ change · space/↵ toggle/edit  ·  esc back";
+const SETTINGS_KEYS: &str = "↑↓ / click a row  ·  ←/→ change · space/↵ toggle/edit  ·  esc back";
 const SETTINGS_EDIT_KEYS: &str = "type the continue message  ·  ↵ save · esc cancel";
 
 /// The settings view: accent color (cycles, live preview), auto-continue on/off, and the
@@ -170,31 +170,54 @@ fn render_settings(f: &mut Frame, app: &App) {
     );
 
     let s = &app.settings;
-    let auto = if s.auto_continue { "on" } else { "off" };
-    let msg_cur = if app.settings_editing { "_" } else { "" };
-    let items: [(&str, String, &str); 3] = [
-        ("accent", s.accent.clone(), "←/→ cycle · live preview"),
-        ("auto-continue", auto.to_string(), "space toggles"),
+    let editing = app.settings_editing;
+    let cur = |i: usize| {
+        if editing && app.settings_idx == i {
+            "_"
+        } else {
+            ""
+        }
+    };
+    let default_agent = if s.default_agent.is_empty() {
+        "(first listed)".to_string()
+    } else {
+        s.default_agent.clone()
+    };
+    let items: [(&str, String, &str); 5] = [
+        ("accent", s.accent.clone(), "←/→ cycle · live"),
+        ("default agent", default_agent, "←/→ cycle"),
+        (
+            "auto-continue",
+            if s.auto_continue { "on" } else { "off" }.to_string(),
+            "space toggles",
+        ),
         (
             "continue message",
-            format!("{}{msg_cur}", s.auto_continue_message),
+            format!("{}{}", s.auto_continue_message, cur(3)),
+            "↵ edit",
+        ),
+        (
+            "worktree template",
+            format!("{}{}", s.worktree_template, cur(4)),
             "↵ edit",
         ),
     ];
+    // Items start one row below the body top (after a leading blank) — record it for clicks.
+    app.settings_geom.set(rows[1].y + 1);
     let mut lines = vec![Line::raw("")];
     for (i, (name, value, hint)) in items.iter().enumerate() {
         let selected = i == app.settings_idx;
         let marker = if selected { "▸" } else { " " };
         let row = if selected {
             Line::from(Span::styled(
-                format!("  {marker} {name:<18}{value:<14}  {hint}"),
+                format!("  {marker} {name:<18}{value:<22}  {hint}"),
                 app.theme.selected(),
             ))
         } else {
             Line::from(vec![
                 Span::raw(format!("  {marker} ")),
                 Span::styled(format!("{name:<18}"), app.theme.muted()),
-                Span::styled(format!("{value:<14}"), app.theme.accented()),
+                Span::styled(format!("{value:<22}"), app.theme.accented()),
                 Span::styled(format!("  {hint}"), app.theme.muted()),
             ])
         };
@@ -202,8 +225,7 @@ fn render_settings(f: &mut Frame, app: &App) {
     }
     lines.push(Line::raw(""));
     lines.push(Line::from(Span::styled(
-        "  accent: cyan/green/magenta/amber/blue/red/white, a #hex in config.toml, or mono"
-            .to_string(),
+        "  ↑↓ or click a row to change it · accent also takes a #hex in config.toml".to_string(),
         app.theme.muted(),
     )));
     if !app.status.is_empty() {

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -560,6 +560,7 @@ fn render_grid(f: &mut Frame, app: &App) {
                     cell.height as usize,
                     idx == active,
                     idx == active && app.focus_insert,
+                    app.hover_lane == Some(ids[idx]),
                 )),
                 cell,
             );
@@ -620,6 +621,7 @@ fn tile_lines(
     height: usize,
     active: bool,
     focused: bool,
+    hovered: bool,
 ) -> Vec<Line<'static>> {
     let marker = if focused {
         "▶"
@@ -640,6 +642,8 @@ fn tile_lines(
         app.theme.selected()
     } else if active {
         app.theme.bold()
+    } else if hovered {
+        app.theme.hover()
     } else {
         app.theme.dim()
     };
@@ -937,7 +941,11 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
             current = Some(lane.repo.id);
             lines.push(repo_header(width, &lane.repo.name, app));
         }
-        let line = lane_row(lane, now, app, i == app.selected);
+        let selected = i == app.selected;
+        let mut line = lane_row(lane, now, app, selected);
+        if !selected && app.hover_lane == Some(lane.id) {
+            line = line.style(app.theme.hover());
+        }
         // Record this row's on-screen rect so a click selects the lane (no live pane here, so a
         // single click only selects; double-click opens the real terminal).
         let li = lines.len() as u16;
@@ -994,7 +1002,7 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
         let counts = dirty_str(&lane.state.dirty);
         let rest = format!(" {:<10} {}", trunc(&lane_name(lane), 10), counts);
         let _ = now;
-        let line = if i == app.selected {
+        let mut line = if i == app.selected {
             Line::from(Span::styled(
                 format!(" {glyph}{rest}"),
                 app.theme.selected(),
@@ -1011,6 +1019,9 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
                 Span::raw(rest),
             ])
         };
+        if i != app.selected && app.hover_lane == Some(lane.id) {
+            line = line.style(app.theme.hover());
+        }
         let li = lines.len() as u16;
         if li < content.height {
             click_zone(

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -1,5 +1,6 @@
-//! Rendering for the four views. Brutalist mono: light/heavy rules, single-char glyphs,
-//! two-space indents, reverse-video selection, no color.
+//! Rendering for the views. Flat, brutalist layout — light/heavy rules, single-char glyphs,
+//! two-space indents — with a semantic color palette over the top (status colors + a
+//! configurable accent; see [`crate::theme`]). `accent = "mono"` restores the no-color look.
 
 use chrono::{DateTime, Local, Utc};
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -71,7 +72,7 @@ fn render_agents(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(vec![
             header_line(area.width, "REPOMON · AGENTS", &fmt_clock(), app),
-            rule(area.width, true),
+            rule(area.width, true, app),
         ]),
         rows[0],
     );
@@ -166,7 +167,7 @@ fn render_addrepo(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(vec![
             header_line(area.width, "REPOMON · ADD REPO", &fmt_clock(), app),
-            rule(area.width, true),
+            rule(area.width, true, app),
             Line::from(Span::styled(path_line, app.theme.dim())),
         ]),
         rows[0],
@@ -203,7 +204,7 @@ fn render_timeline(f: &mut Frame, app: &App) {
     let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
     let mut lines = vec![
         header_line(area.width, "REPOMON · TIMELINE", &fmt_clock(), app),
-        rule(area.width, true),
+        rule(area.width, true, app),
         Line::raw(""),
     ];
     match &app.timeline {
@@ -239,7 +240,7 @@ fn render_timeline(f: &mut Frame, app: &App) {
             }
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled("CORRELATIONS", app.theme.bold())));
-            lines.push(rule(area.width, false));
+            lines.push(rule(area.width, false, app));
             lines.push(Line::raw(""));
             if t.correlations.is_empty() {
                 lines.push(Line::raw("  (none above threshold)".to_string()));
@@ -266,7 +267,7 @@ fn render_sessions(f: &mut Frame, app: &App) {
     let total: i64 = app.sessions.iter().map(|s| s.duration_minutes()).sum();
     let mut lines = vec![
         header_line(area.width, "REPOMON · SESSIONS", &fmt_clock(), app),
-        rule(area.width, true),
+        rule(area.width, true, app),
         Line::raw(""),
         Line::from(Span::styled(
             format!(
@@ -316,7 +317,7 @@ fn render_search(f: &mut Frame, app: &App) {
     let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
     let mut lines = vec![
         header_line(area.width, "REPOMON · SEARCH", &fmt_clock(), app),
-        rule(area.width, true),
+        rule(area.width, true, app),
         Line::raw(""),
         Line::raw(format!("  search commits: {}_", app.search_query)),
         Line::raw(""),
@@ -372,7 +373,7 @@ fn render_split(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(vec![
             header_line(area.width, "REPOMON", &fmt_clock(), app),
-            rule(area.width, true),
+            rule(area.width, true, app),
         ]),
         rows[0],
     );
@@ -404,7 +405,7 @@ fn render_split(f: &mut Frame, app: &App) {
     } else {
         Line::from(Span::styled(
             " ○ i type to the selected agent · ↵/→ full-screen focus ",
-            app.theme.dim(),
+            app.theme.muted(),
         ))
     };
     f.render_widget(Paragraph::new(mode), rows[2]);
@@ -435,7 +436,7 @@ fn render_focus(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(vec![
             header_line(area.width, &title, &fmt_clock(), app),
-            rule(area.width, true),
+            rule(area.width, true, app),
         ]),
         rows[0],
     );
@@ -469,7 +470,7 @@ fn render_focus(f: &mut Frame, app: &App) {
     } else {
         Line::from(Span::styled(
             " ○ COMMAND — ↵/→ open real terminal (native scroll/copy/paste) · i quick-type · PgUp scroll ",
-            app.theme.dim(),
+            app.theme.muted(),
         ))
     };
     f.render_widget(Paragraph::new(mode), rows[2]);
@@ -501,7 +502,7 @@ fn render_grid(f: &mut Frame, app: &App) {
     f.render_widget(
         Paragraph::new(vec![
             header_line(area.width, &header, &fmt_clock(), app),
-            rule(area.width, true),
+            rule(area.width, true, app),
         ]),
         rows[0],
     );
@@ -559,25 +560,30 @@ fn render_grid(f: &mut Frame, app: &App) {
         }
     }
 
-    // Instagram-style position indicator at the bottom (above the footer): a dot per tile,
-    // filled for the active one, plus its name — so what's selected is clear at a glance.
-    let dots: String = (0..n)
-        .map(|i| if i == active { "●" } else { "○" })
-        .collect::<Vec<_>>()
-        .join(" ");
+    // Instagram-style position indicator at the bottom (above the footer): a dot per tile, the
+    // active one filled and accent-colored, plus its name — so what's selected is clear at a glance.
     let label = app
         .lanes
         .iter()
         .find(|l| l.id == ids[active])
         .map(|l| format!("{}/{}", l.repo.name, lane_name(l)))
         .unwrap_or_default();
-    f.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            format!("  {dots}    {}/{n}  {label}", active + 1),
-            app.theme.bold(),
-        ))),
-        rows[2],
-    );
+    let mut spans = vec![Span::raw("  ")];
+    for i in 0..n {
+        if i > 0 {
+            spans.push(Span::raw(" "));
+        }
+        if i == active {
+            spans.push(Span::styled("●", app.theme.accented()));
+        } else {
+            spans.push(Span::styled("○", app.theme.muted()));
+        }
+    }
+    spans.push(Span::styled(
+        format!("    {}/{n}  {label}", active + 1),
+        app.theme.bold(),
+    ));
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[2]);
     let keys = if app.focus_insert {
         GRID_INSERT_KEYS
     } else {
@@ -601,38 +607,45 @@ fn tile_lines(
     } else {
         " "
     };
-    let head = match lane {
-        Some(l) => format!(
-            "{marker}{}/{}  {}",
-            l.repo.name,
-            lane_name(l),
-            agent_badge(l)
-        ),
+    let (badge, badge_style) = match lane {
+        Some(l) => agent_badge(l, app),
+        None => (String::new(), Style::default()),
+    };
+    let label = match lane {
+        Some(l) => format!("{marker}{}/{}  ", l.repo.name, lane_name(l)),
         None => format!("{marker}lane {id}"),
     };
-    // When click-focused, the tile is capturing keystrokes — make that unmistakable.
-    let head = if focused {
-        format!("{head}  ⌨ typing (^O / click-out to blur)")
-    } else {
-        head
-    };
-    let style = if focused {
+    let base = if focused {
         app.theme.selected()
     } else if active {
         app.theme.bold()
     } else {
         app.theme.dim()
     };
-    let mut lines = vec![Line::from(Span::styled(head, style))];
+    let mut spans = vec![Span::styled(label, base)];
+    if !badge.is_empty() {
+        // While focused the whole header is the reverse-video bar; otherwise the badge is colored.
+        let bs = if focused { base } else { badge_style };
+        spans.push(Span::styled(badge, bs));
+    }
+    // When click-focused, the tile is capturing keystrokes — make that unmistakable.
+    if focused {
+        spans.push(Span::styled(
+            "  ⌨ typing (^O / click-out to blur)".to_string(),
+            base,
+        ));
+    }
+    let mut lines = vec![Line::from(spans)];
     lines.extend(output_tail(app, Some(id), height.saturating_sub(1)));
     lines
 }
 
-fn agent_badge(lane: &Lane) -> String {
+/// The status badge text for a lane's agents, plus the style (color) for that status.
+fn agent_badge(lane: &Lane, app: &App) -> (String, Style) {
     use repomon_core::model::AgentStatus;
     let sessions = &lane.agent_sessions;
     if sessions.is_empty() {
-        return String::new();
+        return (String::new(), Style::default());
     }
     let n = sessions.len();
     let waiting = sessions
@@ -658,13 +671,16 @@ fn agent_badge(lane: &Lane) -> String {
         .iter()
         .find(|s| s.status == AgentStatus::RateLimited);
     if let Some(rl) = rate_limited {
-        format!("⏳ rate-limited · {}{count}{tag}", fmt_resume(rl.resume_at))
+        (
+            format!("⏳ rate-limited · {}{count}{tag}", fmt_resume(rl.resume_at)),
+            app.theme.rate_limited(),
+        )
     } else if waiting > 0 {
-        format!("⏸ needs you{count}{tag}")
+        (format!("⏸ needs you{count}{tag}"), app.theme.needs_you())
     } else if running > 0 {
-        format!("▶ running{count}{tag}")
+        (format!("▶ running{count}{tag}"), app.theme.running())
     } else {
-        format!("idle{count}{tag}")
+        (format!("idle{count}{tag}"), app.theme.idle())
     }
 }
 
@@ -808,7 +824,7 @@ fn render_new_lane(f: &mut Frame, app: &App) {
     let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
     let mut lines = vec![
         header_line(area.width, "REPOMON · NEW LANE", &fmt_clock(), app),
-        rule(area.width, true),
+        rule(area.width, true, app),
         Line::raw(""),
     ];
     let repo_name = app
@@ -843,7 +859,7 @@ fn render_new_lane(f: &mut Frame, app: &App) {
     lines.push(Line::raw("  source    HEAD".to_string()));
     lines.push(Line::raw(format!("  path      {preview_path}   [auto]")));
     lines.push(Line::raw(""));
-    lines.push(rule(area.width, false));
+    lines.push(rule(area.width, false, app));
     lines.push(Line::raw(""));
     if !app.status.is_empty() {
         lines.push(Line::raw(format!("  {}", app.status)));
@@ -859,7 +875,7 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
     let now = Utc::now();
     let mut lines = Vec::new();
     lines.push(header_line(width, "REPOMON", &fmt_clock(), app));
-    lines.push(rule(width, true));
+    lines.push(rule(width, true, app));
     lines.push(Line::raw(""));
 
     let visible = app.visible_lanes();
@@ -868,13 +884,13 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
         .iter()
         .filter(|l| l.agent_sessions.iter().any(|s| s.status.needs_you()))
         .count();
-    let left = format!(
-        "FLEET  {} lanes · {repos} repos · {needs} need you",
+    let rest = format!(
+        "  {} lanes · {repos} repos · {needs} need you",
         visible.len()
     );
     let right = format!("today · {} commits", app.commits.len());
-    lines.push(padded_line(width, &left, &right, app.theme.bold()));
-    lines.push(rule(width, false));
+    lines.push(section_header(width, "FLEET", &rest, &right, app));
+    lines.push(rule(width, false, app));
     lines.push(Line::raw(""));
 
     if app.filtering || !app.filter.is_empty() {
@@ -894,13 +910,13 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
     let mut current: Option<RepoId> = None;
     for (i, lane) in visible.iter().enumerate() {
         if current != Some(lane.repo.id) {
+            if current.is_some() {
+                lines.push(Line::raw("")); // a gap between repo groups
+            }
             current = Some(lane.repo.id);
-            lines.push(repo_header(width, &lane.repo.name));
+            lines.push(repo_header(width, &lane.repo.name, app));
         }
-        let mut line = lane_row(lane, now);
-        if i == app.selected {
-            line = line.style(app.theme.selected());
-        }
+        let line = lane_row(lane, now, app, i == app.selected);
         // Record this row's on-screen rect so a click selects the lane (no live pane here, so a
         // single click only selects; double-click opens the real terminal).
         let li = lines.len() as u16;
@@ -921,8 +937,8 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::raw(""));
-    lines.push(padded_line(width, "TODAY", &tz_offset(), app.theme.bold()));
-    lines.push(rule(width, false));
+    lines.push(section_header(width, "TODAY", "", &tz_offset(), app));
+    lines.push(rule(width, false, app));
     lines.push(Line::raw(""));
     for c in app.commits.iter().take(12) {
         lines.push(commit_line(c, app));
@@ -940,7 +956,7 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(Span::styled(
             format!("FLEET {}", visible.len()),
-            app.theme.bold(),
+            app.theme.header_style(),
         )),
         Line::raw(""),
     ];
@@ -950,17 +966,30 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
             current = Some(lane.repo.id);
             lines.push(Line::from(Span::styled(
                 lane.repo.name.clone(),
-                app.theme.dim(),
+                app.theme.muted(),
             )));
         }
         let glyph = status_glyph(lane);
         let counts = dirty_str(&lane.state.dirty);
-        let text = format!(" {glyph} {:<10} {}", trunc(&lane_name(lane), 10), counts);
-        let mut line = Line::raw(text);
+        let rest = format!(" {:<10} {}", trunc(&lane_name(lane), 10), counts);
         let _ = now;
-        if i == app.selected {
-            line = line.style(app.theme.selected());
-        }
+        let line = if i == app.selected {
+            Line::from(Span::styled(
+                format!(" {glyph}{rest}"),
+                app.theme.selected(),
+            ))
+        } else {
+            let glyph_style = if lane.state.dirty.is_clean() {
+                app.theme.muted()
+            } else {
+                app.theme.accented()
+            };
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled(glyph.to_string(), glyph_style),
+                Span::raw(rest),
+            ])
+        };
         let li = lines.len() as u16;
         if li < content.height {
             click_zone(
@@ -990,7 +1019,7 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(Span::styled(
             format!("{} · {}", lane.repo.name, lane_name(lane)),
-            app.theme.bold(),
+            app.theme.header_style(),
         )),
         Line::raw(""),
         Line::raw(format!("  path     {}", lane.worktree.path.display())),
@@ -1034,7 +1063,7 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
         };
         lines.push(Line::from(Span::styled(
             format!("  agents   {n} active · {waiting} waiting{hint}"),
-            app.theme.bold(),
+            app.theme.header_style(),
         )));
         for (i, sess) in lane.agent_sessions.iter().enumerate() {
             let cursor = if i == app.session_idx { "‣" } else { " " };
@@ -1056,11 +1085,12 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
             } else {
                 ago(sess.last_activity_at)
             };
-            lines.push(Line::raw(format!(
-                "  {cursor} {glyph} {kind}  {:<40}  {}",
-                trunc(&label, 40),
-                trailer
-            )));
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {cursor} ")),
+                Span::styled(glyph.to_string(), app.theme.status(sess.status)),
+                Span::raw(format!(" {kind}  {:<40}  ", trunc(&label, 40))),
+                Span::styled(trailer, app.theme.muted()),
+            ]));
         }
     }
     // Plain shell terminals (no agent) — open as many as you like with `t`.
@@ -1074,7 +1104,10 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
     };
     lines.push(Line::raw(term_line));
     lines.push(Line::raw(""));
-    lines.push(Line::from(Span::styled("RECENT COMMITS", app.theme.bold())));
+    lines.push(Line::from(Span::styled(
+        "RECENT COMMITS",
+        app.theme.header_style(),
+    )));
     lines.push(Line::raw(""));
     // The latest commits on this worktree's branch (loaded per-selection), so a feature
     // branch or a repo with nothing today still shows its history.
@@ -1091,65 +1124,106 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
 // ---- atoms -------------------------------------------------------------------
 
 fn footer(keys: &str, app: &App) -> Paragraph<'static> {
-    Paragraph::new(Line::from(Span::styled(keys.to_string(), app.theme.dim())))
+    Paragraph::new(Line::from(Span::styled(
+        keys.to_string(),
+        app.theme.muted(),
+    )))
 }
 
 fn header_line(width: u16, left: &str, right: &str, app: &App) -> Line<'static> {
-    padded_line(width, left, right, app.theme.header_style())
-}
-
-fn padded_line(width: u16, left: &str, right: &str, left_style: Style) -> Line<'static> {
+    // The view title is the accent; the clock on the right is muted.
     let used = left.chars().count() + right.chars().count();
     let pad = (width as usize).saturating_sub(used);
     Line::from(vec![
-        Span::styled(left.to_string(), left_style),
+        Span::styled(left.to_string(), app.theme.header_style()),
         Span::raw(" ".repeat(pad)),
-        Span::raw(right.to_string()),
+        Span::styled(right.to_string(), app.theme.muted()),
     ])
 }
 
-fn rule(width: u16, heavy: bool) -> Line<'static> {
+/// A clear section divider: an accent title, the rest of the left text muted, and an optional
+/// muted right-aligned tail. Used for FLEET / TODAY / AGENTS-style headings.
+fn section_header(width: u16, title: &str, rest: &str, right: &str, app: &App) -> Line<'static> {
+    let used = title.chars().count() + rest.chars().count() + right.chars().count();
+    let pad = (width as usize).saturating_sub(used);
+    Line::from(vec![
+        Span::styled(title.to_string(), app.theme.header_style()),
+        Span::styled(rest.to_string(), app.theme.muted()),
+        Span::raw(" ".repeat(pad)),
+        Span::styled(right.to_string(), app.theme.muted()),
+    ])
+}
+
+fn rule(width: u16, heavy: bool, app: &App) -> Line<'static> {
+    // Heavy header rules take the accent; light section rules are muted — so dividers read as a
+    // distinct layer instead of blending with the white body text.
     let c = if heavy { theme::HEAVY } else { theme::LIGHT };
-    Line::raw(c.to_string().repeat(width as usize))
+    let style = if heavy {
+        app.theme.accented()
+    } else {
+        app.theme.muted()
+    };
+    Line::from(Span::styled(c.to_string().repeat(width as usize), style))
 }
 
-fn repo_header(width: u16, name: &str) -> Line<'static> {
-    let prefix = format!("  {name} ");
-    let dashes = (width as usize).saturating_sub(prefix.chars().count());
-    Line::raw(format!(
-        "{prefix}{}",
-        theme::LIGHT.to_string().repeat(dashes)
-    ))
+fn repo_header(width: u16, name: &str, app: &App) -> Line<'static> {
+    // "  NAME ─────…" — the repo name in the accent, the rule muted, so each group is delineated.
+    let used = 2 + name.chars().count() + 1;
+    let dashes = (width as usize).saturating_sub(used);
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(name.to_string(), app.theme.header_style()),
+        Span::raw(" "),
+        Span::styled(theme::LIGHT.to_string().repeat(dashes), app.theme.muted()),
+    ])
 }
 
-fn lane_row(lane: &Lane, now: DateTime<Utc>) -> Line<'static> {
+fn lane_row(lane: &Lane, now: DateTime<Utc>, app: &App, selected: bool) -> Line<'static> {
     use repomon_core::model::AgentStatus;
     let glyph = status_glyph(lane);
     let any = |st: AgentStatus| lane.agent_sessions.iter().any(|s| s.status == st);
-    let active = if any(AgentStatus::RateLimited) {
-        theme::RATE_LIMITED // ⏳ paused on a usage limit, auto-continuing
+    let (active, active_style) = if any(AgentStatus::RateLimited) {
+        (theme::RATE_LIMITED, app.theme.rate_limited()) // ⏳ paused on a usage limit
     } else if any(AgentStatus::Waiting) {
-        theme::WAITING // ⏸ needs you
+        (theme::WAITING, app.theme.needs_you()) // ⏸ needs you
     } else if any(AgentStatus::Running) {
-        theme::AGENT_ACTIVE // ▶ working
+        (theme::AGENT_ACTIVE, app.theme.running()) // ▶ working
     } else {
-        " "
+        (" ", app.theme.dim())
+    };
+    let glyph_style = if lane.state.dirty.is_clean() {
+        app.theme.muted()
+    } else {
+        app.theme.accented()
     };
     let agent = lane
         .agent_sessions
         .first()
         .map(|s| s.agent.short().to_string())
         .unwrap_or_default();
-    let text = format!(
-        "  {glyph} {active} {:<12} {:<26} {:<11} {:<7} {:<7} {}",
+    let mid = format!(
+        "{:<12} {:<26} {:<11} {:<7} {:<7} ",
         trunc(&lane_name(lane), 12),
         lane_branch(lane),
         dirty_str(&lane.state.dirty),
         ahead_behind_str(lane.state.ahead, lane.state.behind),
         agent,
-        rel_time(lane.last_activity_at, now),
     );
-    Line::raw(text)
+    let time = rel_time(lane.last_activity_at, now);
+    if selected {
+        // A clean reverse-video bar for the selection (per-cell colors would muddy it).
+        let text = format!("  {glyph} {active} {mid}{time}");
+        return Line::from(Span::styled(text, app.theme.selected()));
+    }
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(glyph.to_string(), glyph_style),
+        Span::raw(" "),
+        Span::styled(active.to_string(), active_style),
+        Span::raw(" "),
+        Span::raw(mid),
+        Span::styled(time, app.theme.muted()),
+    ])
 }
 
 fn commit_line(c: &Commit, app: &App) -> Line<'static> {
@@ -1160,7 +1234,11 @@ fn commit_line(c: &Commit, app: &App) -> Line<'static> {
         .find(|l| l.repo.id == c.repo_id)
         .map(|l| l.repo.name.clone())
         .unwrap_or_else(|| format!("repo{}", c.repo_id));
-    Line::raw(format!("  {time}  {:<18} {}", trunc(&repo, 18), c.summary))
+    Line::from(vec![
+        Span::styled(format!("  {time}  "), app.theme.muted()),
+        Span::styled(format!("{:<18} ", trunc(&repo, 18)), app.theme.muted()),
+        Span::raw(c.summary.clone()),
+    ])
 }
 
 fn status_glyph(lane: &Lane) -> &'static str {


### PR DESCRIPTION
Makes repomon prettier and more interactive — flat brutalist layout kept, no merge to `main` yet.

## 1. Semantic color palette
- Fixed status colors: running=green, needs-you=amber, rate-limited=cyan, secondary=gray.
- A **configurable accent** (headers, selection, dividers, dirty marks): any named color or `#hex`, default cyan; `accent = "mono"` restores the original no-color look.
- Selection is now an accent-tinted reverse bar. Captured agent output (ANSI) is untouched.

## 2. Clear dividers
- Accent section titles (`FLEET` / `TODAY` / `AGENTS`, per-repo groups) + muted rules + blank-line gaps.
- **Split view:** a vertical rule (`│`) between the sidebar and the detail/output pane.
- **Grid view:** vertical + horizontal rules between tiles so each pane reads as its own box.

## 3. Mouse hover
- Highlights the lane/tile under the cursor (bold, distinct from the reverse-video selection). Enables any-motion tracking (mode 1003) and hit-tests the existing click zones on `Moved`. Cheap — ratatui diffs the buffer, so only changed cells redraw.

## 4. A proper settings page
- New **Settings** view, opened with `,` from Fleet: cycle the **accent** (live preview), toggle **auto-continue**, edit the **continue message** — each persisted to `~/.config/repomon/config.toml`.
- Daemon `config.get` / `config.set` RPCs (read + partial update + persist); the auto-continue watcher picks up changes immediately. Verified over the socket.

## Verification
- `fmt` / `clippy -D warnings` clean; **98 tests pass** (+ theme/palette unit tests). The fleet render test confirms text/layout is unchanged (styles only).
- TUI + daemon reinstalled; daemon restarted for the new RPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)