### PR TITLE
Agent awareness + fleet management: notifications, multi-agent lanes, triage, spawn picker, timeline polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "gix",
  "ratatui",
  "repomon-core",
  "repomon-daemon",

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -33,6 +33,9 @@ pub struct TranscriptSummary {
     pub tool_call_count: u32,
     pub status: AgentStatus,
     pub title: Option<String>,
+    /// The agent's most recent message text — what it said (or asked) when it last ended a
+    /// turn. This is the "why" behind a needs-you notification.
+    pub last_message: Option<String>,
     /// The Claude config dir this session belongs to, when it isn't the default `~/.claude`
     /// (e.g. a work account run with `CLAUDE_CONFIG_DIR=~/.claude-work`). Drives adopt.
     pub config_dir: Option<PathBuf>,
@@ -55,6 +58,7 @@ impl TranscriptSummary {
             manifest_path: self.manifest_path,
             tool_call_count: self.tool_call_count,
             title: self.title,
+            last_message: self.last_message,
             status: self.status,
             external: false, // overlay flips this based on tmux ownership
             session_id: self.session_id,
@@ -248,6 +252,7 @@ fn parse_transcript_inner(path: &Path) -> Option<TranscriptSummary> {
     let mut last_type: Option<&str> = None;
     let mut last_assistant_has_tool = false;
     let mut title: Option<String> = None;
+    let mut last_message: Option<String> = None;
     let mut cwd: Option<PathBuf> = None;
 
     for line in text.lines() {
@@ -269,9 +274,20 @@ fn parse_transcript_inner(path: &Path) -> Option<TranscriptSummary> {
                     .and_then(Value::as_array)
                 {
                     for block in arr {
-                        if block.get("type").and_then(Value::as_str) == Some("tool_use") {
-                            tool_call_count += 1;
-                            has_tool = true;
+                        match block.get("type").and_then(Value::as_str) {
+                            Some("tool_use") => {
+                                tool_call_count += 1;
+                                has_tool = true;
+                            }
+                            Some("text") => {
+                                if let Some(t) = block.get("text").and_then(Value::as_str) {
+                                    let t = t.trim();
+                                    if !t.is_empty() {
+                                        last_message = Some(truncate(t, 200));
+                                    }
+                                }
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -310,6 +326,7 @@ fn parse_transcript_inner(path: &Path) -> Option<TranscriptSummary> {
         tool_call_count,
         status,
         title,
+        last_message,
         config_dir: None, // set by the caller based on which config dir it came from
         session_id: path
             .file_stem()
@@ -619,6 +636,28 @@ mod tests {
         assert!(s.status.needs_you());
         assert_eq!(s.cwd.as_deref(), Some(Path::new(cwd)));
         assert_eq!(s.title.as_deref(), Some("add tests"));
+        // The "why" behind a needs-you alert: the agent's final message text.
+        assert_eq!(s.last_message.as_deref(), Some("Done — want me to also..."));
+    }
+
+    #[test]
+    fn last_message_is_truncated_and_survives_tool_turns() {
+        let dir = tempfile::tempdir().unwrap();
+        let long = "x".repeat(300);
+        let lines = [
+            format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"{long}"}}]}}}}"#
+            ),
+            // A later tool-only turn must not erase the question text.
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}"#
+                .to_string(),
+        ];
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let path = write_transcript(dir.path(), "s.jsonl", &refs);
+        let s = parse_transcript(&path).unwrap();
+        let msg = s.last_message.unwrap();
+        assert_eq!(msg.chars().count(), 201); // 200 kept + ellipsis
+        assert!(msg.starts_with("xxx") && msg.ends_with('…'));
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -59,6 +59,7 @@ impl TranscriptSummary {
             external: false, // overlay flips this based on tmux ownership
             session_id: self.session_id,
             resume_at: None,
+            inferred: false,
         }
     }
 }

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -58,6 +58,7 @@ impl TranscriptSummary {
             status: self.status,
             external: false, // overlay flips this based on tmux ownership
             session_id: self.session_id,
+            tmux_window: None, // overlay pairs managed sessions with their windows
             resume_at: None,
             inferred: false,
         }

--- a/crates/repomon-core/src/agent/limit.rs
+++ b/crates/repomon-core/src/agent/limit.rs
@@ -62,7 +62,8 @@ fn is_wait_option(lower_text: &str) -> bool {
 
 /// Parse one menu-option-shaped line: optional `❯` cursor, optional `N.` number, then text.
 /// Returns `(has_cursor, number, text)`; `None` when the line isn't option-shaped.
-fn parse_option_line(line: &str) -> Option<(bool, Option<u32>, String)> {
+/// (Shared with the pending-prompt detector in [`super::prompt`].)
+pub(crate) fn parse_option_line(line: &str) -> Option<(bool, Option<u32>, String)> {
     let clean = strip_ansi(line);
     let mut rest = clean.trim_start();
     let cursor = rest.starts_with('❯');
@@ -139,7 +140,7 @@ pub fn menu_select_keys(menu: &LimitMenu) -> Vec<String> {
 
 /// Drop ANSI CSI/OSC escape sequences (pane captures use `-e`, so menu rows carry color and
 /// inverse-video escapes that would break per-line parsing).
-fn strip_ansi(s: &str) -> String {
+pub(crate) fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {

--- a/crates/repomon-core/src/agent/limit.rs
+++ b/crates/repomon-core/src/agent/limit.rs
@@ -19,26 +19,161 @@ pub struct UsageLimit {
     /// When the limit resets (UTC), if a clock time could be parsed from the message. `None`
     /// means the caller should retry periodically rather than wait for a precise moment.
     pub reset_at: Option<DateTime<Utc>>,
-    /// Claude's newer interactive "What do you want to do?" menu is on screen. The caller must
-    /// pick option 1 ("Stop and wait for limit to reset") — a bare Enter on the default — before
-    /// it can resume.
-    pub menu: bool,
+    /// Claude's interactive "What do you want to do?" menu, parsed from the pane when on
+    /// screen. The caller must select the "stop and wait for limit to reset" option — which is
+    /// NOT always option 1 nor always pre-selected (the options move around between
+    /// occurrences) — see [`menu_select_keys`].
+    pub menu: Option<LimitMenu>,
+}
+
+/// The interactive usage-limit menu as read from the pane: where the cursor is and where the
+/// "stop and wait" option actually sits, so the caller selects by position, not by faith.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LimitMenu {
+    /// 0-based row of the selection cursor (`❯`), if visible.
+    pub selected: Option<usize>,
+    /// 0-based row of the "stop and wait for limit to reset" option.
+    pub wait_idx: usize,
+    /// The number printed beside the wait option ("2. Stop and wait…" → 2), for the
+    /// no-visible-cursor fallback.
+    pub wait_number: Option<u32>,
 }
 
 /// Detect the **blocking** usage-limit state in an agent's recent pane text. Returns `None` for
 /// ordinary output and for the non-blocking "approaching usage limit" warning.
 pub fn detect_usage_limit(pane: &str) -> Option<UsageLimit> {
     let lower = pane.to_lowercase();
-    // The newer flow shows an interactive menu whose first option is "Stop and wait for limit to
-    // reset"; it carries none of the classic "limit reached" phrasing, so detect it explicitly.
-    let menu = lower.contains("stop and wait for limit to reset");
-    if !is_blocked(&lower) && !menu {
+    // The newer flow shows an interactive menu offering "Stop and wait for limit to reset"; it
+    // carries none of the classic "limit reached" phrasing, so detect it explicitly.
+    let menu = parse_menu(pane);
+    if !is_blocked(&lower) && menu.is_none() {
         return None;
     }
     Some(UsageLimit {
         reset_at: parse_reset_at(&lower, Local::now()),
         menu,
     })
+}
+
+/// Whether a stripped option text is the "stop and wait" choice.
+fn is_wait_option(lower_text: &str) -> bool {
+    lower_text.contains("stop and wait") || lower_text.contains("wait for limit")
+}
+
+/// Parse one menu-option-shaped line: optional `❯` cursor, optional `N.` number, then text.
+/// Returns `(has_cursor, number, text)`; `None` when the line isn't option-shaped.
+fn parse_option_line(line: &str) -> Option<(bool, Option<u32>, String)> {
+    let clean = strip_ansi(line);
+    let mut rest = clean.trim_start();
+    let cursor = rest.starts_with('❯');
+    if cursor {
+        rest = rest.trim_start_matches('❯').trim_start();
+    }
+    let digits: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .take(2)
+        .collect();
+    let number = if !digits.is_empty() && rest[digits.len()..].starts_with('.') {
+        rest = rest[digits.len() + 1..].trim_start();
+        digits.parse::<u32>().ok()
+    } else {
+        None
+    };
+    // An option row needs at least one of the markers (cursor or number) plus some text —
+    // otherwise every ordinary output line would qualify.
+    if (!cursor && number.is_none()) || rest.is_empty() {
+        return None;
+    }
+    Some((cursor, number, rest.to_string()))
+}
+
+/// Read Claude's usage-limit menu from the pane, anchored on the "stop and wait" option so
+/// numbered lists in ordinary agent output never parse as a menu. The menu block is the run of
+/// contiguous option-shaped lines around that anchor.
+fn parse_menu(pane: &str) -> Option<LimitMenu> {
+    let lines: Vec<&str> = pane.lines().collect();
+    let parsed: Vec<Option<(bool, Option<u32>, String)>> =
+        lines.iter().map(|l| parse_option_line(l)).collect();
+    let anchor = parsed.iter().position(|p| {
+        p.as_ref()
+            .is_some_and(|(_, _, text)| is_wait_option(&text.to_lowercase()))
+    })?;
+    // Expand to the contiguous option block around the anchor.
+    let mut start = anchor;
+    while start > 0 && parsed[start - 1].is_some() {
+        start -= 1;
+    }
+    let mut end = anchor + 1;
+    while end < parsed.len() && parsed[end].is_some() {
+        end += 1;
+    }
+    let block: Vec<&(bool, Option<u32>, String)> = parsed[start..end].iter().flatten().collect();
+    let wait_idx = anchor - start;
+    Some(LimitMenu {
+        selected: block.iter().position(|(cursor, _, _)| *cursor),
+        wait_idx,
+        wait_number: block[wait_idx].1,
+    })
+}
+
+/// The keystrokes (tmux `send-keys` names) that select the menu's wait option: arrow from the
+/// visible cursor to the option's row, then Enter. Without a visible cursor, fall back to the
+/// option's printed number (digit selection confirms immediately; the trailing Enter then lands
+/// harmlessly on the empty input box).
+pub fn menu_select_keys(menu: &LimitMenu) -> Vec<String> {
+    match menu.selected {
+        Some(cur) => {
+            let (from, to) = (cur as i64, menu.wait_idx as i64);
+            let arrow = if to > from { "Down" } else { "Up" };
+            let mut keys = vec![arrow.to_string(); (to - from).unsigned_abs() as usize];
+            keys.push("Enter".into());
+            keys
+        }
+        None => match menu.wait_number {
+            Some(n) => vec![n.to_string(), "Enter".into()],
+            None => vec!["Enter".into()],
+        },
+    }
+}
+
+/// Drop ANSI CSI/OSC escape sequences (pane captures use `-e`, so menu rows carry color and
+/// inverse-video escapes that would break per-line parsing).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: ESC [ … final byte in @-~
+            Some('[') => {
+                chars.next();
+                for n in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&n) {
+                        break;
+                    }
+                }
+            }
+            // OSC: ESC ] … BEL (or ESC \)
+            Some(']') => {
+                chars.next();
+                while let Some(n) = chars.next() {
+                    if n == '\u{07}' {
+                        break;
+                    }
+                    if n == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
 }
 
 /// Whether the pane shows a *blocking* limit. Covers Claude's several phrasings: the classic
@@ -213,7 +348,10 @@ mod tests {
         let pane = "Claude usage limit reached. Please try again later.";
         let lim = detect_usage_limit(pane).expect("block");
         assert_eq!(lim.reset_at, None);
-        assert!(!lim.menu, "the classic message is not the interactive menu");
+        assert!(
+            lim.menu.is_none(),
+            "the classic message is not the interactive menu"
+        );
     }
 
     #[test]
@@ -225,7 +363,10 @@ mod tests {
               3. Upgrade to Team plan\n\
             Enter to confirm · Esc to cancel";
         let lim = detect_usage_limit(pane).expect("should detect the menu");
-        assert!(lim.menu, "menu flag should be set");
+        let menu = lim.menu.expect("menu should be parsed");
+        assert_eq!(menu.selected, Some(0), "cursor on the first row");
+        assert_eq!(menu.wait_idx, 0);
+        assert_eq!(menu.wait_number, Some(1));
         assert_eq!(lim.reset_at, None, "no time shown → retry periodically");
     }
 
@@ -237,9 +378,82 @@ mod tests {
             ❯ 1. Stop and wait for limit to reset\n\
               2. Upgrade your plan";
         let lim = detect_usage_limit(pane).expect("menu");
-        assert!(lim.menu);
+        assert!(lim.menu.is_some());
         let local = lim.reset_at.expect("3pm").with_timezone(&Local);
         assert_eq!(local.hour(), 15);
+    }
+
+    #[test]
+    fn menu_parses_reordered_options() {
+        // The options move around between occurrences — the wait choice here is option 2 and
+        // the cursor sits on option 1. A blind Enter would pick "Upgrade your plan".
+        let pane = "What do you want to do?\n\
+            ❯ 1. Upgrade your plan\n\
+              2. Stop and wait for limit to reset\n\
+              3. Upgrade to Team plan\n\
+            Enter to confirm · Esc to cancel";
+        let menu = detect_usage_limit(pane)
+            .expect("menu")
+            .menu
+            .expect("parsed");
+        assert_eq!(menu.selected, Some(0));
+        assert_eq!(menu.wait_idx, 1);
+        assert_eq!(menu.wait_number, Some(2));
+        assert_eq!(menu_select_keys(&menu), vec!["Down", "Enter"]);
+    }
+
+    #[test]
+    fn menu_parsing_strips_ansi() {
+        // Pane captures use `-e`, so rows carry color/inverse escapes.
+        let pane = "What do you want to do?\n\
+            \u{1b}[7m❯ 1. Upgrade your plan\u{1b}[0m\n\
+            \u{1b}[2m  2. \u{1b}[1mStop and wait\u{1b}[0m\u{1b}[2m for limit to reset\u{1b}[0m";
+        let menu = detect_usage_limit(pane)
+            .expect("menu")
+            .menu
+            .expect("parsed despite ANSI");
+        assert_eq!(menu.selected, Some(0));
+        assert_eq!(menu.wait_idx, 1);
+        assert_eq!(menu.wait_number, Some(2));
+    }
+
+    #[test]
+    fn numbered_output_is_not_a_menu() {
+        // Ordinary agent output with a numbered list must not parse as a limit menu.
+        let pane = "Here's the plan:\n\
+            1. Refactor the parser\n\
+            2. Add tests\n\
+            3. Ship it";
+        assert!(parse_menu(pane).is_none());
+        assert!(detect_usage_limit(pane).is_none());
+    }
+
+    #[test]
+    fn menu_select_keys_paths() {
+        let menu = |selected, wait_idx, wait_number| LimitMenu {
+            selected,
+            wait_idx,
+            wait_number,
+        };
+        // Cursor already on the wait option → just confirm (the old behavior, now verified).
+        assert_eq!(menu_select_keys(&menu(Some(0), 0, Some(1))), vec!["Enter"]);
+        // Below the cursor → walk down.
+        assert_eq!(
+            menu_select_keys(&menu(Some(0), 2, Some(3))),
+            vec!["Down", "Down", "Enter"]
+        );
+        // Above the cursor → walk up.
+        assert_eq!(
+            menu_select_keys(&menu(Some(2), 0, Some(1))),
+            vec!["Up", "Up", "Enter"]
+        );
+        // No visible cursor → select by printed number.
+        assert_eq!(
+            menu_select_keys(&menu(None, 1, Some(2))),
+            vec!["2", "Enter"]
+        );
+        // No cursor and no number: Enter is the only signal left.
+        assert_eq!(menu_select_keys(&menu(None, 0, None)), vec!["Enter"]);
     }
 
     #[test]
@@ -284,7 +498,10 @@ mod tests {
         let pane = "You've hit your session limit · resets 3am (Asia/Karachi)\n\
             /upgrade to increase your usage limit.";
         let lim = detect_usage_limit(pane).expect("session limit is a block");
-        assert!(!lim.menu, "this notice is not the interactive menu");
+        assert!(
+            lim.menu.is_none(),
+            "this notice is not the interactive menu"
+        );
         let local = lim.reset_at.expect("3am").with_timezone(&Local);
         assert_eq!(local.hour(), 3);
     }

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use crate::model::{AgentKind, AgentStatus};
 
 pub use claude::TranscriptSummary;
-pub use limit::{detect_usage_limit, UsageLimit};
+pub use limit::{detect_usage_limit, menu_select_keys, LimitMenu, UsageLimit};
 pub use tmux::{shell_quote, TmuxRuntime};
 
 /// How recently a file must have changed for its agent to count as "running".

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -116,6 +116,7 @@ fn activity_summary(kind: AgentKind, manifest: &Path) -> Option<TranscriptSummar
         tool_call_count: 0,
         status,
         title: None,
+        last_message: None,
         config_dir: None,
         session_id: None,
     })

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod claude;
 pub mod limit;
+pub mod prompt;
 pub mod tmux;
 
 use std::path::Path;

--- a/crates/repomon-core/src/agent/prompt.rs
+++ b/crates/repomon-core/src/agent/prompt.rs
@@ -1,0 +1,238 @@
+//! Detecting a pending interactive prompt (permission dialog, plan approval, trust dialog,
+//! a question with options) in a managed agent's pane.
+//!
+//! A transcript that ends in a tool call reads as **Running**, but the pane may actually be
+//! sitting on "Do you want to proceed? ❯ 1. Yes …" — blocked on the user, with nothing in the
+//! JSONL to say so. This module is the pure, fixture-tested detector: given recent pane text it
+//! decides whether the agent is waiting on an interactive prompt, and produces a compact
+//! summary (dialog header + question) to use as the notification's "why". The daemon flips
+//! such sessions to `Waiting` during `lane.list`.
+
+use super::limit::{parse_option_line, strip_ansi};
+
+/// How far above the option menu the question line may sit.
+const QUESTION_REACH: usize = 5;
+/// How far above the question to look for the dialog's top border (the `╭` line).
+const HEADER_REACH: usize = 20;
+
+/// Detect a pending interactive prompt in an agent's recent pane text and summarize it
+/// (`"Bash command — Do you want to proceed?"`). Returns `None` for ordinary output, for
+/// numbered lists without a selection cursor, and for the usage-limit menu (which is a
+/// rate-limit pause, not a permission ask — see [`super::limit`]).
+pub fn detect_pending_prompt(pane: &str) -> Option<String> {
+    // Claude draws dialogs inside a box; strip ANSI and the `│` borders so option/question
+    // lines parse the same whether boxed or bare.
+    let stripped: Vec<String> = pane.lines().map(strip_ansi).collect();
+    let cleaned: Vec<String> = stripped.iter().map(|l| content(l).to_string()).collect();
+    let options: Vec<Option<(bool, Option<u32>, String)>> =
+        cleaned.iter().map(|l| parse_option_line(l)).collect();
+
+    // The active dialog is the last thing on screen — find the bottom-most option block that
+    // really looks like a selection menu: ≥2 numbered rows plus a visible `❯` cursor.
+    let mut end = options.len();
+    while end > 0 {
+        let block_end = options[..end].iter().rposition(|p| p.is_some())?;
+        let mut start = block_end;
+        while start > 0 && options[start - 1].is_some() {
+            start -= 1;
+        }
+        let block: Vec<&(bool, Option<u32>, String)> =
+            options[start..=block_end].iter().flatten().collect();
+        let numbered = block.iter().filter(|(_, n, _)| n.is_some()).count();
+        let has_cursor = block.iter().any(|(c, _, _)| *c);
+        if numbered >= 2 && has_cursor {
+            // The usage-limit menu is handled by the auto-continue watcher, not as a prompt.
+            if block
+                .iter()
+                .any(|(_, _, t)| is_limit_option(&t.to_lowercase()))
+            {
+                return None;
+            }
+            return summarize(&stripped, &cleaned, start);
+        }
+        end = start; // not a menu — keep scanning the lines above
+    }
+    None
+}
+
+/// Build the summary for a menu starting at line `menu_start`: the question line just above
+/// it, prefixed with the dialog's header (the first content line under the box's `╭` border).
+fn summarize(stripped: &[String], cleaned: &[String], menu_start: usize) -> Option<String> {
+    let q_idx = (menu_start.saturating_sub(QUESTION_REACH)..menu_start)
+        .rev()
+        .find(|&i| is_question(&cleaned[i]))?;
+    let question = cleaned[q_idx].trim().to_string();
+
+    // Walk up to the dialog's top border; the first content line below it names the tool
+    // ("Bash command", "Edit file", …). Boxless dialogs simply get no header.
+    let header = (q_idx.saturating_sub(HEADER_REACH)..q_idx)
+        .rev()
+        .find(|&i| stripped[i].trim_start().starts_with('╭'))
+        .and_then(|b| {
+            (b + 1..q_idx)
+                .map(|i| cleaned[i].trim())
+                .find(|l| !l.is_empty())
+        })
+        .filter(|h| *h != question);
+
+    let summary = match header {
+        Some(h) => format!("{h} — {question}"),
+        None => question,
+    };
+    Some(truncate(&summary, 120))
+}
+
+/// A line that reads as the dialog's question: the explicit ask phrasings, or any line ending
+/// in `?` (covers arbitrary question dialogs). Requiring an adjacent `❯` menu keeps quoted
+/// questions in ordinary output from matching.
+fn is_question(cleaned: &str) -> bool {
+    let t = cleaned.trim();
+    if t.is_empty() {
+        return false;
+    }
+    let lower = t.to_lowercase();
+    lower.contains("do you want") || lower.contains("would you like") || t.ends_with('?')
+}
+
+/// Whether an option row belongs to the usage-limit menu.
+fn is_limit_option(lower_text: &str) -> bool {
+    lower_text.contains("stop and wait") || lower_text.contains("wait for limit")
+}
+
+/// Strip the dialog box borders (`│ … │`) and padding from an ANSI-stripped line.
+fn content(stripped: &str) -> &str {
+    stripped
+        .trim()
+        .trim_start_matches(['│', '┃'])
+        .trim_end_matches(['│', '┃'])
+        .trim()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_boxed_permission_dialog_with_header() {
+        let pane = "● Running cargo test…\n\
+            ╭──────────────────────────────────────────────╮\n\
+            │ Bash command                                 │\n\
+            │                                              │\n\
+            │   cargo install --path crates/repomon-tui    │\n\
+            │   Install the repomon TUI                    │\n\
+            │                                              │\n\
+            │ Do you want to proceed?                      │\n\
+            │ ❯ 1. Yes                                     │\n\
+            │   2. Yes, and don't ask again for cargo      │\n\
+            │   3. No, and tell Claude what to do          │\n\
+            ╰──────────────────────────────────────────────╯";
+        assert_eq!(
+            detect_pending_prompt(pane).as_deref(),
+            Some("Bash command — Do you want to proceed?")
+        );
+    }
+
+    #[test]
+    fn detects_bare_trust_dialog_without_header() {
+        let pane = "Do you trust the files in this folder?\n\
+            ❯ 1. Yes, proceed\n\
+              2. No, exit";
+        assert_eq!(
+            detect_pending_prompt(pane).as_deref(),
+            Some("Do you trust the files in this folder?")
+        );
+    }
+
+    #[test]
+    fn detects_question_dialog_by_trailing_question_mark() {
+        let pane = "╭───────────────────────────────╮\n\
+            │ Which auth method should we use?  │\n\
+            │ ❯ 1. OAuth                        │\n\
+            │   2. API keys                     │\n\
+            │   3. Sessions                     │\n\
+            ╰───────────────────────────────╯";
+        assert_eq!(
+            detect_pending_prompt(pane).as_deref(),
+            Some("Which auth method should we use?")
+        );
+    }
+
+    #[test]
+    fn handles_ansi_escapes() {
+        let pane = "Do you want to make this edit to app.rs?\n\
+            \u{1b}[7m❯ 1. Yes\u{1b}[0m\n\
+            \u{1b}[2m  2. Yes, allow all edits during this session\u{1b}[0m\n\
+            \u{1b}[2m  3. No\u{1b}[0m";
+        assert_eq!(
+            detect_pending_prompt(pane).as_deref(),
+            Some("Do you want to make this edit to app.rs?")
+        );
+    }
+
+    #[test]
+    fn usage_limit_menu_is_not_a_prompt() {
+        // The limit menu is the auto-continue watcher's job; double-alerting would be noise.
+        let pane = "What do you want to do?\n\
+            ❯ 1. Stop and wait for limit to reset\n\
+              2. Upgrade your plan";
+        assert_eq!(detect_pending_prompt(pane), None);
+    }
+
+    #[test]
+    fn numbered_list_without_cursor_is_not_a_prompt() {
+        let pane = "Which option do you prefer?\n\
+            1. Refactor the parser\n\
+            2. Add tests first";
+        assert_eq!(detect_pending_prompt(pane), None);
+    }
+
+    #[test]
+    fn menu_without_question_is_not_a_prompt() {
+        let pane = "❯ 1. alpha\n  2. beta\n  3. gamma";
+        assert_eq!(detect_pending_prompt(pane), None);
+    }
+
+    #[test]
+    fn ordinary_output_and_input_box_do_not_match() {
+        let pane = "test result: ok. 121 passed; 0 failed\n\
+            ╭─────────────────────────────╮\n\
+            │ >                           │\n\
+            ╰─────────────────────────────╯\n\
+            ? for shortcuts";
+        assert_eq!(detect_pending_prompt(pane), None);
+    }
+
+    #[test]
+    fn picks_the_bottom_most_dialog() {
+        // Scrollback may contain an old (answered) dialog; only the last one on screen counts.
+        let pane = "Do you want to proceed?\n\
+            ❯ 1. Yes\n\
+              2. No\n\
+            ● ran the command\n\
+            Do you want to apply the patch?\n\
+            ❯ 1. Yes\n\
+              2. No";
+        assert_eq!(
+            detect_pending_prompt(pane).as_deref(),
+            Some("Do you want to apply the patch?")
+        );
+    }
+
+    #[test]
+    fn long_summaries_truncate() {
+        let q = format!("Do you want to {}?", "x".repeat(200));
+        let pane = format!("{q}\n❯ 1. Yes\n  2. No");
+        let s = detect_pending_prompt(&pane).unwrap();
+        assert_eq!(s.chars().count(), 120);
+        assert!(s.ends_with('…'));
+    }
+}

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -38,14 +38,56 @@ impl TmuxRuntime {
         &self.session
     }
 
-    /// The tmux window name for a lane.
+    /// The tmux window name for a lane's first agent slot.
     pub fn window_name(lane: LaneId) -> String {
         format!("lane-{lane}")
     }
 
-    /// The `session:window` target for a lane.
+    /// The window name for a lane's `slot`-th agent (1-based): `lane-7`, `lane-7-2`, `lane-7-3`…
+    /// Several agents can run side by side in one lane, one window each.
+    pub fn slot_name(lane: LaneId, slot: usize) -> String {
+        if slot <= 1 {
+            Self::window_name(lane)
+        } else {
+            format!("lane-{lane}-{slot}")
+        }
+    }
+
+    /// Filter `names` down to `lane`'s agent windows, in slot order (= spawn order). Exact
+    /// matching, so `lane-1` never claims `lane-12`'s windows.
+    pub fn lane_windows_in(names: &[String], lane: LaneId) -> Vec<String> {
+        let base = Self::window_name(lane);
+        let prefix = format!("{base}-");
+        let mut slots: Vec<(usize, String)> = names
+            .iter()
+            .filter_map(|n| {
+                if *n == base {
+                    Some((1, n.clone()))
+                } else {
+                    let rest = n.strip_prefix(&prefix)?;
+                    let slot: usize = rest.parse().ok().filter(|&s| s >= 2)?;
+                    Some((slot, n.clone()))
+                }
+            })
+            .collect();
+        slots.sort_by_key(|(s, _)| *s);
+        slots.into_iter().map(|(_, n)| n).collect()
+    }
+
+    /// `lane`'s live agent windows, in slot order.
+    pub fn windows_for(&self, lane: LaneId) -> Result<Vec<String>> {
+        Ok(Self::lane_windows_in(&self.list_windows()?, lane))
+    }
+
+    /// The `session:window` target for a lane's first agent slot.
     pub fn target(&self, lane: LaneId) -> String {
         format!("{}:{}", self.session, Self::window_name(lane))
+    }
+
+    /// An *exact* `session:=window` target — tmux otherwise prefix-matches window names, which
+    /// would let `lane-1` resolve to `lane-1-2` once the first slot is gone.
+    fn exact_target(&self, name: &str) -> String {
+        format!("{}:={}", self.session, name)
     }
 
     /// repomon runs its tmux on a dedicated socket (named after the session) so its windows
@@ -103,13 +145,16 @@ impl TmuxRuntime {
             .unwrap_or(false)
     }
 
-    /// Launch `command` for `lane` in `cwd`, (re)creating the window. Returns the target.
+    /// Launch `command` for `lane` in `cwd` in the lane's first *free* agent slot — a running
+    /// agent is never killed, so spawning again runs a second agent side by side. Returns the
+    /// new window's exact target.
     pub fn spawn(&self, lane: LaneId, cwd: &Path, command: &str) -> Result<String> {
-        let window = Self::window_name(lane);
+        let taken = self.windows_for(lane).unwrap_or_default();
+        let window = (1..)
+            .map(|slot| Self::slot_name(lane, slot))
+            .find(|name| !taken.contains(name))
+            .expect("unbounded slot range");
         let cwd = cwd.to_string_lossy();
-        if self.has_window(lane) {
-            let _ = self.kill(lane);
-        }
         if self.session_exists() {
             self.run(&[
                 "new-window",
@@ -140,15 +185,20 @@ impl TmuxRuntime {
             ])?;
         }
         self.configure();
-        Ok(self.target(lane))
+        Ok(self.exact_target(&window))
     }
 
     /// Capture the pane's text, including ANSI color escapes (`-e`).
     pub fn capture(&self, lane: LaneId, lines: Option<u32>) -> Result<String> {
-        if !self.has_window(lane) {
+        self.capture_named(&Self::window_name(lane), lines)
+    }
+
+    /// Capture a specific agent window's pane text.
+    pub fn capture_named(&self, window: &str, lines: Option<u32>) -> Result<String> {
+        if !self.has_named(window) {
             return Ok(String::new());
         }
-        let target = self.target(lane);
+        let target = self.exact_target(window);
         let start = lines.map(|n| format!("-{n}")).unwrap_or_default();
         let mut args = vec!["capture-pane", "-e", "-p", "-t", &target];
         if lines.is_some() {
@@ -160,13 +210,21 @@ impl TmuxRuntime {
 
     /// Send a literal string (no trailing Enter) — one keystroke's worth of input.
     pub fn send_literal(&self, lane: LaneId, text: &str) -> Result<()> {
-        self.run(&["send-keys", "-t", &self.target(lane), "-l", text])?;
+        self.send_literal_named(&Self::window_name(lane), text)
+    }
+
+    pub fn send_literal_named(&self, window: &str, text: &str) -> Result<()> {
+        self.run(&["send-keys", "-t", &self.exact_target(window), "-l", text])?;
         Ok(())
     }
 
     /// Type `text` into the agent and press Enter.
     pub fn send_text(&self, lane: LaneId, text: &str) -> Result<()> {
-        let target = self.target(lane);
+        self.send_text_named(&Self::window_name(lane), text)
+    }
+
+    pub fn send_text_named(&self, window: &str, text: &str) -> Result<()> {
+        let target = self.exact_target(window);
         self.run(&["send-keys", "-t", &target, "-l", text])?;
         self.run(&["send-keys", "-t", &target, "Enter"])?;
         Ok(())
@@ -174,15 +232,17 @@ impl TmuxRuntime {
 
     /// Send a raw key (e.g. `C-c`) to the agent.
     pub fn send_key(&self, lane: LaneId, key: &str) -> Result<()> {
-        let target = self.target(lane);
-        self.run(&["send-keys", "-t", &target, key])?;
+        self.send_key_named(&Self::window_name(lane), key)
+    }
+
+    pub fn send_key_named(&self, window: &str, key: &str) -> Result<()> {
+        self.run(&["send-keys", "-t", &self.exact_target(window), key])?;
         Ok(())
     }
 
-    /// Terminate the agent's window.
+    /// Terminate the agent's first-slot window.
     pub fn kill(&self, lane: LaneId) -> Result<()> {
-        self.run(&["kill-window", "-t", &self.target(lane)])?;
-        Ok(())
+        self.kill_named(&Self::window_name(lane))
     }
 
     /// Make the attached experience feel like a native terminal: mouse on (wheel scroll +
@@ -264,9 +324,10 @@ impl TmuxRuntime {
         Ok(self.target_named(name))
     }
 
-    /// Terminate a named window (e.g. a terminal).
+    /// Terminate a named window (an agent slot or a terminal). Exact-match target, so killing
+    /// `lane-1` can't take out `lane-1-2`.
     pub fn kill_named(&self, name: &str) -> Result<()> {
-        self.run(&["kill-window", "-t", &self.target_named(name)])?;
+        self.run(&["kill-window", "-t", &self.exact_target(name)])?;
         Ok(())
     }
 
@@ -305,6 +366,27 @@ mod tests {
     }
 
     #[test]
+    fn slot_names_and_lane_window_filtering() {
+        assert_eq!(TmuxRuntime::slot_name(7, 1), "lane-7");
+        assert_eq!(TmuxRuntime::slot_name(7, 2), "lane-7-2");
+
+        // Exact matching: lane 1 must not claim lane 12's (or a terminal's) windows, and the
+        // result comes back in slot order regardless of input order.
+        let names: Vec<String> = [
+            "lane-12", "lane-1-3", "term-1", "lane-1", "lane-1-2", "lane-1-x",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            TmuxRuntime::lane_windows_in(&names, 1),
+            vec!["lane-1", "lane-1-2", "lane-1-3"]
+        );
+        assert_eq!(TmuxRuntime::lane_windows_in(&names, 12), vec!["lane-12"]);
+        assert!(TmuxRuntime::lane_windows_in(&names, 3).is_empty());
+    }
+
+    #[test]
     fn spawn_capture_send_kill_roundtrip() {
         if !TmuxRuntime::available() {
             eprintln!("tmux not available; skipping live runtime test");
@@ -327,7 +409,22 @@ mod tests {
         let out2 = rt.capture(lane, None).unwrap();
         assert!(out2.contains("SECOND_LINE"), "after send: {out2:?}");
 
+        // A second spawn runs side by side in the next slot (the first agent survives), and
+        // per-window ops hit the right pane even after the first slot goes away.
+        rt.spawn(lane, &cwd, "sh -c 'echo SLOT_TWO; sleep 30'")
+            .unwrap();
+        assert_eq!(rt.windows_for(lane).unwrap(), vec!["lane-1", "lane-1-2"]);
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        let one = rt.capture(lane, None).unwrap();
+        assert!(one.contains("HELLO_REPOMON"), "slot 1 was: {one:?}");
+        let two = rt.capture_named("lane-1-2", None).unwrap();
+        assert!(two.contains("SLOT_TWO"), "slot 2 was: {two:?}");
+
         rt.kill(lane).unwrap();
+        assert_eq!(rt.windows_for(lane).unwrap(), vec!["lane-1-2"]);
+        // Exact targeting: the primary name must not resolve onto the surviving slot.
+        assert_eq!(rt.capture(lane, None).unwrap(), "");
+        rt.kill_named("lane-1-2").unwrap();
         assert!(!rt.has_window(lane));
 
         // Tear down the test session.

--- a/crates/repomon-core/src/analytics.rs
+++ b/crates/repomon-core/src/analytics.rs
@@ -30,6 +30,22 @@ pub fn density_char(level: u8) -> &'static str {
     DENSITY_CHARS[(level as usize).min(5)]
 }
 
+/// Resample a density row to `width` cells for rendering at the current terminal size. Each
+/// output cell takes the MAX of its source span, so activity peaks survive shrinking; when
+/// stretching, cells repeat (nearest neighbor).
+pub fn resample_max(src: &[u8], width: usize) -> Vec<u8> {
+    if src.is_empty() {
+        return vec![0; width];
+    }
+    (0..width)
+        .map(|i| {
+            let lo = i * src.len() / width;
+            let hi = ((i + 1) * src.len() / width).max(lo + 1).min(src.len());
+            src[lo..hi].iter().copied().max().unwrap_or(0)
+        })
+        .collect()
+}
+
 /// Build the timeline: per-repo density rows + Jaccard correlations over `[from, to)`.
 pub fn build_timeline(
     commits: &[Commit],
@@ -122,6 +138,18 @@ fn correlations(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn resample_keeps_peaks_and_stretches() {
+        // Shrinking: the max of each span survives (the 5 must not vanish).
+        assert_eq!(resample_max(&[0, 5, 0, 0, 1, 1, 0, 2], 4), vec![5, 0, 1, 2]);
+        // Stretching: nearest-neighbor repetition.
+        assert_eq!(resample_max(&[1, 3], 4), vec![1, 1, 3, 3]);
+        // Identity and edge cases.
+        assert_eq!(resample_max(&[1, 2, 3], 3), vec![1, 2, 3]);
+        assert_eq!(resample_max(&[], 3), vec![0, 0, 0]);
+        assert!(resample_max(&[1, 2], 0).is_empty());
+    }
 
     fn commit(repo_id: RepoId, secs: i64, base: DateTime<Utc>) -> Commit {
         Commit {

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -47,6 +47,19 @@ pub struct Config {
     pub auto_continue: bool,
     /// What to type when auto-continuing a rate-limited agent (sent with Enter).
     pub auto_continue_message: String,
+    /// Master switch for desktop/in-app notifications on agent state changes. When off, no
+    /// individual `notify_*` trigger fires.
+    pub notify_enabled: bool,
+    /// Notify when an agent finishes its turn / is waiting on you (`Running` → `Waiting`).
+    pub notify_needs_you: bool,
+    /// Notify when an agent pauses on a usage/rate limit.
+    pub notify_rate_limited: bool,
+    /// Notify when a rate-limited agent is auto-continued and resumes work.
+    pub notify_resumed: bool,
+    /// Notify when an agent goes idle / its session ends (off by default — can be noisy).
+    pub notify_idle: bool,
+    /// Play the system notification sound with each desktop notification.
+    pub notify_sound: bool,
     /// Per-repo overrides, keyed by repo display name.
     pub repos: HashMap<String, RepoConfig>,
 }
@@ -63,6 +76,12 @@ impl Default for Config {
             agents: HashMap::new(),
             auto_continue: true,
             auto_continue_message: "continue".to_string(),
+            notify_enabled: true,
+            notify_needs_you: true,
+            notify_rate_limited: true,
+            notify_resumed: true,
+            notify_idle: false,
+            notify_sound: true,
             repos: HashMap::new(),
         }
     }

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -47,6 +47,9 @@ pub struct Config {
     pub auto_continue: bool,
     /// What to type when auto-continuing a rate-limited agent (sent with Enter).
     pub auto_continue_message: String,
+    /// Prompt (with a quick agent picker) every time you spawn an agent on a lane (`e`). When
+    /// off, `e` spawns the configured default agent immediately.
+    pub spawn_prompt: bool,
     /// Master switch for desktop/in-app notifications on agent state changes. When off, no
     /// individual `notify_*` trigger fires.
     pub notify_enabled: bool,
@@ -76,6 +79,7 @@ impl Default for Config {
             agents: HashMap::new(),
             auto_continue: true,
             auto_continue_message: "continue".to_string(),
+            spawn_prompt: true,
             notify_enabled: true,
             notify_needs_you: true,
             notify_rate_limited: true,

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -63,6 +63,15 @@ pub struct Config {
     pub notify_idle: bool,
     /// Play the system notification sound with each desktop notification.
     pub notify_sound: bool,
+    /// Include the agent's actual last message (what it said/asked) in notification bodies,
+    /// instead of just the original task title.
+    pub notify_show_why: bool,
+    /// Collapse a burst of simultaneous alerts into one "N agents need attention" popup
+    /// (each event still lands individually in the in-app feed).
+    pub notify_coalesce: bool,
+    /// Make desktop popups click-to-focus the terminal (uses `terminal-notifier` when
+    /// installed; falls back to plain popups otherwise).
+    pub notify_click_focus: bool,
     /// Per-repo overrides, keyed by repo display name.
     pub repos: HashMap<String, RepoConfig>,
 }
@@ -86,6 +95,9 @@ impl Default for Config {
             notify_resumed: true,
             notify_idle: false,
             notify_sound: true,
+            notify_show_why: true,
+            notify_coalesce: true,
+            notify_click_focus: true,
             repos: HashMap::new(),
         }
     }

--- a/crates/repomon-core/src/git/reader.rs
+++ b/crates/repomon-core/src/git/reader.rs
@@ -44,6 +44,24 @@ pub fn head_info(repo: &gix::Repository) -> Result<HeadInfo> {
 
 /// Count staged / unstaged / untracked changes via the gix status iterator.
 pub fn dirty_state(repo: &gix::Repository) -> Result<DirtyState> {
+    Ok(dirty_and_activity(repo, None)?.0)
+}
+
+/// How many changed worktree files to `stat` for the activity mtime before giving up. Any single
+/// recently-touched file already proves activity, so a small cap keeps the syscalls bounded even
+/// for a worktree with thousands of changes.
+const ACTIVITY_STAT_CAP: u32 = 512;
+
+/// Count dirty entries AND, in the same status walk, find the newest mtime among the changed
+/// worktree files. `worktree_root` enables the mtime capture (the relative paths from the status
+/// iterator are joined onto it and `stat`ed); pass `None` to skip it (plain dirty count).
+///
+/// The mtime is repomon's "file activity" signal: a worktree being actively edited by an agent
+/// that leaves no transcript or process of its own still shows that work is happening.
+fn dirty_and_activity(
+    repo: &gix::Repository,
+    worktree_root: Option<&Path>,
+) -> Result<(DirtyState, Option<DateTime<Utc>>)> {
     use gix::status::index_worktree::Item as IwItem;
     use gix::status::Item;
 
@@ -53,19 +71,44 @@ pub fn dirty_state(repo: &gix::Repository) -> Result<DirtyState> {
         .map_err(gix_err)?;
 
     let mut d = DirtyState::default();
+    let mut newest: Option<std::time::SystemTime> = None;
+    let mut stats = 0u32;
     for item in iter {
         match item.map_err(gix_err)? {
             // HEAD tree vs index → staged.
             Item::TreeIndex(_) => d.staged += 1,
-            Item::IndexWorktree(iw) => match iw {
-                IwItem::Modification { .. } => d.unstaged += 1,
-                // Default status() excludes ignored files, so directory contents are untracked.
-                IwItem::DirectoryContents { .. } => d.untracked += 1,
-                IwItem::Rewrite { .. } => d.unstaged += 1,
-            },
+            Item::IndexWorktree(iw) => {
+                // Worktree-side changes reflect live file edits; stat the path for its mtime.
+                if let Some(root) = worktree_root {
+                    if stats < ACTIVITY_STAT_CAP {
+                        stats += 1;
+                        note_mtime(root, iw.rela_path(), &mut newest);
+                    }
+                }
+                match iw {
+                    IwItem::Modification { .. } => d.unstaged += 1,
+                    // Default status() excludes ignored files, so directory contents are untracked.
+                    IwItem::DirectoryContents { .. } => d.untracked += 1,
+                    IwItem::Rewrite { .. } => d.unstaged += 1,
+                }
+            }
         }
     }
-    Ok(d)
+    Ok((d, newest.map(DateTime::<Utc>::from)))
+}
+
+/// Update `newest` with the mtime of `root/rela`, if it's newer (best-effort; ignores errors).
+fn note_mtime(root: &Path, rela: &gix::bstr::BStr, newest: &mut Option<std::time::SystemTime>) {
+    let Ok(rel) = rela.to_path() else {
+        return;
+    };
+    if let Ok(md) = std::fs::symlink_metadata(root.join(rel)) {
+        if let Ok(m) = md.modified() {
+            if newest.is_none_or(|n| m > n) {
+                *newest = Some(m);
+            }
+        }
+    }
 }
 
 /// Ahead/behind counts vs the current branch's upstream, plus the upstream's short name.
@@ -127,7 +170,7 @@ pub fn head_commit_time(repo: &gix::Repository) -> Result<Option<DateTime<Utc>>>
 pub fn read_state(path: &Path, worktree_id: WorktreeId) -> Result<WorktreeState> {
     let repo = open(path)?;
     let hi = head_info(&repo)?;
-    let dirty = dirty_state(&repo)?;
+    let (dirty, last_change_at) = dirty_and_activity(&repo, Some(path))?;
     let (ahead, behind, upstream) = ahead_behind(&repo)?;
     let last_commit_at = head_commit_time(&repo).ok().flatten();
     let head = hi
@@ -144,6 +187,7 @@ pub fn read_state(path: &Path, worktree_id: WorktreeId) -> Result<WorktreeState>
         last_commit_at,
         locked: false,
         prunable: false,
+        last_change_at,
     })
 }
 

--- a/crates/repomon-core/src/lane.rs
+++ b/crates/repomon-core/src/lane.rs
@@ -138,6 +138,7 @@ impl Lanes {
                     last_commit_at: None,
                     locked: entry.locked.is_some(),
                     prunable: true,
+                    last_change_at: None,
                 },
             };
             state.locked = entry.locked.is_some();
@@ -529,6 +530,29 @@ mod tests {
         let after = lanes.list().await.unwrap();
         assert_eq!(after.len(), 1);
         assert!(after[0].worktree.is_main);
+    }
+
+    #[tokio::test]
+    async fn worktree_file_activity_is_detected() {
+        use chrono::Utc;
+        let (dir, store, cfg) = repo_with_commit().await;
+        let reg = Registry::new(store.clone());
+        reg.add(dir.path()).await.unwrap();
+        let lanes = Lanes::new(store, cfg);
+
+        // A clean worktree has no recent file-change signal.
+        let before = lanes.list().await.unwrap();
+        assert!(before[0].state.last_change_at.is_none());
+
+        // Writing an untracked file makes the worktree show recent activity (the "file activity"
+        // signal the daemon uses to surface agents that leave no transcript).
+        std::fs::write(dir.path().join("scratch.txt"), "work\n").unwrap();
+        let after = lanes.list().await.unwrap();
+        let changed = after[0]
+            .state
+            .last_change_at
+            .expect("a dirty worktree should report a change time");
+        assert!((Utc::now() - changed).num_seconds().abs() < 60);
     }
 
     #[tokio::test]

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -250,6 +250,11 @@ pub struct AgentSession {
     /// renders these with a softer "active" indicator and they don't drive "needs you" alerts.
     #[serde(default)]
     pub inferred: bool,
+    /// The managed tmux window this session runs in, when repomon manages it. Several agents
+    /// can run side by side in one lane (one window each); keys/captures/stops are routed to
+    /// this window. `None` for external and inferred sessions.
+    #[serde(default)]
+    pub tmux_window: Option<String>,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -255,6 +255,10 @@ pub struct AgentSession {
     /// this window. `None` for external and inferred sessions.
     #[serde(default)]
     pub tmux_window: Option<String>,
+    /// The agent's most recent message text (truncated) — what it said or asked when it last
+    /// ended a turn. Gives needs-you notifications their "why".
+    #[serde(default)]
+    pub last_message: Option<String>,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -88,6 +88,12 @@ pub struct WorktreeState {
     pub locked: bool,
     #[serde(default)]
     pub prunable: bool,
+    /// Newest mtime among the worktree's changed/untracked files — repomon's "file activity"
+    /// signal. Lets the daemon surface a worktree that's being actively edited by an agent that
+    /// leaves no transcript or process of its own (e.g. a Claude Code worktree-isolated subagent).
+    /// `None` when the worktree is clean. Computed live; not persisted.
+    #[serde(default)]
+    pub last_change_at: Option<DateTime<Utc>>,
 }
 
 /// A single commit, summarized for timelines and the Today view.
@@ -238,6 +244,12 @@ pub struct AgentSession {
     /// `RateLimited` status; `None` when the reset time couldn't be parsed (periodic retry).
     #[serde(default)]
     pub resume_at: Option<DateTime<Utc>>,
+    /// True when this session was *inferred* from raw worktree file activity rather than detected
+    /// from a transcript or live process — i.e. repomon can see the worktree is being worked on
+    /// but can't identify the specific agent (Claude Code worktree-isolated subagents). The UI
+    /// renders these with a softer "active" indicator and they don't drive "needs you" alerts.
+    #[serde(default)]
+    pub inferred: bool,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -608,6 +608,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         resume_at: None,
         inferred: false,
         tmux_window: None,
+        last_message: None,
     })
 }
 
@@ -833,6 +834,7 @@ mod tests {
             resume_at: None,
             inferred: false,
             tmux_window: None,
+            last_message: None,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -607,6 +607,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         session_id: None,
         resume_at: None,
         inferred: false,
+        tmux_window: None,
     })
 }
 
@@ -831,6 +832,7 @@ mod tests {
             session_id: None,
             resume_at: None,
             inferred: false,
+            tmux_window: None,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -606,6 +606,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         external: false,
         session_id: None,
         resume_at: None,
+        inferred: false,
     })
 }
 
@@ -829,6 +830,7 @@ mod tests {
             external: false,
             session_id: None,
             resume_at: None,
+            inferred: false,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-daemon/src/auto_continue.rs
+++ b/crates/repomon-daemon/src/auto_continue.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use repomon_core::agent::{detect_usage_limit, UsageLimit};
+use repomon_core::agent::{detect_usage_limit, menu_select_keys, UsageLimit};
 use repomon_core::model::LaneId;
 use repomon_core::TmuxRuntime;
 
@@ -44,8 +44,8 @@ struct Sched {
     next_attempt: DateTime<Utc>,
     gave_up: bool,
     cooldown_until: Option<DateTime<Utc>>,
-    /// We've already pressed Enter on Claude's "Stop and wait for limit to reset" menu for this
-    /// pause, so don't press it again (reset only when the lane clears).
+    /// We've already selected "Stop and wait for limit to reset" on Claude's menu for this
+    /// pause, so don't select it again (reset only when the lane clears).
     menu_confirmed: bool,
 }
 
@@ -56,8 +56,12 @@ enum Action {
         reset_at: Option<DateTime<Utc>>,
         next_attempt: DateTime<Utc>,
     },
-    /// Press Enter to pick option 1 ("Stop and wait for limit to reset") on the interactive menu.
-    ChooseWait,
+    /// Select "Stop and wait for limit to reset" on the interactive menu. The keys are derived
+    /// from the menu as *read from the pane* (the options change position between occurrences,
+    /// so a blind Enter could confirm "Upgrade your plan" instead).
+    ChooseWait {
+        keys: Vec<String>,
+    },
     /// Type the continue message now.
     Send,
     /// Waited too long without resuming — stop and surface needs-you.
@@ -110,9 +114,12 @@ fn decide(
                     return Action::Nothing;
                 }
                 // Pick "Stop and wait for limit to reset" once, before ever typing `continue` —
-                // otherwise the continue text would land in the menu.
-                if lim.menu && !s.menu_confirmed {
-                    return Action::ChooseWait;
+                // otherwise the continue text would land in the menu. The pane was captured
+                // moments ago, so the parsed positions reflect what's actually on screen.
+                if let Some(menu) = lim.menu.as_ref().filter(|_| !s.menu_confirmed) {
+                    return Action::ChooseWait {
+                        keys: menu_select_keys(menu),
+                    };
                 }
                 if now >= s.next_attempt {
                     Action::Send
@@ -220,10 +227,20 @@ async fn apply(
                 serde_json::json!({ "lane_id": lane, "status": "rate-limited" }),
             );
         }
-        Action::ChooseWait => {
-            // Press Enter to confirm the menu's default option 1 ("Stop and wait …").
+        Action::ChooseWait { keys } => {
+            // Walk the cursor to "Stop and wait …" and confirm — the exact keys were derived
+            // from the menu's on-screen positions. A short gap between keys lets the menu's
+            // renderer keep up with repeated arrows.
             let tmux = ctx.tmux.clone();
-            let _ = tokio::task::spawn_blocking(move || tmux.send_key(lane, "Enter")).await;
+            let _ = tokio::task::spawn_blocking(move || {
+                for (i, key) in keys.iter().enumerate() {
+                    if i > 0 {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    let _ = tmux.send_key(lane, key);
+                }
+            })
+            .await;
             if let Some(s) = sched.get_mut(&lane) {
                 s.menu_confirmed = true;
                 s.cooldown_until = Some(now + chrono::Duration::seconds(SEND_COOLDOWN_SECS));
@@ -271,6 +288,7 @@ async fn apply(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use repomon_core::agent::LimitMenu;
 
     fn now() -> DateTime<Utc> {
         Utc.timestamp_opt(1_700_000_000, 0).unwrap()
@@ -288,14 +306,23 @@ mod tests {
         }
     }
 
-    fn lim(reset_at: Option<DateTime<Utc>>, menu: bool) -> UsageLimit {
+    fn lim(reset_at: Option<DateTime<Utc>>, menu: Option<LimitMenu>) -> UsageLimit {
         UsageLimit { reset_at, menu }
+    }
+
+    /// A parsed menu with the cursor on row 0 and the wait option at `wait_idx`.
+    fn menu_at(wait_idx: usize) -> LimitMenu {
+        LimitMenu {
+            selected: Some(0),
+            wait_idx,
+            wait_number: Some(wait_idx as u32 + 1),
+        }
     }
 
     #[test]
     fn disabled_lane_never_tracks_or_sends() {
         assert_eq!(
-            decide(None, Some(&lim(None, false)), false, now()),
+            decide(None, Some(&lim(None, None)), false, now()),
             Action::Nothing
         );
     }
@@ -309,7 +336,7 @@ mod tests {
     #[test]
     fn new_detection_tracks_with_reset_buffer() {
         let reset = now() + chrono::Duration::hours(2);
-        let action = decide(None, Some(&lim(Some(reset), false)), true, now());
+        let action = decide(None, Some(&lim(Some(reset), None)), true, now());
         assert_eq!(
             action,
             Action::Track {
@@ -321,7 +348,7 @@ mod tests {
 
     #[test]
     fn new_detection_without_time_uses_periodic_retry() {
-        let action = decide(None, Some(&lim(None, false)), true, now());
+        let action = decide(None, Some(&lim(None, None)), true, now());
         assert_eq!(
             action,
             Action::Track {
@@ -335,7 +362,7 @@ mod tests {
     fn waits_until_next_attempt() {
         let s = sched(120, false, None); // attempt is in the future
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, false)), true, now()),
+            decide(Some(&s), Some(&lim(None, None)), true, now()),
             Action::Nothing
         );
     }
@@ -344,7 +371,7 @@ mod tests {
     fn sends_when_due() {
         let s = sched(-1, false, None);
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, false)), true, now()),
+            decide(Some(&s), Some(&lim(None, None)), true, now()),
             Action::Send
         );
     }
@@ -353,7 +380,7 @@ mod tests {
     fn cooldown_suppresses_send() {
         let s = sched(-1, false, Some(60)); // due, but cooling down
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, false)), true, now()),
+            decide(Some(&s), Some(&lim(None, None)), true, now()),
             Action::Nothing
         );
     }
@@ -363,7 +390,7 @@ mod tests {
         let mut s = sched(-1, false, None);
         s.started = now() - chrono::Duration::hours(GIVE_UP_AFTER_HOURS + 1);
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, false)), true, now()),
+            decide(Some(&s), Some(&lim(None, None)), true, now()),
             Action::GiveUp
         );
     }
@@ -372,7 +399,7 @@ mod tests {
     fn gave_up_stays_quiet() {
         let s = sched(-1, true, None);
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, false)), true, now()),
+            decide(Some(&s), Some(&lim(None, None)), true, now()),
             Action::Nothing
         );
     }
@@ -385,13 +412,30 @@ mod tests {
 
     #[test]
     fn confirms_menu_before_continue() {
-        // The interactive menu is up and we haven't chosen yet: pick option 1, don't type
-        // `continue` — even though a send is otherwise due.
+        // The interactive menu is up and we haven't chosen yet: select the wait option, don't
+        // type `continue` — even though a send is otherwise due. The wait option here is row 2
+        // with the cursor on row 0 (the options move around), so the keys walk down to it: a
+        // blind Enter would have confirmed the wrong option.
         let mut s = sched(-1, false, None);
         s.menu_confirmed = false;
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, true)), true, now()),
-            Action::ChooseWait
+            decide(Some(&s), Some(&lim(None, Some(menu_at(2)))), true, now()),
+            Action::ChooseWait {
+                keys: vec!["Down".into(), "Down".into(), "Enter".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn confirms_preselected_wait_with_enter_only() {
+        // Cursor already on the wait option → just Enter (the classic layout).
+        let mut s = sched(-1, false, None);
+        s.menu_confirmed = false;
+        assert_eq!(
+            decide(Some(&s), Some(&lim(None, Some(menu_at(0)))), true, now()),
+            Action::ChooseWait {
+                keys: vec!["Enter".into()]
+            }
         );
     }
 
@@ -400,7 +444,7 @@ mod tests {
         // Menu text still on screen but already confirmed → proceed to send `continue`.
         let s = sched(-1, false, None); // menu_confirmed: true by default
         assert_eq!(
-            decide(Some(&s), Some(&lim(None, true)), true, now()),
+            decide(Some(&s), Some(&lim(None, Some(menu_at(0)))), true, now()),
             Action::Send
         );
     }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -38,6 +38,9 @@ pub struct Ctx {
     pub events: pubsub::EventTx,
     /// Lanes the TUI currently has visible — fast-polled for output (M9).
     pub viewport: Mutex<Vec<LaneId>>,
+    /// Which agent window the focused lane should stream, when the TUI has a specific session
+    /// selected (Tab in Focus/Split). Lanes not named here stream their first slot.
+    pub viewport_focus: Mutex<Option<(LaneId, String)>>,
     /// Cache of how many live `claude` processes have each working dir (ps/lsof, ~2s TTL), so
     /// `/exit`ed sessions whose transcripts linger aren't counted as running.
     pub live_cwds: Mutex<Option<(Instant, HashMap<PathBuf, usize>)>>,
@@ -82,6 +85,7 @@ impl Ctx {
             db_path,
             events,
             viewport: Mutex::new(Vec::new()),
+            viewport_focus: Mutex::new(None),
             live_cwds: Mutex::new(None),
             rate_limits: Mutex::new(HashMap::new()),
             auto_continue_off: Mutex::new(HashSet::new()),
@@ -108,7 +112,9 @@ impl Ctx {
 /// and push `event.agent.output` deltas. When nothing is visible, this is nearly free.
 pub async fn stream_output(ctx: Arc<Ctx>) {
     use std::collections::HashMap;
-    let mut last: HashMap<LaneId, String> = HashMap::new();
+    // Last pushed (window, content) per lane — a window switch (Tab between a lane's agents)
+    // re-pushes even if the new pane happens to look identical.
+    let mut last: HashMap<LaneId, (String, String)> = HashMap::new();
     let mut tick = tokio::time::interval(std::time::Duration::from_millis(100));
     loop {
         tick.tick().await;
@@ -117,16 +123,27 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
             last.clear();
             continue;
         }
+        let focus = ctx.viewport_focus.lock().await.clone();
         last.retain(|k, _| lanes.contains(k));
         for lane in lanes {
-            let tmux = ctx.tmux.clone();
-            let content = match tokio::task::spawn_blocking(move || tmux.capture(lane, None)).await
-            {
-                Ok(Ok(c)) => c,
-                _ => continue,
+            // The focused lane streams its selected agent's window; others their first slot.
+            let window = match &focus {
+                Some((l, w)) if *l == lane => w.clone(),
+                _ => TmuxRuntime::window_name(lane),
             };
-            if last.get(&lane).map(|c| c != &content).unwrap_or(true) {
-                last.insert(lane, content.clone());
+            let tmux = ctx.tmux.clone();
+            let w = window.clone();
+            let content =
+                match tokio::task::spawn_blocking(move || tmux.capture_named(&w, None)).await {
+                    Ok(Ok(c)) => c,
+                    _ => continue,
+                };
+            let fresh = last
+                .get(&lane)
+                .map(|(pw, pc)| pw != &window || pc != &content)
+                .unwrap_or(true);
+            if fresh {
+                last.insert(lane, (window, content.clone()));
                 ctx.broadcast(
                     pubsub::topic::AGENT_OUTPUT,
                     serde_json::json!({ "lane_id": lane, "content": content }),

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -38,6 +38,12 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "auto_continue_message": cfg.auto_continue_message,
         "default_agent": cfg.default_agent,
         "worktree_template": cfg.worktree_template,
+        "notify_enabled": cfg.notify_enabled,
+        "notify_needs_you": cfg.notify_needs_you,
+        "notify_rate_limited": cfg.notify_rate_limited,
+        "notify_resumed": cfg.notify_resumed,
+        "notify_idle": cfg.notify_idle,
+        "notify_sound": cfg.notify_sound,
     })
 }
 
@@ -143,6 +149,18 @@ struct ConfigSet {
     default_agent: Option<String>,
     #[serde(default)]
     worktree_template: Option<String>,
+    #[serde(default)]
+    notify_enabled: Option<bool>,
+    #[serde(default)]
+    notify_needs_you: Option<bool>,
+    #[serde(default)]
+    notify_rate_limited: Option<bool>,
+    #[serde(default)]
+    notify_resumed: Option<bool>,
+    #[serde(default)]
+    notify_idle: Option<bool>,
+    #[serde(default)]
+    notify_sound: Option<bool>,
 }
 #[derive(Deserialize)]
 struct AgentAdopt {
@@ -531,6 +549,24 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 if let Some(w) = p.worktree_template {
                     cfg.worktree_template = w;
                 }
+                if let Some(b) = p.notify_enabled {
+                    cfg.notify_enabled = b;
+                }
+                if let Some(b) = p.notify_needs_you {
+                    cfg.notify_needs_you = b;
+                }
+                if let Some(b) = p.notify_rate_limited {
+                    cfg.notify_rate_limited = b;
+                }
+                if let Some(b) = p.notify_resumed {
+                    cfg.notify_resumed = b;
+                }
+                if let Some(b) = p.notify_idle {
+                    cfg.notify_idle = b;
+                }
+                if let Some(b) = p.notify_sound {
+                    cfg.notify_sound = b;
+                }
                 if let Err(e) = cfg.save_to(&ctx.config_path) {
                     *cfg = prev;
                     return Err(internal(e));
@@ -853,6 +889,10 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
 /// cap on how many concurrent sessions to surface per worktree.
 const SESSION_WINDOW_HOURS: i64 = 6;
 const MAX_SESSIONS_PER_LANE: usize = 8;
+/// How recently a worktree's files must have changed to infer an *active* (but unidentified)
+/// agent in it — the fallback that surfaces Claude Code worktree-isolated subagents, which leave
+/// no transcript or process of their own. Short, so the indicator tracks actual work.
+const ACTIVITY_WINDOW_SECS: i64 = 90;
 
 async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let paths: Vec<std::path::PathBuf> = lanes.iter().map(|l| l.worktree.path.clone()).collect();
@@ -938,7 +978,37 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 external: false,
                 session_id: None,
                 resume_at: None,
+                inferred: false,
             });
+        } else if let Some(changed) = lane.state.last_change_at {
+            // No identified agent, but a *non-main* worktree's files changed very recently — infer
+            // an active agent we can't name (e.g. a Claude Code worktree-isolated subagent, which
+            // runs inside its parent's process and leaves no transcript or process here). The main
+            // checkout is excluded so hand-edits there don't masquerade as an agent.
+            let active = !lane.worktree.is_main
+                && (chrono::Utc::now() - changed).num_seconds() < ACTIVITY_WINDOW_SECS;
+            if active {
+                if changed > lane.last_activity_at {
+                    lane.last_activity_at = changed;
+                }
+                lane.agent_sessions.push(AgentSession {
+                    id: 0,
+                    agent: AgentKind::Other("active".into()),
+                    repo_id: lane.repo.id,
+                    worktree_id: Some(lane.worktree.id),
+                    started_at: changed,
+                    last_activity_at: changed,
+                    ended_at: None,
+                    manifest_path: std::path::PathBuf::new(),
+                    tool_call_count: 0,
+                    title: Some("active — file activity".into()),
+                    status: AgentStatus::Running,
+                    external: true,
+                    session_id: None,
+                    resume_at: None,
+                    inferred: true,
+                });
+            }
         }
 
         // Overlay a usage-limit pause onto the managed (non-external) session.

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -38,6 +38,7 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "auto_continue_message": cfg.auto_continue_message,
         "default_agent": cfg.default_agent,
         "worktree_template": cfg.worktree_template,
+        "spawn_prompt": cfg.spawn_prompt,
         "notify_enabled": cfg.notify_enabled,
         "notify_needs_you": cfg.notify_needs_you,
         "notify_rate_limited": cfg.notify_rate_limited,
@@ -149,6 +150,8 @@ struct ConfigSet {
     default_agent: Option<String>,
     #[serde(default)]
     worktree_template: Option<String>,
+    #[serde(default)]
+    spawn_prompt: Option<bool>,
     #[serde(default)]
     notify_enabled: Option<bool>,
     #[serde(default)]
@@ -548,6 +551,9 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 }
                 if let Some(w) = p.worktree_template {
                     cfg.worktree_template = w;
+                }
+                if let Some(b) = p.spawn_prompt {
+                    cfg.spawn_prompt = b;
                 }
                 if let Some(b) = p.notify_enabled {
                     cfg.notify_enabled = b;

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1109,6 +1109,48 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             }
         }
     }
+
+    // Permission prompts: a transcript that ends in a tool call reads **Running**, but the
+    // pane may be sitting on an interactive "Do you want…?" dialog — blocked on the user with
+    // nothing in the JSONL to say so. Sniff the panes of managed Running sessions and flip
+    // those to Waiting, carrying the dialog summary as the notification-ready "why".
+    let candidates: Vec<(usize, usize, String)> = lanes
+        .iter()
+        .enumerate()
+        .flat_map(|(li, lane)| {
+            lane.agent_sessions
+                .iter()
+                .enumerate()
+                .filter_map(move |(si, s)| {
+                    (!s.external && !s.inferred && s.status == AgentStatus::Running)
+                        .then(|| s.tmux_window.clone().map(|w| (li, si, w)))
+                        .flatten()
+                })
+        })
+        .collect();
+    if !candidates.is_empty() {
+        let tmux = ctx.tmux.clone();
+        let windows: Vec<String> = candidates.iter().map(|(_, _, w)| w.clone()).collect();
+        let prompts = tokio::task::spawn_blocking(move || {
+            windows
+                .iter()
+                .map(|w| {
+                    tmux.capture_named(w, Some(45))
+                        .ok()
+                        .and_then(|p| agent::prompt::detect_pending_prompt(&p))
+                })
+                .collect::<Vec<_>>()
+        })
+        .await
+        .unwrap_or_default();
+        for ((li, si, _), found) in candidates.into_iter().zip(prompts) {
+            if let Some(summary) = found {
+                let s = &mut lanes[li].agent_sessions[si];
+                s.status = AgentStatus::Waiting;
+                s.last_message = Some(summary);
+            }
+        }
+    }
 }
 
 /// List the subdirectories of `start` (default: $HOME) for the repo browser, marking which

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -96,6 +96,9 @@ struct AgentInput {
     /// Press Enter after the text (default). `false` just inserts it (e.g. a pasted path).
     #[serde(default = "default_true")]
     enter: bool,
+    /// Route to a specific agent window (several can share a lane); `None` = first slot.
+    #[serde(default)]
+    window: Option<String>,
 }
 fn default_true() -> bool {
     true
@@ -104,6 +107,8 @@ fn default_true() -> bool {
 struct AgentSignal {
     lane_id: repomon_core::model::LaneId,
     key: String,
+    #[serde(default)]
+    window: Option<String>,
 }
 #[derive(Deserialize)]
 struct AgentKey {
@@ -111,12 +116,29 @@ struct AgentKey {
     key: String,
     #[serde(default)]
     literal: bool,
+    #[serde(default)]
+    window: Option<String>,
 }
 #[derive(Deserialize)]
 struct AgentCapture {
     lane_id: repomon_core::model::LaneId,
     #[serde(default)]
     lines: Option<u32>,
+    #[serde(default)]
+    window: Option<String>,
+}
+#[derive(Deserialize)]
+struct AgentStop {
+    lane_id: repomon_core::model::LaneId,
+    /// Stop one specific agent window; `None` stops the lane's first slot.
+    #[serde(default)]
+    window: Option<String>,
+}
+#[derive(Deserialize)]
+struct AgentTarget {
+    lane_id: repomon_core::model::LaneId,
+    #[serde(default)]
+    window: Option<String>,
 }
 #[derive(Deserialize)]
 struct AgentAutoContinue {
@@ -184,6 +206,12 @@ struct TerminalId {
 #[derive(Deserialize)]
 struct ViewportSet {
     lane_ids: Vec<repomon_core::model::LaneId>,
+    /// Which agent window the focused lane's pane should stream (Tab cycling in Focus/Split);
+    /// other viewport lanes stream their first slot.
+    #[serde(default)]
+    focus_lane: Option<repomon_core::model::LaneId>,
+    #[serde(default)]
+    focus_window: Option<String>,
 }
 #[derive(Deserialize)]
 struct LaneMerge {
@@ -676,8 +704,11 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "agent.capture" => {
             let p: AgentCapture = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let (lane, lines) = (p.lane_id, p.lines);
-            let content = tokio::task::spawn_blocking(move || tmux.capture(lane, lines))
+            let lines = p.lines;
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            let content = tokio::task::spawn_blocking(move || tmux.capture_named(&window, lines))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
@@ -687,11 +718,12 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             let p: AgentInput = parse(params)?;
             let tmux = ctx.tmux.clone();
             let (lane, text, enter) = (p.lane_id, p.text, p.enter);
+            let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             tokio::task::spawn_blocking(move || {
                 if enter {
-                    tmux.send_text(lane, &text)
+                    tmux.send_text_named(&window, &text)
                 } else {
-                    tmux.send_literal(lane, &text)
+                    tmux.send_literal_named(&window, &text)
                 }
             })
             .await
@@ -702,8 +734,11 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "agent.signal" => {
             let p: AgentSignal = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let (lane, key) = (p.lane_id, p.key);
-            tokio::task::spawn_blocking(move || tmux.send_key(lane, &key))
+            let key = p.key;
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            tokio::task::spawn_blocking(move || tmux.send_key_named(&window, &key))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
@@ -712,12 +747,15 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "agent.key" => {
             let p: AgentKey = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let (lane, key, literal) = (p.lane_id, p.key, p.literal);
+            let (key, literal) = (p.key, p.literal);
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
             tokio::task::spawn_blocking(move || {
                 if literal {
-                    tmux.send_literal(lane, &key)
+                    tmux.send_literal_named(&window, &key)
                 } else {
-                    tmux.send_key(lane, &key)
+                    tmux.send_key_named(&window, &key)
                 }
             })
             .await
@@ -726,11 +764,19 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             Ok(Value::Null)
         }
         "agent.stop" => {
-            let p: LaneId = parse(params)?;
+            let p: AgentStop = parse(params)?;
             let tmux = ctx.tmux.clone();
             let lane = p.lane_id;
-            let _ = tokio::task::spawn_blocking(move || tmux.kill(lane)).await;
-            let _ = ctx.store.set_lane_tmux_window(p.lane_id, None).await;
+            let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
+            let remaining = tokio::task::spawn_blocking(move || {
+                let _ = tmux.kill_named(&window);
+                tmux.windows_for(lane).unwrap_or_default().len()
+            })
+            .await
+            .unwrap_or(0);
+            if remaining == 0 {
+                let _ = ctx.store.set_lane_tmux_window(p.lane_id, None).await;
+            }
             ctx.broadcast(
                 crate::pubsub::topic::AGENT_STATUS,
                 json!({ "lane_id": p.lane_id, "status": "ended" }),
@@ -746,13 +792,17 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             Ok(Value::Null)
         }
         "agent.target" => {
-            let p: LaneId = parse(params)?;
+            let p: AgentTarget = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let lane = p.lane_id;
-            let available = tokio::task::spawn_blocking(move || tmux.has_window(lane))
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            let w = window.clone();
+            let available = tokio::task::spawn_blocking(move || tmux.has_named(&w))
                 .await
                 .map_err(internal)?;
-            Ok(json!({ "target": ctx.tmux.target(p.lane_id), "available": available }))
+            let target = format!("{}:={}", ctx.tmux.session(), window);
+            Ok(json!({ "target": target, "available": available }))
         }
         // Arm/disarm auto-continue (resume on usage limit) for one lane, this session.
         "agent.auto_continue" => {
@@ -858,6 +908,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "viewport.set" => {
             let p: ViewportSet = parse(params)?;
             *ctx.viewport.lock().await = p.lane_ids;
+            *ctx.viewport_focus.lock().await = p.focus_lane.zip(p.focus_window);
             Ok(Value::Null)
         }
 
@@ -948,20 +999,28 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             let alive = live.get(&key).copied().unwrap_or(0);
             summaries.truncate(alive); // sorted newest-first; 0 → none
         }
-        let managed = windows.contains(&TmuxRuntime::window_name(lane.id));
+        // The lane's managed agent windows, in slot order (= spawn order). Several agents can
+        // run side by side; pair the newest `k` transcripts with the `k` windows, oldest with
+        // oldest (slot order tracks spawn order, transcripts arrive newest-first). A heuristic,
+        // but it routes keys/captures to the right pane in practice.
+        let lane_windows = TmuxRuntime::lane_windows_in(&windows, lane.id);
+        let managed_n = lane_windows.len();
         if !summaries.is_empty() {
+            let paired = summaries.len().min(managed_n);
             for (idx, s) in summaries.into_iter().enumerate() {
                 if s.last_activity > lane.last_activity_at {
                     lane.last_activity_at = s.last_activity;
                 }
-                // repomon manages at most one session per worktree (its single tmux window);
-                // assume that's the most-recent one. Every other session is running in another
-                // terminal, so it's external and adoptable.
                 let mut session = s.into_session(lane.repo.id, lane.worktree.id);
-                session.external = !(managed && idx == 0);
+                if idx < paired {
+                    session.external = false;
+                    session.tmux_window = Some(lane_windows[paired - 1 - idx].clone());
+                } else {
+                    session.external = true;
+                }
                 lane.agent_sessions.push(session);
             }
-        } else if managed {
+        } else if managed_n > 0 {
             // No parseable transcript: surface a repomon-spawned agent if its window is alive.
             let kind = metas
                 .iter()
@@ -985,6 +1044,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 session_id: None,
                 resume_at: None,
                 inferred: false,
+                tmux_window: lane_windows.first().cloned(),
             });
         } else if let Some(changed) = lane.state.last_change_at {
             // No identified agent, but a *non-main* worktree's files changed very recently — infer
@@ -1013,6 +1073,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     session_id: None,
                     resume_at: None,
                     inferred: true,
+                    tmux_window: None,
                 });
             }
         }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -45,6 +45,9 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "notify_resumed": cfg.notify_resumed,
         "notify_idle": cfg.notify_idle,
         "notify_sound": cfg.notify_sound,
+        "notify_show_why": cfg.notify_show_why,
+        "notify_coalesce": cfg.notify_coalesce,
+        "notify_click_focus": cfg.notify_click_focus,
     })
 }
 
@@ -186,6 +189,12 @@ struct ConfigSet {
     notify_idle: Option<bool>,
     #[serde(default)]
     notify_sound: Option<bool>,
+    #[serde(default)]
+    notify_show_why: Option<bool>,
+    #[serde(default)]
+    notify_coalesce: Option<bool>,
+    #[serde(default)]
+    notify_click_focus: Option<bool>,
 }
 #[derive(Deserialize)]
 struct AgentAdopt {
@@ -600,6 +609,15 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 }
                 if let Some(b) = p.notify_sound {
                     cfg.notify_sound = b;
+                }
+                if let Some(b) = p.notify_show_why {
+                    cfg.notify_show_why = b;
+                }
+                if let Some(b) = p.notify_coalesce {
+                    cfg.notify_coalesce = b;
+                }
+                if let Some(b) = p.notify_click_focus {
+                    cfg.notify_click_focus = b;
                 }
                 if let Err(e) = cfg.save_to(&ctx.config_path) {
                     *cfg = prev;
@@ -1045,6 +1063,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 resume_at: None,
                 inferred: false,
                 tmux_window: lane_windows.first().cloned(),
+                last_message: None,
             });
         } else if let Some(changed) = lane.state.last_change_at {
             // No identified agent, but a *non-main* worktree's files changed very recently — infer
@@ -1074,6 +1093,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     resume_at: None,
                     inferred: true,
                     tmux_window: None,
+                    last_message: None,
                 });
             }
         }

--- a/crates/repomon-tui/Cargo.toml
+++ b/crates/repomon-tui/Cargo.toml
@@ -30,3 +30,6 @@ ansi-to-tui = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Only for building Lane/Worktree fixtures (ObjectId) in unit tests; already compiled anyway
+# via repomon-core.
+gix = { workspace = true }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -185,8 +185,10 @@ pub struct App {
     /// True once the first lane list has seeded `prev_status` (so startup doesn't notify for
     /// every already-running agent at once).
     notif_seeded: bool,
-    /// Per-lane debounce: the last time a notification fired for a lane (suppresses flapping).
-    notif_debounce: HashMap<LaneId, Instant>,
+    /// Debounce keyed by (lane, kind): the last time each *kind* of alert fired for a lane.
+    /// Keying on the kind suppresses a flapping identical alert without swallowing a genuinely
+    /// different transition (e.g. a usage-limit alert right after a needs-you one).
+    notif_debounce: HashMap<(LaneId, NotifKind), Instant>,
     /// In-app notification history (newest last), shown in the Notifications view.
     pub notifications: VecDeque<NotifEvent>,
     /// Scroll offset (rows from the top) in the Notifications view.
@@ -352,10 +354,15 @@ impl App {
     /// which arrive as notifications that trigger a full [`refresh`].
     pub async fn refresh_lanes(&mut self) {
         match self.client.call_typed::<Vec<Lane>>("lane.list", None).await {
-            Ok(l) => self.lanes = l,
+            Ok(l) => {
+                self.lanes = l;
+                // Run notification edge-detection only on a *successful* fetch. Seeding off a
+                // failed first call (empty lanes) would make the next good refresh treat every
+                // running agent as a fresh transition — the startup storm seeding prevents.
+                self.detect_notifications();
+            }
             Err(e) => self.status = format!("lane.list failed: {e}"),
         }
-        self.detect_notifications();
         self.clamp_selection();
     }
 
@@ -386,6 +393,12 @@ impl App {
             return;
         }
 
+        // Drop bookkeeping for lanes that no longer exist, so the maps don't grow across a long
+        // session of create/delete churn.
+        let live: HashSet<LaneId> = self.lanes.iter().map(|l| l.id).collect();
+        self.prev_status.retain(|id, _| live.contains(id));
+        self.notif_debounce.retain(|&(id, _), _| live.contains(&id));
+
         // Decide what to fire first (updating the snapshot + debounce as we go), then deliver —
         // delivery composes from `self.lanes` and mutates `self`, so it can't run while we still
         // hold a borrow into the lanes here.
@@ -402,13 +415,14 @@ impl App {
             if !self.notif_enabled_for(kind) {
                 continue;
             }
-            // Debounce per lane so a flapping agent can't spam.
-            if let Some(t) = self.notif_debounce.get(&id) {
+            // Debounce per (lane, kind): suppress a flapping identical alert, but never swallow a
+            // genuinely different transition for the same lane.
+            if let Some(t) = self.notif_debounce.get(&(id, kind)) {
                 if t.elapsed() < NOTIF_DEBOUNCE {
                     continue;
                 }
             }
-            self.notif_debounce.insert(id, Instant::now());
+            self.notif_debounce.insert((id, kind), Instant::now());
             fires.push((id, kind));
         }
         for (id, kind) in fires {
@@ -1170,7 +1184,9 @@ impl App {
                 self.notif_scroll = self.notif_scroll.saturating_sub(1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.notif_scroll = self.notif_scroll.saturating_add(1);
+                // Clamp to the last event so scrolling past the end can't blank the feed.
+                let max = self.notifications.len().saturating_sub(1);
+                self.notif_scroll = (self.notif_scroll + 1).min(max);
             }
             KeyCode::Char('c') => {
                 self.notifications.clear();

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -230,6 +230,9 @@ pub struct App {
     pub browse_parent: Option<String>,
     pub browse_entries: Vec<BrowseEntry>,
     pub browse_selected: usize,
+    /// Two-press confirm for unregistering a repo from the browser (`x x`): the repo id armed
+    /// by the first press.
+    repo_remove_pending: Option<i64>,
     /// Agent-manager state: the list, the cursor, and the add/edit form.
     pub agents: Vec<AgentChoice>,
     pub agents_selected: usize,
@@ -243,6 +246,7 @@ pub struct App {
     /// Where `esc` returns from the Agents view (e.g. back to New Lane).
     agents_return: Option<View>,
     last_viewport: Vec<LaneId>,
+    last_viewport_focus: Option<(LaneId, String)>,
     attach_request: Option<LaneId>,
     /// A tmux target (e.g. a terminal window) the loop should attach to next.
     attach_target: Option<String>,
@@ -330,6 +334,7 @@ impl App {
             browse_parent: None,
             browse_entries: Vec::new(),
             browse_selected: 0,
+            repo_remove_pending: None,
             agents: Vec::new(),
             agents_selected: 0,
             ag_editing: false,
@@ -340,6 +345,7 @@ impl App {
             ag_orig: None,
             agents_return: None,
             last_viewport: Vec::new(),
+            last_viewport_focus: None,
             attach_request: None,
             attach_target: None,
             input_suspended: Arc::new(AtomicBool::new(false)),
@@ -724,15 +730,32 @@ impl App {
         }
     }
 
-    /// Tell the daemon which lanes are visible, if that set changed.
+    /// Tell the daemon which lanes are visible — and, in Split/Focus, which agent window the
+    /// selected lane should stream (so Tab between a lane's agents retargets the pane) — if
+    /// either changed.
     pub async fn sync_viewport(&mut self) {
         let live = self.live_lanes();
-        if live != self.last_viewport {
+        let focus = match self.view {
+            View::Split | View::Focus => self
+                .selected_lane()
+                .map(|l| l.id)
+                .zip(self.selected_window()),
+            _ => None,
+        };
+        if live != self.last_viewport || focus != self.last_viewport_focus {
             let _ = self
                 .client
-                .call("viewport.set", Some(json!({ "lane_ids": live })))
+                .call(
+                    "viewport.set",
+                    Some(json!({
+                        "lane_ids": live,
+                        "focus_lane": focus.as_ref().map(|(l, _)| l),
+                        "focus_window": focus.as_ref().map(|(_, w)| w),
+                    })),
+                )
                 .await;
             self.last_viewport = live;
+            self.last_viewport_focus = focus;
         }
     }
 
@@ -882,6 +905,15 @@ impl App {
             KeyCode::Char('q') => self.should_quit = true,
             _ => {}
         }
+    }
+
+    /// The managed tmux window of the session the cursor is on (Tab cycles it) — where keys,
+    /// captures, stops, and attaches are routed. `None` falls back to the lane's first slot
+    /// (external/inferred sessions have no window of their own).
+    fn selected_window(&self) -> Option<String> {
+        self.selected_lane()
+            .and_then(|l| l.agent_sessions.get(self.session_idx))
+            .and_then(|s| s.tmux_window.clone())
     }
 
     /// Move the session cursor among the selected lane's agents.
@@ -1058,9 +1090,53 @@ impl App {
             }
             KeyCode::Char('a') => self.add_browsed().await,
             KeyCode::Char('d') => self.discover_here().await,
+            KeyCode::Char('x') => self.remove_browsed().await,
             KeyCode::Esc => self.view = View::Fleet,
             KeyCode::Char('q') => self.should_quit = true,
             _ => {}
+        }
+        // Any key other than the confirming second `x` disarms a pending removal.
+        if key.code != KeyCode::Char('x') {
+            self.repo_remove_pending = None;
+        }
+    }
+
+    /// Unregister the selected repo (must already be registered — marked `+`). Two presses of
+    /// `x`: the first arms, the second removes. Only repomon's bookkeeping goes away — the
+    /// project, its worktrees, and any running agents on disk are untouched.
+    async fn remove_browsed(&mut self) {
+        let Some(entry) = self.browse_entries.get(self.browse_selected) else {
+            return;
+        };
+        if !entry.added {
+            self.status = "not a registered repo (only + entries can be removed)".into();
+            self.repo_remove_pending = None;
+            return;
+        }
+        let Some(repo) = self.repos.iter().find(|r| r.path == entry.path) else {
+            self.status = "couldn't match this entry to a registered repo".into();
+            self.repo_remove_pending = None;
+            return;
+        };
+        let (id, name) = (repo.id, repo.name.clone());
+        if self.repo_remove_pending != Some(id) {
+            self.repo_remove_pending = Some(id);
+            self.status = format!("press x again to remove {name} (files on disk stay)");
+            return;
+        }
+        self.repo_remove_pending = None;
+        match self
+            .client
+            .call("repo.remove", Some(json!({ "repo_id": id })))
+            .await
+        {
+            Ok(_) => {
+                self.status = format!("removed {name} — files on disk untouched");
+                self.refresh().await;
+                let here = self.browse_path.clone();
+                self.load_browse(Some(here)).await;
+            }
+            Err(e) => self.status = format!("remove failed: {e}"),
         }
     }
 
@@ -1833,7 +1909,12 @@ impl App {
                 .client
                 .call(
                     "agent.key",
-                    Some(json!({ "lane_id": id, "key": spec, "literal": literal })),
+                    Some(json!({
+                        "lane_id": id,
+                        "key": spec,
+                        "literal": literal,
+                        "window": self.selected_window(),
+                    })),
                 )
                 .await;
         }
@@ -2197,7 +2278,12 @@ impl App {
                     .client
                     .call(
                         "agent.send_input",
-                        Some(json!({ "lane_id": id, "text": format!("{path} "), "enter": false })),
+                        Some(json!({
+                            "lane_id": id,
+                            "text": format!("{path} "),
+                            "enter": false,
+                            "window": self.selected_window(),
+                        })),
                     )
                     .await;
                 self.reset_scroll();
@@ -2232,7 +2318,11 @@ impl App {
                     .client
                     .call(
                         "agent.capture",
-                        Some(json!({ "lane_id": id, "lines": 2000 })),
+                        Some(json!({
+                            "lane_id": id,
+                            "lines": 2000,
+                            "window": self.selected_window(),
+                        })),
                     )
                     .await
                 {
@@ -2326,7 +2416,10 @@ impl App {
         if let Some(id) = self.selected_lane().map(|l| l.id) {
             let _ = self
                 .client
-                .call("agent.stop", Some(json!({ "lane_id": id })))
+                .call(
+                    "agent.stop",
+                    Some(json!({ "lane_id": id, "window": self.selected_window() })),
+                )
                 .await;
             self.status = "stopped agent".into();
             // Don't keep staring at the stopped agent's pane.
@@ -2873,11 +2966,16 @@ async fn event_loop(
     }
 }
 
-/// Suspend the TUI, attach to the lane's tmux window, then re-enter.
+/// Suspend the TUI, attach to the lane's tmux window (the selected agent's, when several run
+/// side by side), then re-enter.
 async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) {
+    let window = app.selected_window();
     let resp = app
         .client
-        .call("agent.target", Some(json!({ "lane_id": lane })))
+        .call(
+            "agent.target",
+            Some(json!({ "lane_id": lane, "window": window })),
+        )
         .await;
     let (target, available) = match resp {
         Ok(v) => (
@@ -3155,6 +3253,7 @@ mod tests {
             session_id: session_id.map(str::to_string),
             resume_at: None,
             inferred,
+            tmux_window: None,
         }
     }
 

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1145,6 +1145,10 @@ impl App {
             }
             11 => {
                 self.settings.notify_sound = !self.settings.notify_sound;
+                // Preview the chime immediately so "is sound working?" is answered on the spot.
+                if self.settings.notify_sound {
+                    notify::play_chime();
+                }
                 self.save_settings().await;
             }
             _ => {}

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -13,8 +13,8 @@ use ratatui::layout::{Position, Rect};
 use ratatui::text::Line;
 use ratatui::DefaultTerminal;
 use repomon_core::model::{
-    AgentChoice, AgentStatus, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo, TimelineData,
-    WorkSession,
+    AgentChoice, AgentSession, AgentStatus, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo,
+    TimelineData, WorkSession,
 };
 use repomon_core::protocol::Notification;
 use serde_json::json;
@@ -28,7 +28,7 @@ use crate::view;
 
 /// How long an in-app notification banner stays up before reverting to the footer hints.
 pub const NOTIF_BANNER_TTL: Duration = Duration::from_secs(6);
-/// Don't re-fire the same lane's notification within this window (suppresses status flapping).
+/// Don't re-fire the same session's notification within this window (suppresses status flapping).
 const NOTIF_DEBOUNCE: Duration = Duration::from_secs(30);
 /// Cap on the in-app notification history feed.
 const NOTIF_HISTORY_CAP: usize = 200;
@@ -180,15 +180,18 @@ pub struct App {
     pub settings_editing: bool,
     /// Screen row of the first settings item (for click hit-testing), set during render.
     pub settings_geom: std::cell::Cell<u16>,
-    /// Last-seen agent status per lane, for notification edge-detection. `None` = no real agent.
-    prev_status: HashMap<LaneId, Option<AgentStatus>>,
+    /// Last-seen status per real agent session, for notification edge-detection. A session that
+    /// left the snapshot is expressed by key absence (there is no `None` value), which is what
+    /// lets each agent in a shared lane fire its own alerts instead of one rolled-up status.
+    prev_status: HashMap<(LaneId, SessKey), AgentStatus>,
     /// True once the first lane list has seeded `prev_status` (so startup doesn't notify for
     /// every already-running agent at once).
     notif_seeded: bool,
-    /// Debounce keyed by (lane, kind): the last time each *kind* of alert fired for a lane.
-    /// Keying on the kind suppresses a flapping identical alert without swallowing a genuinely
-    /// different transition (e.g. a usage-limit alert right after a needs-you one).
-    notif_debounce: HashMap<(LaneId, NotifKind), Instant>,
+    /// Debounce keyed by (lane, session, kind): the last time each *kind* of alert fired for a
+    /// session. Keying on the kind suppresses a flapping identical alert without swallowing a
+    /// genuinely different transition (e.g. a usage-limit alert right after a needs-you one);
+    /// keying on the session lets two agents in one lane each raise the same kind of alert.
+    notif_debounce: HashMap<(LaneId, SessKey, NotifKind), Instant>,
     /// In-app notification history (newest last), shown in the Notifications view.
     pub notifications: VecDeque<NotifEvent>,
     /// Scroll offset (rows from the top) in the Notifications view.
@@ -366,67 +369,64 @@ impl App {
         self.clamp_selection();
     }
 
-    /// A lane's notification-relevant status: the highest-priority status among its *real*
-    /// (non-inferred) agent sessions. `None` when the lane has no identified agent — inferred
-    /// "file activity" placeholders are deliberately ignored so they don't drive named alerts.
-    fn lane_status(lane: &Lane) -> Option<AgentStatus> {
-        use AgentStatus::*;
-        let real = || lane.agent_sessions.iter().filter(|s| !s.inferred);
-        [RateLimited, Waiting, Running, Idle, Ended]
-            .into_iter()
-            .find(|&want| real().any(|s| s.status == want))
-    }
-
-    /// Diff the freshly-fetched lane statuses against the previous snapshot and fire a
+    /// Diff the freshly-fetched per-session statuses against the previous snapshot and fire a
     /// notification on each meaningful transition. The first call only seeds the snapshot.
     fn detect_notifications(&mut self) {
-        // Snapshot the new per-lane statuses.
-        let now_status: Vec<(LaneId, Option<AgentStatus>)> = self
+        // Snapshot the new statuses, one entry per real agent session.
+        let now: HashMap<(LaneId, SessKey), AgentStatus> = self
             .lanes
             .iter()
-            .map(|l| (l.id, Self::lane_status(l)))
+            .flat_map(|l| session_statuses(l.id, &l.agent_sessions))
             .collect();
 
         if !self.notif_seeded {
-            self.prev_status = now_status.into_iter().collect();
+            self.prev_status = now;
             self.notif_seeded = true;
             return;
         }
 
-        // Drop bookkeeping for lanes that no longer exist, so the maps don't grow across a long
-        // session of create/delete churn.
-        let live: HashSet<LaneId> = self.lanes.iter().map(|l| l.id).collect();
-        self.prev_status.retain(|id, _| live.contains(id));
-        self.notif_debounce.retain(|&(id, _), _| live.contains(&id));
+        let live_lanes: HashSet<LaneId> = self.lanes.iter().map(|l| l.id).collect();
+        // Lanes that currently have a managed real session — used by the diff to suppress the
+        // identity handoff where the no-transcript `Fallback` key vanishes in the same refresh
+        // its `Transcript` key first appears (the agent didn't stop, it became identifiable).
+        let lanes_with_managed: HashSet<LaneId> = self
+            .lanes
+            .iter()
+            .filter(|l| l.agent_sessions.iter().any(|s| !s.external && !s.inferred))
+            .map(|l| l.id)
+            .collect();
 
-        // Decide what to fire first (updating the snapshot + debounce as we go), then deliver —
-        // delivery composes from `self.lanes` and mutates `self`, so it can't run while we still
-        // hold a borrow into the lanes here.
-        let mut fires: Vec<(LaneId, NotifKind)> = Vec::new();
-        for (id, now) in now_status {
-            let prev = self.prev_status.get(&id).copied().flatten();
-            self.prev_status.insert(id, now);
-            if now == prev {
-                continue;
-            }
-            let Some(kind) = transition_kind(prev, now) else {
-                continue;
-            };
+        // Decide what to fire first (updating the debounce as we go), then deliver — delivery
+        // composes from `self.lanes` and mutates `self`, so it can't run while we still hold a
+        // borrow into the lanes here.
+        let mut fires: Vec<((LaneId, SessKey), NotifKind)> = Vec::new();
+        for (key, kind) in
+            diff_session_transitions(&self.prev_status, &now, &live_lanes, &lanes_with_managed)
+        {
             if !self.notif_enabled_for(kind) {
                 continue;
             }
-            // Debounce per (lane, kind): suppress a flapping identical alert, but never swallow a
-            // genuinely different transition for the same lane.
-            if let Some(t) = self.notif_debounce.get(&(id, kind)) {
+            let dkey = (key.0, key.1.clone(), kind);
+            if let Some(t) = self.notif_debounce.get(&dkey) {
                 if t.elapsed() < NOTIF_DEBOUNCE {
                     continue;
                 }
             }
-            self.notif_debounce.insert((id, kind), Instant::now());
-            fires.push((id, kind));
+            self.notif_debounce.insert(dkey, Instant::now());
+            fires.push((key, kind));
         }
-        for (id, kind) in fires {
-            self.fire_notification(id, kind);
+
+        // Replacing the snapshot wholesale prunes dead lanes AND dead sessions in one move. The
+        // debounce keeps entries for sessions still in the snapshot, plus a grace window so the
+        // maps can't grow across a long session of lane/transcript churn.
+        self.prev_status = now;
+        let prev = &self.prev_status;
+        self.notif_debounce.retain(|(lane, sess, _), t| {
+            prev.contains_key(&(*lane, sess.clone())) || t.elapsed() < NOTIF_DEBOUNCE
+        });
+
+        for ((lane, key), kind) in fires {
+            self.fire_notification(lane, &key, kind);
         }
     }
 
@@ -443,14 +443,15 @@ impl App {
         }
     }
 
-    /// Compose + deliver a notification for a lane: native popup, in-app banner, history entry.
-    fn fire_notification(&mut self, id: LaneId, kind: NotifKind) {
-        // Compose under an immutable borrow that ends before we mutate `self`.
+    /// Compose + deliver a notification about one session: native popup, banner, history entry.
+    fn fire_notification(&mut self, id: LaneId, key: &SessKey, kind: NotifKind) {
+        // Compose under an immutable borrow that ends before we mutate `self`. The session may
+        // be gone when its disappearance was the trigger — compose degrades to a generic line.
         let Some((title, body)) = self
             .lanes
             .iter()
             .find(|l| l.id == id)
-            .map(|l| notify::compose(kind, l))
+            .map(|l| notify::compose(kind, l, session_by_key(l, key)))
         else {
             return;
         };
@@ -2348,8 +2349,107 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     Ok(app.cd_target)
 }
 
-/// Map a lane's agent-status transition to the notification it should fire, if any. `None`
-/// means "no real agent". Priority resolves cases like `Running → RateLimited` to the limit.
+/// Identifies one real agent session within a lane across refreshes.
+///
+/// Transcript-backed sessions key on the Claude session id (the transcript filename stem),
+/// which is stable across polls. `claude --resume` may continue the same logical work in a new
+/// transcript; that reads as one session vanishing and another appearing — acceptable noise. A
+/// lane has at most one real session *without* a transcript id per snapshot (the managed
+/// no-transcript placeholder or the generic process monitor — mutually exclusive branches in
+/// the daemon's `overlay_agents`), so a single `Fallback` sentinel covers it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum SessKey {
+    Transcript(String),
+    Fallback,
+}
+
+/// Key/status pairs for one lane's *real* agent sessions. Inferred "file activity" placeholders
+/// are dropped so they never drive named alerts. On a (theoretically impossible) duplicate key,
+/// the higher-priority status wins — the same order the old per-lane rollup used.
+fn session_statuses(
+    lane_id: LaneId,
+    sessions: &[AgentSession],
+) -> Vec<((LaneId, SessKey), AgentStatus)> {
+    let mut out: Vec<((LaneId, SessKey), AgentStatus)> = Vec::new();
+    for s in sessions.iter().filter(|s| !s.inferred) {
+        let key = (
+            lane_id,
+            s.session_id
+                .clone()
+                .map(SessKey::Transcript)
+                .unwrap_or(SessKey::Fallback),
+        );
+        match out.iter_mut().find(|(k, _)| *k == key) {
+            Some((_, st)) if status_priority(s.status) < status_priority(*st) => *st = s.status,
+            Some(_) => {}
+            None => out.push((key, s.status)),
+        }
+    }
+    out
+}
+
+/// Notification priority of a status (lower = more urgent).
+fn status_priority(s: AgentStatus) -> usize {
+    use AgentStatus::*;
+    [RateLimited, Waiting, Running, Idle, Ended]
+        .iter()
+        .position(|&x| x == s)
+        .unwrap_or(usize::MAX)
+}
+
+/// Diff the previous and current per-session status maps into the notifications to fire.
+///
+/// Sessions present in `now` are edge-detected against their previous status. Sessions that
+/// vanished fire as a transition to `None` (→ Idle if they were active), except when their
+/// whole lane is gone (deleting a lane isn't an agent going quiet) or when a lane's `Fallback`
+/// key was handed off to a transcript-backed key (`lanes_with_managed`): the managed
+/// no-transcript placeholder disappears the moment the agent's transcript becomes parseable,
+/// and firing Idle there would alert on every spawn.
+fn diff_session_transitions(
+    prev: &HashMap<(LaneId, SessKey), AgentStatus>,
+    now: &HashMap<(LaneId, SessKey), AgentStatus>,
+    live_lanes: &HashSet<LaneId>,
+    lanes_with_managed: &HashSet<LaneId>,
+) -> Vec<((LaneId, SessKey), NotifKind)> {
+    let mut out = Vec::new();
+    for (key, &status) in now {
+        let was = prev.get(key).copied();
+        if was == Some(status) {
+            continue;
+        }
+        if let Some(kind) = transition_kind(was, Some(status)) {
+            out.push((key.clone(), kind));
+        }
+    }
+    for (key, &was) in prev {
+        if now.contains_key(key) || !live_lanes.contains(&key.0) {
+            continue;
+        }
+        if key.1 == SessKey::Fallback && lanes_with_managed.contains(&key.0) {
+            continue;
+        }
+        if let Some(kind) = transition_kind(Some(was), None) {
+            out.push((key.clone(), kind));
+        }
+    }
+    out
+}
+
+/// Resolve a session key back to the lane's session, for composing the notification text.
+/// `None` when the session vanished (i.e. its disappearance was the trigger).
+fn session_by_key<'a>(lane: &'a Lane, key: &SessKey) -> Option<&'a AgentSession> {
+    lane.agent_sessions
+        .iter()
+        .filter(|s| !s.inferred)
+        .find(|s| match key {
+            SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
+            SessKey::Fallback => s.session_id.is_none(),
+        })
+}
+
+/// Map a session's status transition to the notification it should fire, if any. `None` means
+/// the session was absent from that snapshot. Priority resolves cases like
+/// `Running → RateLimited` to the limit.
 fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> Option<NotifKind> {
     use AgentStatus::*;
     match (prev, now) {
@@ -2758,6 +2858,132 @@ mod tests {
         assert_eq!(transition_kind(None, Some(Running)), None);
         assert_eq!(transition_kind(Some(Idle), Some(Running)), None);
         assert_eq!(transition_kind(Some(Waiting), Some(Waiting)), None);
+    }
+
+    /// A minimal real-or-inferred session, mirroring the daemon's `overlay_agents` literals.
+    fn sess(session_id: Option<&str>, status: AgentStatus, inferred: bool) -> AgentSession {
+        AgentSession {
+            id: 0,
+            agent: repomon_core::model::AgentKind::ClaudeCode,
+            repo_id: 1,
+            worktree_id: None,
+            started_at: chrono::Utc::now(),
+            last_activity_at: chrono::Utc::now(),
+            ended_at: None,
+            manifest_path: PathBuf::new(),
+            tool_call_count: 0,
+            title: None,
+            status,
+            external: false,
+            session_id: session_id.map(str::to_string),
+            resume_at: None,
+            inferred,
+        }
+    }
+
+    #[test]
+    fn session_statuses_keys_and_filters() {
+        use AgentStatus::*;
+        let sessions = vec![
+            sess(Some("a"), Waiting, false),
+            sess(Some("b"), RateLimited, false),
+            sess(None, Running, true), // inferred file-activity placeholder — excluded
+            sess(None, Running, false),
+        ];
+        let got = session_statuses(7, &sessions);
+        assert_eq!(got.len(), 3);
+        assert!(got.contains(&((7, SessKey::Transcript("a".into())), Waiting)));
+        assert!(got.contains(&((7, SessKey::Transcript("b".into())), RateLimited)));
+        assert!(got.contains(&((7, SessKey::Fallback), Running)));
+
+        // Defensive: a duplicate key keeps the higher-priority status.
+        let dup = vec![sess(None, Idle, false), sess(None, Waiting, false)];
+        assert_eq!(
+            session_statuses(7, &dup),
+            vec![((7, SessKey::Fallback), Waiting)]
+        );
+    }
+
+    #[test]
+    fn two_sessions_fire_independent_streams() {
+        use AgentStatus::*;
+        let k = |id: &str| (1, SessKey::Transcript(id.into()));
+        let live: HashSet<LaneId> = [1].into();
+        let managed = HashSet::new();
+
+        // One agent finishes its turn while its lane-mate is still rate-limited. The old
+        // per-lane rollup saw "RateLimited" before and after and fired nothing — the masking
+        // this change exists to fix.
+        let prev: HashMap<_, _> = [(k("a"), Running), (k("b"), RateLimited)].into();
+        let now: HashMap<_, _> = [(k("a"), Waiting), (k("b"), RateLimited)].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &now, &live, &managed),
+            vec![(k("a"), NotifKind::NeedsYou)]
+        );
+
+        // And the rate-limited lane-mate resumes independently.
+        let now2: HashMap<_, _> = [(k("a"), Waiting), (k("b"), Running)].into();
+        assert_eq!(
+            diff_session_transitions(&now, &now2, &live, &managed),
+            vec![(k("b"), NotifKind::Resumed)]
+        );
+    }
+
+    #[test]
+    fn disappearance_fires_idle_only_when_lane_lives() {
+        use AgentStatus::*;
+        let k = (1, SessKey::Transcript("a".into()));
+        let prev: HashMap<_, _> = [(k.clone(), Waiting)].into();
+        let now = HashMap::new();
+        let managed = HashSet::new();
+
+        let live: HashSet<LaneId> = [1].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &now, &live, &managed),
+            vec![(k, NotifKind::Idle)]
+        );
+        // The whole lane went away (deleted): not an agent going quiet.
+        assert!(diff_session_transitions(&prev, &now, &HashSet::new(), &managed).is_empty());
+    }
+
+    #[test]
+    fn fallback_handoff_does_not_fire_idle() {
+        use AgentStatus::*;
+        let live: HashSet<LaneId> = [1].into();
+        let prev: HashMap<_, _> = [((1, SessKey::Fallback), Running)].into();
+        let now: HashMap<_, _> = [((1, SessKey::Transcript("a".into())), Running)].into();
+
+        // The managed spawn's transcript became parseable: Fallback hands off to Transcript
+        // within one refresh. The agent didn't stop, so nothing fires.
+        let managed: HashSet<LaneId> = [1].into();
+        assert!(diff_session_transitions(&prev, &now, &live, &managed).is_empty());
+
+        // But with no managed session left in the lane, a vanished fallback is a real stop.
+        let gone = HashMap::new();
+        assert_eq!(
+            diff_session_transitions(&prev, &gone, &live, &HashSet::new()),
+            vec![((1, SessKey::Fallback), NotifKind::Idle)]
+        );
+    }
+
+    #[test]
+    fn new_session_already_waiting_fires_needs_you() {
+        use AgentStatus::*;
+        let live: HashSet<LaneId> = [1].into();
+        let managed = HashSet::new();
+        let prev = HashMap::new();
+        let k = (1, SessKey::Transcript("a".into()));
+
+        // A second agent appearing mid-run already waiting (e.g. a parallel session that
+        // finished between refreshes) is exactly the alert the user wants.
+        let waiting: HashMap<_, _> = [(k.clone(), Waiting)].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &waiting, &live, &managed),
+            vec![(k.clone(), NotifKind::NeedsYou)]
+        );
+        // Appearing already-running is just work starting; stay quiet.
+        let running: HashMap<_, _> = [(k, Running)].into();
+        assert!(diff_session_transitions(&prev, &running, &live, &managed).is_empty());
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -203,6 +203,13 @@ pub struct App {
     pub spawn_pick_idx: usize,
     pub spawn_pick_lane: Option<LaneId>,
     spawn_return: Option<View>,
+    /// Fleet shows only lanes needing attention (waiting / stuck on a limit) when set.
+    pub urgent_only: bool,
+    /// Lane-switcher state: the typed query, the highlighted match, and the view to return to
+    /// on cancel.
+    pub jump_query: String,
+    pub jump_idx: usize,
+    jump_return: Option<View>,
     pub timeline: Option<TimelineData>,
     pub timeline_zoom: Zoom,
     pub sessions: Vec<WorkSession>,
@@ -304,6 +311,10 @@ impl App {
             spawn_pick_idx: 0,
             spawn_pick_lane: None,
             spawn_return: None,
+            urgent_only: false,
+            jump_query: String::new(),
+            jump_idx: 0,
+            jump_return: None,
             timeline: None,
             timeline_zoom: Zoom::Day,
             sessions: Vec::new(),
@@ -358,15 +369,190 @@ impl App {
     pub async fn refresh_lanes(&mut self) {
         match self.client.call_typed::<Vec<Lane>>("lane.list", None).await {
             Ok(l) => {
+                // Keep the cursor on the same lane across the attention re-sort below.
+                let keep = self.selected_lane().map(|l| l.id);
                 self.lanes = l;
                 // Run notification edge-detection only on a *successful* fetch. Seeding off a
                 // failed first call (empty lanes) would make the next good refresh treat every
                 // running agent as a fresh transition — the startup storm seeding prevents.
                 self.detect_notifications();
+                self.sort_lanes();
+                if let Some(id) = keep {
+                    if let Some(i) = self.visible_lanes().iter().position(|l| l.id == id) {
+                        self.selected = i;
+                    }
+                }
             }
             Err(e) => self.status = format!("lane.list failed: {e}"),
         }
         self.clamp_selection();
+    }
+
+    /// Order lanes for display: repo groups keep their original (daemon) order, and within each
+    /// group pinned lanes come first, then by attention (waiting > stuck on a limit > running),
+    /// then most recent activity. Stable, so ties keep the daemon's order — the cursor is
+    /// remapped by the caller since this runs on every refresh.
+    fn sort_lanes(&mut self) {
+        let mut repo_order: HashMap<i64, usize> = HashMap::new();
+        for l in &self.lanes {
+            let next = repo_order.len();
+            repo_order.entry(l.repo.id).or_insert(next);
+        }
+        let attention: HashMap<LaneId, u8> = self
+            .lanes
+            .iter()
+            .map(|l| (l.id, self.lane_attention(l)))
+            .collect();
+        self.lanes.sort_by_key(|l| {
+            (
+                repo_order[&l.repo.id],
+                !l.pinned,
+                attention[&l.id],
+                std::cmp::Reverse(l.last_activity_at),
+            )
+        });
+    }
+
+    /// How urgently this lane needs the user (lower = more urgent), accounting for whether a
+    /// rate-limited agent will be auto-continued (global toggle minus this lane's opt-out).
+    fn lane_attention(&self, lane: &Lane) -> u8 {
+        let armed = self.settings.auto_continue && !self.ac_off.contains(&lane.id);
+        attention_rank(&lane.agent_sessions, armed)
+    }
+
+    /// Whether this lane is blocked on the user: an agent waiting for input, or rate-limited
+    /// with no auto-continue coming.
+    fn lane_needs_attention(&self, lane: &Lane) -> bool {
+        self.lane_attention(lane) <= 1
+    }
+
+    /// Cycle the selection through the lanes blocked on the user, wrapping past the end. While
+    /// a notification banner is fresh, the first press goes to the lane that just alerted.
+    fn jump_attention(&mut self) {
+        let banner_lane = self
+            .notif_banner
+            .as_ref()
+            .filter(|(_, t)| t.elapsed() < NOTIF_BANNER_TTL)
+            .and_then(|_| self.notifications.back())
+            .map(|e| e.lane_id);
+
+        // Resolve the target under one immutable borrow of the lanes, then mutate.
+        let lanes = self.visible_lanes();
+        let hits: Vec<usize> = lanes
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| self.lane_needs_attention(l))
+            .map(|(i, _)| i)
+            .collect();
+        let banner_idx = banner_lane
+            .and_then(|id| lanes.iter().position(|l| l.id == id))
+            .filter(|&i| i != self.selected);
+        let label = |i: usize| format!("{}/{}", lanes[i].repo.name, lanes[i].worktree.name);
+
+        let (target, msg) = if let Some(i) = banner_idx {
+            (Some(i), format!("→ {} (just alerted)", label(i)))
+        } else if hits.is_empty() {
+            (None, "no agents need you".to_string())
+        } else {
+            let next = hits
+                .iter()
+                .copied()
+                .find(|&i| i > self.selected)
+                .unwrap_or(hits[0]);
+            let pos = hits.iter().position(|&i| i == next).unwrap_or(0);
+            (
+                Some(next),
+                format!("needs you {}/{} — {}", pos + 1, hits.len(), label(next)),
+            )
+        };
+        if let Some(i) = target {
+            self.selected = i;
+        }
+        self.status = msg;
+    }
+
+    /// Open the fuzzy lane switcher, remembering where to return on cancel.
+    fn enter_lane_jump(&mut self) {
+        self.jump_query.clear();
+        self.jump_idx = 0;
+        self.jump_return = Some(self.view);
+        self.view = View::LaneJump;
+    }
+
+    /// Lanes matching the switcher query, best first: fuzzy score, then attention, then
+    /// recency. An empty query lists every lane.
+    pub fn lane_jump_matches(&self) -> Vec<&Lane> {
+        let mut hits: Vec<(&Lane, u32)> = self
+            .lanes
+            .iter()
+            .filter_map(|l| {
+                let name = format!("{}/{}", l.repo.name, l.worktree.name);
+                let branch = l.state.branch.as_deref().unwrap_or("");
+                let score = match (
+                    fuzzy_score(&name, &self.jump_query),
+                    fuzzy_score(branch, &self.jump_query),
+                ) {
+                    (Some(a), Some(b)) => Some(a.min(b)),
+                    (a, b) => a.or(b),
+                }?;
+                Some((l, score))
+            })
+            .collect();
+        hits.sort_by_key(|(l, score)| {
+            (
+                *score,
+                self.lane_attention(l),
+                std::cmp::Reverse(l.last_activity_at),
+            )
+        });
+        hits.into_iter().map(|(l, _)| l).collect()
+    }
+
+    fn lane_jump_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Up | KeyCode::BackTab => self.jump_idx = self.jump_idx.saturating_sub(1),
+            KeyCode::Down | KeyCode::Tab if self.jump_idx + 1 < self.lane_jump_matches().len() => {
+                self.jump_idx += 1;
+            }
+            KeyCode::Enter => {
+                let id = self.lane_jump_matches().get(self.jump_idx).map(|l| l.id);
+                match id {
+                    Some(id) => self.jump_to_lane(id),
+                    None => self.status = "no lanes match".into(),
+                }
+            }
+            KeyCode::Esc => self.view = self.jump_return.take().unwrap_or(View::Fleet),
+            KeyCode::Backspace => {
+                self.jump_query.pop();
+                self.jump_idx = 0;
+            }
+            KeyCode::Char(c) => {
+                self.jump_query.push(c);
+                self.jump_idx = 0;
+            }
+            _ => {}
+        }
+    }
+
+    /// Select lane `id` — clearing any filter that hides it — and open it in Focus.
+    fn jump_to_lane(&mut self, id: LaneId) {
+        let find = |me: &Self| me.visible_lanes().iter().position(|l| l.id == id);
+        let mut idx = find(self);
+        if idx.is_none() && (!self.filter.is_empty() || self.urgent_only) {
+            self.filter.clear();
+            self.filtering = false;
+            self.urgent_only = false;
+            idx = find(self);
+        }
+        match idx {
+            Some(i) => {
+                self.selected = i;
+                self.focus_insert = false;
+                self.reset_scroll();
+                self.view = View::Focus;
+            }
+            None => self.status = "that lane no longer exists".into(),
+        }
     }
 
     /// Diff the freshly-fetched per-session statuses against the previous snapshot and fire a
@@ -460,6 +646,7 @@ impl App {
         self.notifications.push_back(NotifEvent {
             when: chrono::Local::now(),
             kind,
+            lane_id: id,
             title,
             body,
         });
@@ -469,14 +656,13 @@ impl App {
     }
 
     pub fn visible_lanes(&self) -> Vec<&Lane> {
-        if self.filter.is_empty() {
-            return self.lanes.iter().collect();
-        }
         let f = self.filter.to_lowercase();
         self.lanes
             .iter()
+            .filter(|l| !self.urgent_only || self.lane_needs_attention(l))
             .filter(|l| {
-                l.repo.name.to_lowercase().contains(&f)
+                f.is_empty()
+                    || l.repo.name.to_lowercase().contains(&f)
                     || l.worktree.name.to_lowercase().contains(&f)
                     || l.state
                         .branch
@@ -492,14 +678,14 @@ impl App {
         self.visible_lanes().into_iter().nth(self.selected)
     }
 
-    /// Lane ids to babysit in the grid: pinned first, then needs-you, then most-active.
+    /// Lane ids to babysit in the grid: pinned first, then by attention, then most-active.
     pub fn grid_lane_ids(&self) -> Vec<LaneId> {
         let mut lanes: Vec<&Lane> = self.visible_lanes();
         lanes.sort_by(|a, b| {
             let key = |l: &Lane| {
                 (
                     !l.pinned,
-                    !l.agent_sessions.iter().any(|s| s.status.needs_you()),
+                    self.lane_attention(l),
                     std::cmp::Reverse(l.last_activity_at),
                 )
             };
@@ -533,7 +719,8 @@ impl App {
             | View::Agents
             | View::Settings
             | View::Notifications
-            | View::SpawnPick => Vec::new(),
+            | View::SpawnPick
+            | View::LaneJump => Vec::new(),
         }
     }
 
@@ -666,7 +853,32 @@ impl App {
                 self.select_grid_active();
                 self.toggle_pin().await;
             }
-            KeyCode::Char(' ') | KeyCode::Char('f') | KeyCode::Esc => self.view = View::Fleet,
+            // Hop to the next tile whose agent needs you, wrapping.
+            KeyCode::Char('g') if n > 0 => {
+                let ids = self.grid_lane_ids();
+                let need: Vec<usize> = ids
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, id)| {
+                        self.lanes
+                            .iter()
+                            .find(|l| l.id == **id)
+                            .is_some_and(|l| self.lane_needs_attention(l))
+                    })
+                    .map(|(i, _)| i)
+                    .collect();
+                match need
+                    .iter()
+                    .copied()
+                    .find(|&i| i > self.grid_active)
+                    .or(need.first().copied())
+                {
+                    Some(i) => self.grid_active = i,
+                    None => self.status = "no agents need you".into(),
+                }
+            }
+            KeyCode::Char('f') => self.enter_lane_jump(),
+            KeyCode::Char(' ') | KeyCode::Esc => self.view = View::Fleet,
             KeyCode::Char('q') => self.should_quit = true,
             _ => {}
         }
@@ -773,6 +985,7 @@ impl App {
             View::Settings => self.settings_key(key).await,
             View::Notifications => self.notifications_key(key),
             View::SpawnPick => self.spawn_pick_key(key).await,
+            View::LaneJump => self.lane_jump_key(key),
             _ if self.filtering => self.filter_key(key),
             _ => {
                 if let Some(action) = keybinds::nav(key) {
@@ -1192,6 +1405,19 @@ impl App {
             KeyCode::Char('c') => {
                 self.notifications.clear();
                 self.notif_scroll = 0;
+            }
+            // The feed renders newest-first with `notif_scroll` as the top row; ↵ opens the
+            // lane behind that top event (marked ▸).
+            KeyCode::Enter | KeyCode::Right => {
+                if let Some(id) = self
+                    .notifications
+                    .iter()
+                    .rev()
+                    .nth(self.notif_scroll)
+                    .map(|e| e.lane_id)
+                {
+                    self.jump_to_lane(id);
+                }
             }
             KeyCode::Esc | KeyCode::Left => self.view = View::Fleet,
             KeyCode::Char('q') => self.should_quit = true,
@@ -1698,6 +1924,13 @@ impl App {
             KeyCode::Char('c') => self.cd_to_lane(),
             KeyCode::Char('v') => self.paste_image().await,
             KeyCode::Char('y') => self.toggle_mouse(),
+            // Triage without leaving Focus: retarget to the next agent needing you, or pull up
+            // the lane switcher.
+            KeyCode::Char('g') => {
+                self.reset_scroll();
+                self.jump_attention();
+            }
+            KeyCode::Char('f') => self.enter_lane_jump(),
             // esc/← stops scrolling first, then leaves to Split.
             KeyCode::Esc | KeyCode::Left if self.scroll > 0 => self.reset_scroll(),
             KeyCode::Esc | KeyCode::Left => self.view = View::Split,
@@ -2197,7 +2430,14 @@ impl App {
                     | View::Agents
                     | View::Settings
                     | View::Notifications
-                    | View::SpawnPick => self.view = View::Fleet,
+                    | View::SpawnPick
+                    | View::LaneJump => self.view = View::Fleet,
+                    // Esc in Fleet clears the urgent filter first (like the text filter), then
+                    // quits.
+                    View::Fleet if self.urgent_only => {
+                        self.urgent_only = false;
+                        self.clamp_selection();
+                    }
                     View::Fleet => self.should_quit = true,
                 }
             }
@@ -2265,15 +2505,16 @@ impl App {
                     View::Grid
                 };
             }
-            Action::JumpNeedsYou => {
-                let target = self
-                    .visible_lanes()
-                    .iter()
-                    .position(|l| l.agent_sessions.iter().any(|s| s.status.needs_you()));
-                match target {
-                    Some(i) => self.selected = i,
-                    None => self.status = "no agents need you".into(),
-                }
+            Action::JumpNeedsYou => self.jump_attention(),
+            Action::FindLane => self.enter_lane_jump(),
+            Action::ToggleUrgent => {
+                self.urgent_only = !self.urgent_only;
+                self.status = if self.urgent_only {
+                    "showing only lanes that need you — ! or esc to clear".into()
+                } else {
+                    "showing all lanes".into()
+                };
+                self.clamp_selection();
             }
             Action::StopAgent => self.stop_agent().await,
             Action::Pin => self.toggle_pin().await,
@@ -2347,6 +2588,42 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     ratatui::restore();
     outcome?;
     Ok(app.cd_target)
+}
+
+/// How urgently a lane's sessions need the user: 0 = waiting on you, 1 = rate-limited with no
+/// auto-continue coming, 2 = working, 3 = nothing actionable. Inferred file-activity
+/// placeholders never rank — they can't be acted on.
+fn attention_rank(sessions: &[AgentSession], auto_continue_armed: bool) -> u8 {
+    use AgentStatus::*;
+    sessions
+        .iter()
+        .filter(|s| !s.inferred)
+        .map(|s| match s.status {
+            Waiting => 0,
+            RateLimited if !auto_continue_armed => 1,
+            Running | RateLimited => 2,
+            Idle | Ended => 3,
+        })
+        .min()
+        .unwrap_or(3)
+}
+
+/// Case-insensitive subsequence match of `needle` in `haystack` for the lane switcher. Lower
+/// scores are better: matches that start earlier and sit closer together rank first. Greedy
+/// leftmost matching; an empty needle matches everything with the best score.
+fn fuzzy_score(haystack: &str, needle: &str) -> Option<u32> {
+    let mut hay = haystack.chars().flat_map(char::to_lowercase).enumerate();
+    let mut score = 0u32;
+    let mut prev: Option<usize> = None;
+    for n in needle.chars().flat_map(char::to_lowercase) {
+        let (i, _) = hay.by_ref().find(|&(_, h)| h == n)?;
+        score += match prev {
+            None => i as u32,              // distance from the start
+            Some(p) => (i - p - 1) as u32, // gap since the previous matched char
+        };
+        prev = Some(i);
+    }
+    Some(score)
 }
 
 /// Identifies one real agent session within a lane across refreshes.
@@ -2984,6 +3261,50 @@ mod tests {
         // Appearing already-running is just work starting; stay quiet.
         let running: HashMap<_, _> = [(k, Running)].into();
         assert!(diff_session_transitions(&prev, &running, &live, &managed).is_empty());
+    }
+
+    #[test]
+    fn attention_rank_orders_urgency() {
+        use AgentStatus::*;
+        // Waiting always tops; a rate-limited agent only needs you when nothing will resume it.
+        assert_eq!(attention_rank(&[sess(Some("a"), Waiting, false)], true), 0);
+        assert_eq!(
+            attention_rank(&[sess(Some("a"), RateLimited, false)], false),
+            1
+        );
+        assert_eq!(
+            attention_rank(&[sess(Some("a"), RateLimited, false)], true),
+            2
+        );
+        assert_eq!(attention_rank(&[sess(Some("a"), Running, false)], true), 2);
+        assert_eq!(attention_rank(&[sess(Some("a"), Idle, false)], true), 3);
+        // The most urgent session wins; inferred placeholders never rank.
+        assert_eq!(
+            attention_rank(
+                &[
+                    sess(Some("a"), Running, false),
+                    sess(Some("b"), Waiting, false)
+                ],
+                true
+            ),
+            0
+        );
+        assert_eq!(attention_rank(&[sess(None, Waiting, true)], true), 3);
+        assert_eq!(attention_rank(&[], true), 3);
+    }
+
+    #[test]
+    fn fuzzy_score_prefers_early_contiguous() {
+        // Contiguous prefix beats a gappy subsequence; case-insensitive; misses are None.
+        let hay = "repomon/feat-x";
+        assert_eq!(fuzzy_score(hay, ""), Some(0));
+        assert_eq!(fuzzy_score(hay, "repo"), Some(0));
+        assert!(fuzzy_score(hay, "repo") < fuzzy_score(hay, "rmn"));
+        assert!(fuzzy_score(hay, "feat") < fuzzy_score(hay, "ftx"));
+        assert_eq!(fuzzy_score(hay, "REPO"), fuzzy_score(hay, "repo"));
+        assert_eq!(fuzzy_score(hay, "zzz"), None);
+        // Later starts cost more, so "feat" in a later position scores worse than at the front.
+        assert!(fuzzy_score("feat-x", "feat") < fuzzy_score("repomon/feat-x", "feat"));
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1,11 +1,11 @@
 //! Application state and the interactive event loop.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -13,7 +13,8 @@ use ratatui::layout::{Position, Rect};
 use ratatui::text::Line;
 use ratatui::DefaultTerminal;
 use repomon_core::model::{
-    AgentChoice, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo, TimelineData, WorkSession,
+    AgentChoice, AgentStatus, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo, TimelineData,
+    WorkSession,
 };
 use repomon_core::protocol::Notification;
 use serde_json::json;
@@ -21,8 +22,16 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::client::DaemonClient;
 use crate::keybinds::{self, Action, View};
+use crate::notify::{self, NotifEvent, NotifKind};
 use crate::theme::Theme;
 use crate::view;
+
+/// How long an in-app notification banner stays up before reverting to the footer hints.
+pub const NOTIF_BANNER_TTL: Duration = Duration::from_secs(6);
+/// Don't re-fire the same lane's notification within this window (suppresses status flapping).
+const NOTIF_DEBOUNCE: Duration = Duration::from_secs(30);
+/// Cap on the in-app notification history feed.
+const NOTIF_HISTORY_CAP: usize = 200;
 
 /// Agent kinds offered when creating a lane (cycled with Tab).
 pub const AGENT_KINDS: &[&str] = &["claude-code", "codex", "aider"];
@@ -93,6 +102,12 @@ pub struct Settings {
     pub auto_continue: bool,
     pub auto_continue_message: String,
     pub worktree_template: String,
+    pub notify_enabled: bool,
+    pub notify_needs_you: bool,
+    pub notify_rate_limited: bool,
+    pub notify_resumed: bool,
+    pub notify_idle: bool,
+    pub notify_sound: bool,
 }
 
 /// Accent choices the Settings view cycles through (`mono` = no color).
@@ -101,7 +116,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 5;
+const SETTINGS_COUNT: usize = 11;
 
 pub struct App {
     pub client: DaemonClient,
@@ -164,6 +179,19 @@ pub struct App {
     pub settings_editing: bool,
     /// Screen row of the first settings item (for click hit-testing), set during render.
     pub settings_geom: std::cell::Cell<u16>,
+    /// Last-seen agent status per lane, for notification edge-detection. `None` = no real agent.
+    prev_status: HashMap<LaneId, Option<AgentStatus>>,
+    /// True once the first lane list has seeded `prev_status` (so startup doesn't notify for
+    /// every already-running agent at once).
+    notif_seeded: bool,
+    /// Per-lane debounce: the last time a notification fired for a lane (suppresses flapping).
+    notif_debounce: HashMap<LaneId, Instant>,
+    /// In-app notification history (newest last), shown in the Notifications view.
+    pub notifications: VecDeque<NotifEvent>,
+    /// Scroll offset (rows from the top) in the Notifications view.
+    pub notif_scroll: usize,
+    /// A transient banner shown above the footer after a notification fires; auto-clears.
+    pub notif_banner: Option<(String, Instant)>,
     pub timeline: Option<TimelineData>,
     pub timeline_zoom: Zoom,
     pub sessions: Vec<WorkSession>,
@@ -241,10 +269,26 @@ impl App {
             refresh_pending: false,
             ac_off: HashSet::new(),
             grid_active: 0,
-            settings: Settings::default(),
+            // Notify defaults mirror the daemon config defaults, so alerts behave sensibly even
+            // before the first `config.get` lands (load_settings refreshes them at startup).
+            settings: Settings {
+                notify_enabled: true,
+                notify_needs_you: true,
+                notify_rate_limited: true,
+                notify_resumed: true,
+                notify_idle: false,
+                notify_sound: true,
+                ..Settings::default()
+            },
             settings_idx: 0,
             settings_editing: false,
             settings_geom: std::cell::Cell::new(0),
+            prev_status: HashMap::new(),
+            notif_seeded: false,
+            notif_debounce: HashMap::new(),
+            notifications: VecDeque::new(),
+            notif_scroll: 0,
+            notif_banner: None,
             timeline: None,
             timeline_zoom: Zoom::Day,
             sessions: Vec::new(),
@@ -301,7 +345,102 @@ impl App {
             Ok(l) => self.lanes = l,
             Err(e) => self.status = format!("lane.list failed: {e}"),
         }
+        self.detect_notifications();
         self.clamp_selection();
+    }
+
+    /// A lane's notification-relevant status: the highest-priority status among its *real*
+    /// (non-inferred) agent sessions. `None` when the lane has no identified agent — inferred
+    /// "file activity" placeholders are deliberately ignored so they don't drive named alerts.
+    fn lane_status(lane: &Lane) -> Option<AgentStatus> {
+        use AgentStatus::*;
+        let real = || lane.agent_sessions.iter().filter(|s| !s.inferred);
+        [RateLimited, Waiting, Running, Idle, Ended]
+            .into_iter()
+            .find(|&want| real().any(|s| s.status == want))
+    }
+
+    /// Diff the freshly-fetched lane statuses against the previous snapshot and fire a
+    /// notification on each meaningful transition. The first call only seeds the snapshot.
+    fn detect_notifications(&mut self) {
+        // Snapshot the new per-lane statuses.
+        let now_status: Vec<(LaneId, Option<AgentStatus>)> = self
+            .lanes
+            .iter()
+            .map(|l| (l.id, Self::lane_status(l)))
+            .collect();
+
+        if !self.notif_seeded {
+            self.prev_status = now_status.into_iter().collect();
+            self.notif_seeded = true;
+            return;
+        }
+
+        // Decide what to fire first (updating the snapshot + debounce as we go), then deliver —
+        // delivery composes from `self.lanes` and mutates `self`, so it can't run while we still
+        // hold a borrow into the lanes here.
+        let mut fires: Vec<(LaneId, NotifKind)> = Vec::new();
+        for (id, now) in now_status {
+            let prev = self.prev_status.get(&id).copied().flatten();
+            self.prev_status.insert(id, now);
+            if now == prev {
+                continue;
+            }
+            let Some(kind) = transition_kind(prev, now) else {
+                continue;
+            };
+            if !self.notif_enabled_for(kind) {
+                continue;
+            }
+            // Debounce per lane so a flapping agent can't spam.
+            if let Some(t) = self.notif_debounce.get(&id) {
+                if t.elapsed() < NOTIF_DEBOUNCE {
+                    continue;
+                }
+            }
+            self.notif_debounce.insert(id, Instant::now());
+            fires.push((id, kind));
+        }
+        for (id, kind) in fires {
+            self.fire_notification(id, kind);
+        }
+    }
+
+    /// Whether the given notification kind is enabled (master switch ∧ per-kind toggle).
+    fn notif_enabled_for(&self, kind: NotifKind) -> bool {
+        if !self.settings.notify_enabled {
+            return false;
+        }
+        match kind {
+            NotifKind::NeedsYou => self.settings.notify_needs_you,
+            NotifKind::RateLimited => self.settings.notify_rate_limited,
+            NotifKind::Resumed => self.settings.notify_resumed,
+            NotifKind::Idle => self.settings.notify_idle,
+        }
+    }
+
+    /// Compose + deliver a notification for a lane: native popup, in-app banner, history entry.
+    fn fire_notification(&mut self, id: LaneId, kind: NotifKind) {
+        // Compose under an immutable borrow that ends before we mutate `self`.
+        let Some((title, body)) = self
+            .lanes
+            .iter()
+            .find(|l| l.id == id)
+            .map(|l| notify::compose(kind, l))
+        else {
+            return;
+        };
+        notify::send_native(&title, &body, self.settings.notify_sound);
+        self.notif_banner = Some((format!("{title}  ·  {body}"), Instant::now()));
+        self.notifications.push_back(NotifEvent {
+            when: chrono::Local::now(),
+            kind,
+            title,
+            body,
+        });
+        while self.notifications.len() > NOTIF_HISTORY_CAP {
+            self.notifications.pop_front();
+        }
     }
 
     pub fn visible_lanes(&self) -> Vec<&Lane> {
@@ -367,7 +506,8 @@ impl App {
             | View::Search
             | View::AddRepo
             | View::Agents
-            | View::Settings => Vec::new(),
+            | View::Settings
+            | View::Notifications => Vec::new(),
         }
     }
 
@@ -605,6 +745,7 @@ impl App {
             View::AddRepo => self.addrepo_key(key).await,
             View::Agents => self.agents_key(key).await,
             View::Settings => self.settings_key(key).await,
+            View::Notifications => self.notifications_key(key),
             _ if self.filtering => self.filter_key(key),
             _ => {
                 if let Some(action) = keybinds::nav(key) {
@@ -832,6 +973,25 @@ impl App {
         if let Some(w) = v.get("worktree_template").and_then(|x| x.as_str()) {
             self.settings.worktree_template = w.to_string();
         }
+        let b = |key: &str| v.get(key).and_then(|x| x.as_bool());
+        if let Some(x) = b("notify_enabled") {
+            self.settings.notify_enabled = x;
+        }
+        if let Some(x) = b("notify_needs_you") {
+            self.settings.notify_needs_you = x;
+        }
+        if let Some(x) = b("notify_rate_limited") {
+            self.settings.notify_rate_limited = x;
+        }
+        if let Some(x) = b("notify_resumed") {
+            self.settings.notify_resumed = x;
+        }
+        if let Some(x) = b("notify_idle") {
+            self.settings.notify_idle = x;
+        }
+        if let Some(x) = b("notify_sound") {
+            self.settings.notify_sound = x;
+        }
     }
 
     /// Persist the current settings to the daemon config and apply the accent live.
@@ -847,6 +1007,12 @@ impl App {
             "auto_continue": self.settings.auto_continue,
             "auto_continue_message": self.settings.auto_continue_message,
             "worktree_template": self.settings.worktree_template,
+            "notify_enabled": self.settings.notify_enabled,
+            "notify_needs_you": self.settings.notify_needs_you,
+            "notify_rate_limited": self.settings.notify_rate_limited,
+            "notify_resumed": self.settings.notify_resumed,
+            "notify_idle": self.settings.notify_idle,
+            "notify_sound": self.settings.notify_sound,
         });
         match self.client.call("config.set", Some(params)).await {
             Ok(v) => self.apply_settings_value(&v),
@@ -937,14 +1103,57 @@ impl App {
                 self.settings.auto_continue = !self.settings.auto_continue;
                 self.save_settings().await;
             }
+            5 => {
+                self.settings.notify_enabled = !self.settings.notify_enabled;
+                self.save_settings().await;
+            }
+            6 => {
+                self.settings.notify_needs_you = !self.settings.notify_needs_you;
+                self.save_settings().await;
+            }
+            7 => {
+                self.settings.notify_rate_limited = !self.settings.notify_rate_limited;
+                self.save_settings().await;
+            }
+            8 => {
+                self.settings.notify_resumed = !self.settings.notify_resumed;
+                self.save_settings().await;
+            }
+            9 => {
+                self.settings.notify_idle = !self.settings.notify_idle;
+                self.save_settings().await;
+            }
+            10 => {
+                self.settings.notify_sound = !self.settings.notify_sound;
+                self.save_settings().await;
+            }
             _ => {}
         }
     }
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 => self.adjust_setting(true).await,
+            0..=2 | 5..=10 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
+            _ => {}
+        }
+    }
+
+    /// Key handling for the Notifications history view: scroll, clear, or leave.
+    fn notifications_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.notif_scroll = self.notif_scroll.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.notif_scroll = self.notif_scroll.saturating_add(1);
+            }
+            KeyCode::Char('c') => {
+                self.notifications.clear();
+                self.notif_scroll = 0;
+            }
+            KeyCode::Esc | KeyCode::Left => self.view = View::Fleet,
+            KeyCode::Char('q') => self.should_quit = true,
             _ => {}
         }
     }
@@ -1885,7 +2094,8 @@ impl App {
                     | View::Search
                     | View::AddRepo
                     | View::Agents
-                    | View::Settings => self.view = View::Fleet,
+                    | View::Settings
+                    | View::Notifications => self.view = View::Fleet,
                     View::Fleet => self.should_quit = true,
                 }
             }
@@ -1906,6 +2116,7 @@ impl App {
                     }
                     View::Agents => self.enter_agents(None).await,
                     View::Settings => self.load_settings().await,
+                    View::Notifications => self.notif_scroll = 0,
                     _ => {}
                 }
             }
@@ -1994,6 +2205,9 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     let mut app = App::new(client);
     app.theme = theme;
     app.refresh().await;
+    // Prime the notification toggles (and default-agent picker) from the daemon config so alerts
+    // honor the user's settings even if they never open the Settings view this session.
+    app.load_settings().await;
 
     let mut terminal = ratatui::init();
     if app.mouse_on {
@@ -2031,6 +2245,23 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     ratatui::restore();
     outcome?;
     Ok(app.cd_target)
+}
+
+/// Map a lane's agent-status transition to the notification it should fire, if any. `None`
+/// means "no real agent". Priority resolves cases like `Running → RateLimited` to the limit.
+fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> Option<NotifKind> {
+    use AgentStatus::*;
+    match (prev, now) {
+        // Hit a usage limit.
+        (p, Some(RateLimited)) if p != Some(RateLimited) => Some(NotifKind::RateLimited),
+        // Auto-resumed after a limit.
+        (Some(RateLimited), Some(Running)) => Some(NotifKind::Resumed),
+        // Finished its turn / needs you.
+        (p, Some(Waiting)) if p != Some(Waiting) => Some(NotifKind::NeedsYou),
+        // Was active, now quiet (idle / ended / the session went away).
+        (Some(Running) | Some(Waiting), Some(Idle) | Some(Ended) | None) => Some(NotifKind::Idle),
+        _ => None,
+    }
 }
 
 /// Cycle `current` to the next/previous option (wrapping). Returns `current` if `options` is empty.
@@ -2086,6 +2317,12 @@ async fn event_loop(
         app.sync_terminals().await;
         app.sync_session_cursor();
         app.check_focus_alive();
+        // Expire a stale notification banner so the footer hints come back.
+        if let Some((_, since)) = &app.notif_banner {
+            if since.elapsed() >= NOTIF_BANNER_TTL {
+                app.notif_banner = None;
+            }
+        }
         if app.view != View::Focus && app.scroll != 0 {
             app.reset_scroll();
         }
@@ -2147,12 +2384,12 @@ async fn event_loop(
                 None => events_alive = false,
             },
             _ = tick.tick() => {
-                // Keep agent state fresh in views that show it, so an agent that exits on its
-                // own (e.g. `/exit`) is noticed promptly and Focus drops back to Split. Only the
-                // lane list needs this cadence; commits/repos refresh on git notifications.
-                if matches!(app.view, View::Focus | View::Split | View::Grid) {
-                    app.refresh_lanes().await;
-                }
+                // Refresh the lane list every second in *all* views: it keeps agent state fresh
+                // (an agent that exits on its own is noticed promptly, Focus drops back to Split)
+                // AND it's what drives notification edge-detection, which must work even when the
+                // user is looking at Fleet or another view. lane.list is cheap (~55ms) at 1Hz and
+                // only runs while the TUI is open; commits/repos still refresh on git events.
+                app.refresh_lanes().await;
             }
         }
     }
@@ -2383,6 +2620,44 @@ async fn next_note(rx: &mut broadcast::Receiver<Notification>) -> Option<Notific
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn notification_transitions() {
+        use AgentStatus::*;
+        // The headline alerts.
+        assert_eq!(
+            transition_kind(Some(Running), Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        assert_eq!(
+            transition_kind(None, Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        assert_eq!(
+            transition_kind(Some(Running), Some(RateLimited)),
+            Some(NotifKind::RateLimited)
+        );
+        assert_eq!(
+            transition_kind(Some(RateLimited), Some(Running)),
+            Some(NotifKind::Resumed)
+        );
+        // Gave up on the limit and now needs you.
+        assert_eq!(
+            transition_kind(Some(RateLimited), Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        // Went quiet (idle / ended / the agent went away).
+        assert_eq!(
+            transition_kind(Some(Running), Some(Idle)),
+            Some(NotifKind::Idle)
+        );
+        assert_eq!(transition_kind(Some(Waiting), None), Some(NotifKind::Idle));
+        // Non-events: you replied, work simply started, or nothing changed.
+        assert_eq!(transition_kind(Some(Waiting), Some(Running)), None);
+        assert_eq!(transition_kind(None, Some(Running)), None);
+        assert_eq!(transition_kind(Some(Idle), Some(Running)), None);
+        assert_eq!(transition_kind(Some(Waiting), Some(Waiting)), None);
+    }
 
     #[test]
     fn double_click_needs_same_lane_within_window() {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -52,12 +52,14 @@ pub enum AgField {
 }
 
 impl Zoom {
-    /// (lookback seconds, bucket seconds, label).
+    /// (lookback seconds, minimum bucket seconds, label). The actual bucket size is derived
+    /// from the terminal width at load time (see `load_timeline`), floored at the minimum so a
+    /// huge terminal doesn't ask for sub-minute buckets nobody can read.
     fn params(self) -> (i64, i64, &'static str) {
         match self {
-            Zoom::Day => (24 * 3600, 3600, "day"),
-            Zoom::Week => (7 * 24 * 3600, 6 * 3600, "week"),
-            Zoom::Month => (30 * 24 * 3600, 24 * 3600, "month"),
+            Zoom::Day => (24 * 3600, 5 * 60, "day"),
+            Zoom::Week => (7 * 24 * 3600, 30 * 60, "week"),
+            Zoom::Month => (30 * 24 * 3600, 2 * 3600, "month"),
         }
     }
 }
@@ -247,6 +249,8 @@ pub struct App {
     agents_return: Option<View>,
     last_viewport: Vec<LaneId>,
     last_viewport_focus: Option<(LaneId, String)>,
+    /// Last terminal title emitted (OSC 2), to skip redundant writes.
+    last_title: String,
     attach_request: Option<LaneId>,
     /// A tmux target (e.g. a terminal window) the loop should attach to next.
     attach_target: Option<String>,
@@ -346,6 +350,7 @@ impl App {
             agents_return: None,
             last_viewport: Vec::new(),
             last_viewport_focus: None,
+            last_title: String::new(),
             attach_request: None,
             attach_target: None,
             input_suspended: Arc::new(AtomicBool::new(false)),
@@ -782,6 +787,23 @@ impl App {
         }
     }
 
+    /// Keep the terminal window/tab title on the open repo (OSC 2) so several terminals are
+    /// tellable apart at a glance. Re-emitted only when it changes; the shell resets the title
+    /// on exit as usual.
+    fn sync_title(&mut self) {
+        let title = match self.selected_lane() {
+            Some(l) => format!("repomon · {}/{}", l.repo.name, l.worktree.name),
+            None => "repomon".to_string(),
+        };
+        if title != self.last_title {
+            use std::io::Write;
+            let mut out = std::io::stdout();
+            let _ = write!(out, "\x1b]2;{title}\x07");
+            let _ = out.flush();
+            self.last_title = title;
+        }
+    }
+
     /// Keep the session cursor in range: reset to 0 when the selected lane changes, and clamp
     /// to the number of sessions on that lane.
     fn sync_session_cursor(&mut self) {
@@ -956,6 +978,15 @@ impl App {
     async fn handle_event(&mut self, ev: Event) {
         let key = match ev {
             Event::Key(key) => key,
+            // Views render from the live frame size every draw, so a resize redraws correctly
+            // on its own; the timeline additionally refetches so its bucket count tracks the
+            // new width (the renderer resamples in the meantime).
+            Event::Resize(_, _) => {
+                if self.view == View::Timeline {
+                    self.load_timeline().await;
+                }
+                return;
+            }
             Event::Mouse(me) => {
                 use ratatui::crossterm::event::{MouseButton, MouseEventKind};
                 // Bare movement just updates the hovered lane (highlighted on render).
@@ -1699,7 +1730,14 @@ impl App {
     }
 
     async fn load_timeline(&mut self) {
-        let (lookback, bucket, _) = self.timeline_zoom.params();
+        let (lookback, min_bucket, _) = self.timeline_zoom.params();
+        // Size buckets to the terminal so the strip fills the width (the renderer resamples to
+        // cover the gap until a resize refetch lands). 26 ≈ repo-label column + margins.
+        let width = ratatui::crossterm::terminal::size()
+            .map(|(w, _)| w as i64)
+            .unwrap_or(100);
+        let buckets = (width - 26).clamp(24, 240);
+        let bucket = (lookback / buckets).max(min_bucket);
         let to = chrono::Utc::now();
         let from = to - chrono::Duration::seconds(lookback);
         let params = json!({
@@ -2679,6 +2717,13 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     let outcome = event_loop(&mut terminal, &mut app, &mut in_rx, &mut events).await;
     disable_mouse();
     ratatui::restore();
+    // Hand the title back to the shell (most shells re-set it at the next prompt anyway).
+    {
+        use std::io::Write;
+        let mut out = std::io::stdout();
+        let _ = write!(out, "\x1b]2;\x07");
+        let _ = out.flush();
+    }
     outcome?;
     Ok(app.cd_target)
 }
@@ -2887,6 +2932,7 @@ async fn event_loop(
         app.sync_recent_commits().await;
         app.sync_terminals().await;
         app.sync_session_cursor();
+        app.sync_title();
         app.check_focus_alive();
         // Expire a stale notification banner so the footer hints come back.
         if let Some((_, since)) = &app.notif_banner {
@@ -3009,6 +3055,7 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     drain_pending_input();
     app.input_suspended.store(false, Ordering::Relaxed);
     app.last_viewport.clear(); // force a viewport resync after returning
+    app.last_title.clear(); // tmux set its own title; re-assert ours next tick
     app.status = "back from the agent (it's still running) — ↵ to reopen".into();
 }
 
@@ -3030,6 +3077,7 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
     drain_pending_input();
     app.input_suspended.store(false, Ordering::Relaxed);
     app.last_viewport.clear();
+    app.last_title.clear(); // tmux set its own title; re-assert ours next tick
     app.terminals_lane = None; // the shell may have exited; refresh the terminal list
 }
 

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -102,6 +102,7 @@ pub struct Settings {
     pub auto_continue: bool,
     pub auto_continue_message: String,
     pub worktree_template: String,
+    pub spawn_prompt: bool,
     pub notify_enabled: bool,
     pub notify_needs_you: bool,
     pub notify_rate_limited: bool,
@@ -116,7 +117,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 11;
+const SETTINGS_COUNT: usize = 12;
 
 pub struct App {
     pub client: DaemonClient,
@@ -192,6 +193,11 @@ pub struct App {
     pub notif_scroll: usize,
     /// A transient banner shown above the footer after a notification fires; auto-clears.
     pub notif_banner: Option<(String, Instant)>,
+    /// Spawn-picker state: which agent row is highlighted, the lane to spawn into, and the view
+    /// to return to on cancel.
+    pub spawn_pick_idx: usize,
+    pub spawn_pick_lane: Option<LaneId>,
+    spawn_return: Option<View>,
     pub timeline: Option<TimelineData>,
     pub timeline_zoom: Zoom,
     pub sessions: Vec<WorkSession>,
@@ -272,6 +278,7 @@ impl App {
             // Notify defaults mirror the daemon config defaults, so alerts behave sensibly even
             // before the first `config.get` lands (load_settings refreshes them at startup).
             settings: Settings {
+                spawn_prompt: true,
                 notify_enabled: true,
                 notify_needs_you: true,
                 notify_rate_limited: true,
@@ -289,6 +296,9 @@ impl App {
             notifications: VecDeque::new(),
             notif_scroll: 0,
             notif_banner: None,
+            spawn_pick_idx: 0,
+            spawn_pick_lane: None,
+            spawn_return: None,
             timeline: None,
             timeline_zoom: Zoom::Day,
             sessions: Vec::new(),
@@ -507,7 +517,8 @@ impl App {
             | View::AddRepo
             | View::Agents
             | View::Settings
-            | View::Notifications => Vec::new(),
+            | View::Notifications
+            | View::SpawnPick => Vec::new(),
         }
     }
 
@@ -746,6 +757,7 @@ impl App {
             View::Agents => self.agents_key(key).await,
             View::Settings => self.settings_key(key).await,
             View::Notifications => self.notifications_key(key),
+            View::SpawnPick => self.spawn_pick_key(key).await,
             _ if self.filtering => self.filter_key(key),
             _ => {
                 if let Some(action) = keybinds::nav(key) {
@@ -974,6 +986,9 @@ impl App {
             self.settings.worktree_template = w.to_string();
         }
         let b = |key: &str| v.get(key).and_then(|x| x.as_bool());
+        if let Some(x) = b("spawn_prompt") {
+            self.settings.spawn_prompt = x;
+        }
         if let Some(x) = b("notify_enabled") {
             self.settings.notify_enabled = x;
         }
@@ -1007,6 +1022,7 @@ impl App {
             "auto_continue": self.settings.auto_continue,
             "auto_continue_message": self.settings.auto_continue_message,
             "worktree_template": self.settings.worktree_template,
+            "spawn_prompt": self.settings.spawn_prompt,
             "notify_enabled": self.settings.notify_enabled,
             "notify_needs_you": self.settings.notify_needs_you,
             "notify_rate_limited": self.settings.notify_rate_limited,
@@ -1104,26 +1120,30 @@ impl App {
                 self.save_settings().await;
             }
             5 => {
-                self.settings.notify_enabled = !self.settings.notify_enabled;
+                self.settings.spawn_prompt = !self.settings.spawn_prompt;
                 self.save_settings().await;
             }
             6 => {
-                self.settings.notify_needs_you = !self.settings.notify_needs_you;
+                self.settings.notify_enabled = !self.settings.notify_enabled;
                 self.save_settings().await;
             }
             7 => {
-                self.settings.notify_rate_limited = !self.settings.notify_rate_limited;
+                self.settings.notify_needs_you = !self.settings.notify_needs_you;
                 self.save_settings().await;
             }
             8 => {
-                self.settings.notify_resumed = !self.settings.notify_resumed;
+                self.settings.notify_rate_limited = !self.settings.notify_rate_limited;
                 self.save_settings().await;
             }
             9 => {
-                self.settings.notify_idle = !self.settings.notify_idle;
+                self.settings.notify_resumed = !self.settings.notify_resumed;
                 self.save_settings().await;
             }
             10 => {
+                self.settings.notify_idle = !self.settings.notify_idle;
+                self.save_settings().await;
+            }
+            11 => {
                 self.settings.notify_sound = !self.settings.notify_sound;
                 self.save_settings().await;
             }
@@ -1133,7 +1153,7 @@ impl App {
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 | 5..=10 => self.adjust_setting(true).await,
+            0..=2 | 5..=11 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
             _ => {}
         }
@@ -1708,12 +1728,32 @@ impl App {
         let Some(id) = self.selected_lane().map(|l| l.id) else {
             return;
         };
-        let agent = self.default_agent_name().await;
+        // With the picker on (default), `e` prompts for which agent every time; otherwise it
+        // spawns the configured default immediately.
+        if self.settings.spawn_prompt {
+            self.enter_spawn_pick(id).await;
+        } else {
+            let agent = self.default_agent_name().await;
+            self.do_spawn(id, &agent).await;
+        }
+    }
+
+    /// Open the quick agent picker for `lane`, remembering where to return on cancel.
+    async fn enter_spawn_pick(&mut self, lane: LaneId) {
+        self.load_agents().await; // populates nl_agents (+ marks the default)
+        self.spawn_pick_idx = self.nl_agents.iter().position(|a| a.default).unwrap_or(0);
+        self.spawn_pick_lane = Some(lane);
+        self.spawn_return = Some(self.view);
+        self.view = View::SpawnPick;
+    }
+
+    /// Spawn `agent` into `lane`: on success drop into Focus, ready to drive it.
+    async fn do_spawn(&mut self, id: LaneId, agent: &str) {
         match self
             .client
             .call(
                 "agent.spawn",
-                Some(json!({ "lane_id": id, "agent": &agent })),
+                Some(json!({ "lane_id": id, "agent": agent })),
             )
             .await
         {
@@ -1723,6 +1763,46 @@ impl App {
                 self.focus_insert = false;
             }
             Err(e) => self.status = format!("spawn failed: {e}"),
+        }
+    }
+
+    /// Key handling for the spawn picker: move, jump by number, spawn, or cancel.
+    async fn spawn_pick_key(&mut self, key: KeyEvent) {
+        let n = self.nl_agents.len();
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') if n > 0 => {
+                self.spawn_pick_idx = (self.spawn_pick_idx + n - 1) % n;
+            }
+            KeyCode::Down | KeyCode::Char('j') if n > 0 => {
+                self.spawn_pick_idx = (self.spawn_pick_idx + 1) % n;
+            }
+            KeyCode::Char(c) if c.is_ascii_digit() && c != '0' => {
+                let i = (c as usize) - ('1' as usize);
+                if i < n {
+                    self.spawn_pick_idx = i;
+                    self.confirm_spawn_pick().await;
+                }
+            }
+            KeyCode::Enter | KeyCode::Right => self.confirm_spawn_pick().await,
+            KeyCode::Esc | KeyCode::Left => {
+                self.view = self.spawn_return.take().unwrap_or(View::Fleet);
+            }
+            KeyCode::Char('q') => self.should_quit = true,
+            _ => {}
+        }
+    }
+
+    /// Spawn the highlighted agent into the remembered lane.
+    async fn confirm_spawn_pick(&mut self) {
+        let agent = self
+            .nl_agents
+            .get(self.spawn_pick_idx)
+            .map(|a| a.name.clone());
+        let lane = self.spawn_pick_lane.take();
+        self.spawn_return = None;
+        match (agent, lane) {
+            (Some(agent), Some(id)) => self.do_spawn(id, &agent).await,
+            _ => self.view = View::Fleet,
         }
     }
 
@@ -2095,7 +2175,8 @@ impl App {
                     | View::AddRepo
                     | View::Agents
                     | View::Settings
-                    | View::Notifications => self.view = View::Fleet,
+                    | View::Notifications
+                    | View::SpawnPick => self.view = View::Fleet,
                     View::Fleet => self.should_quit = true,
                 }
             }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -111,6 +111,9 @@ pub struct Settings {
     pub notify_resumed: bool,
     pub notify_idle: bool,
     pub notify_sound: bool,
+    pub notify_show_why: bool,
+    pub notify_coalesce: bool,
+    pub notify_click_focus: bool,
 }
 
 /// Accent choices the Settings view cycles through (`mono` = no color).
@@ -119,7 +122,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 12;
+const SETTINGS_COUNT: usize = 15;
 
 pub struct App {
     pub client: DaemonClient,
@@ -196,8 +199,9 @@ pub struct App {
     notif_debounce: HashMap<(LaneId, SessKey, NotifKind), Instant>,
     /// In-app notification history (newest last), shown in the Notifications view.
     pub notifications: VecDeque<NotifEvent>,
-    /// Scroll offset (rows from the top) in the Notifications view.
-    pub notif_scroll: usize,
+    /// Cursor in the Notifications view: offset into the feed, newest-first (0 = newest).
+    /// The render derives its scroll window from this so the cursor stays visible.
+    pub notif_sel: usize,
     /// A transient banner shown above the footer after a notification fires; auto-clears.
     pub notif_banner: Option<(String, Instant)>,
     /// Spawn-picker state: which agent row is highlighted, the lane to spawn into, and the view
@@ -305,6 +309,9 @@ impl App {
                 notify_resumed: true,
                 notify_idle: false,
                 notify_sound: true,
+                notify_show_why: true,
+                notify_coalesce: true,
+                notify_click_focus: true,
                 ..Settings::default()
             },
             settings_idx: 0,
@@ -314,7 +321,7 @@ impl App {
             notif_seeded: false,
             notif_debounce: HashMap::new(),
             notifications: VecDeque::new(),
-            notif_scroll: 0,
+            notif_sel: 0,
             notif_banner: None,
             spawn_pick_idx: 0,
             spawn_pick_lane: None,
@@ -482,6 +489,33 @@ impl App {
         self.status = msg;
     }
 
+    /// `G`: jump_attention, then go all the way into the pane — select the session the fresh
+    /// banner identified (if any) and request a tmux attach. Does nothing extra when the jump
+    /// found no lane blocked on you.
+    fn jump_attention_attach(&mut self) {
+        let banner_sess = self
+            .notif_banner
+            .as_ref()
+            .filter(|(_, t)| t.elapsed() < NOTIF_BANNER_TTL)
+            .and_then(|_| self.notifications.back())
+            .map(|e| (e.lane_id, e.session_id.clone()));
+        self.jump_attention();
+        let Some((lane_id, needs)) = self
+            .selected_lane()
+            .map(|l| (l.id, self.lane_needs_attention(l)))
+        else {
+            return;
+        };
+        let from_banner = banner_sess.as_ref().is_some_and(|(id, _)| *id == lane_id);
+        if !needs && !from_banner {
+            return; // the jump didn't land on an alerting lane — stay put, no attach
+        }
+        if let Some((_, sid)) = banner_sess.filter(|(id, _)| *id == lane_id) {
+            self.select_session(lane_id, sid.as_deref());
+        }
+        self.attach_request = Some(lane_id);
+    }
+
     /// Open the fuzzy lane switcher, remembering where to return on cancel.
     fn enter_lane_jump(&mut self) {
         self.jump_query.clear();
@@ -622,8 +656,28 @@ impl App {
             prev.contains_key(&(*lane, sess.clone())) || t.elapsed() < NOTIF_DEBOUNCE
         });
 
+        // A burst (≥2 alerts in one tick) coalesces into a single popup + banner so the desktop
+        // isn't spammed; each event still lands individually (and unread) in the history feed.
+        let coalesce = self.settings.notify_coalesce && fires.len() >= 2;
+        if coalesce {
+            let labels: Vec<(String, NotifKind)> = fires
+                .iter()
+                .filter_map(|((id, _), kind)| {
+                    let l = self.lanes.iter().find(|l| l.id == *id)?;
+                    Some((format!("{}/{}", l.repo.name, l.worktree.name), *kind))
+                })
+                .collect();
+            let (title, body) = notify::compose_burst(&labels);
+            notify::send_native(
+                &title,
+                &body,
+                self.settings.notify_sound,
+                self.settings.notify_click_focus,
+            );
+            self.notif_banner = Some((format!("{title}  ·  {body}"), Instant::now()));
+        }
         for ((lane, key), kind) in fires {
-            self.fire_notification(lane, &key, kind);
+            self.fire_notification(lane, &key, kind, coalesce);
         }
     }
 
@@ -641,29 +695,51 @@ impl App {
     }
 
     /// Compose + deliver a notification about one session: native popup, banner, history entry.
-    fn fire_notification(&mut self, id: LaneId, key: &SessKey, kind: NotifKind) {
+    /// `quiet` records the event in the feed only — the popup/banner were already covered by a
+    /// coalesced burst summary.
+    fn fire_notification(&mut self, id: LaneId, key: &SessKey, kind: NotifKind, quiet: bool) {
         // Compose under an immutable borrow that ends before we mutate `self`. The session may
         // be gone when its disappearance was the trigger — compose degrades to a generic line.
-        let Some((title, body)) = self
-            .lanes
-            .iter()
-            .find(|l| l.id == id)
-            .map(|l| notify::compose(kind, l, session_by_key(l, key)))
-        else {
+        let Some((title, body, session_id)) = self.lanes.iter().find(|l| l.id == id).map(|l| {
+            let sess = session_by_key(l, key);
+            // Which of the lane's side-by-side agents this is (1-based in the body when >1).
+            let slot = sess.and_then(|hit| {
+                let real: Vec<&AgentSession> =
+                    l.agent_sessions.iter().filter(|s| !s.inferred).collect();
+                let i = real.iter().position(|s| std::ptr::eq(*s, hit))?;
+                Some((i, real.len()))
+            });
+            let (t, b) = notify::compose(kind, l, sess, slot, self.settings.notify_show_why);
+            (t, b, sess.and_then(|s| s.session_id.clone()))
+        }) else {
             return;
         };
-        notify::send_native(&title, &body, self.settings.notify_sound);
-        self.notif_banner = Some((format!("{title}  ·  {body}"), Instant::now()));
+        if !quiet {
+            notify::send_native(
+                &title,
+                &body,
+                self.settings.notify_sound,
+                self.settings.notify_click_focus,
+            );
+            self.notif_banner = Some((format!("{title}  ·  {body}"), Instant::now()));
+        }
         self.notifications.push_back(NotifEvent {
             when: chrono::Local::now(),
             kind,
             lane_id: id,
+            session_id,
+            read: false,
             title,
             body,
         });
         while self.notifications.len() > NOTIF_HISTORY_CAP {
             self.notifications.pop_front();
         }
+    }
+
+    /// Notifications not yet seen (the feed hasn't been opened since they fired) — the ⚑ badge.
+    pub fn unread_notifs(&self) -> usize {
+        self.notifications.iter().filter(|e| !e.read).count()
     }
 
     pub fn visible_lanes(&self) -> Vec<&Lane> {
@@ -1342,6 +1418,15 @@ impl App {
         if let Some(x) = b("notify_sound") {
             self.settings.notify_sound = x;
         }
+        if let Some(x) = b("notify_show_why") {
+            self.settings.notify_show_why = x;
+        }
+        if let Some(x) = b("notify_coalesce") {
+            self.settings.notify_coalesce = x;
+        }
+        if let Some(x) = b("notify_click_focus") {
+            self.settings.notify_click_focus = x;
+        }
     }
 
     /// Persist the current settings to the daemon config and apply the accent live.
@@ -1364,6 +1449,9 @@ impl App {
             "notify_resumed": self.settings.notify_resumed,
             "notify_idle": self.settings.notify_idle,
             "notify_sound": self.settings.notify_sound,
+            "notify_show_why": self.settings.notify_show_why,
+            "notify_coalesce": self.settings.notify_coalesce,
+            "notify_click_focus": self.settings.notify_click_focus,
         });
         match self.client.call("config.set", Some(params)).await {
             Ok(v) => self.apply_settings_value(&v),
@@ -1486,49 +1574,96 @@ impl App {
                 }
                 self.save_settings().await;
             }
+            12 => {
+                self.settings.notify_show_why = !self.settings.notify_show_why;
+                self.save_settings().await;
+            }
+            13 => {
+                self.settings.notify_coalesce = !self.settings.notify_coalesce;
+                self.save_settings().await;
+            }
+            14 => {
+                self.settings.notify_click_focus = !self.settings.notify_click_focus;
+                self.save_settings().await;
+            }
             _ => {}
         }
     }
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 | 5..=11 => self.adjust_setting(true).await,
+            0..=2 | 5..=14 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
             _ => {}
         }
     }
 
-    /// Key handling for the Notifications history view: scroll, clear, or leave.
+    /// Key handling for the Notifications history view: move the cursor, open or attach to
+    /// the event's agent, dismiss one, clear all, or leave.
     fn notifications_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                self.notif_scroll = self.notif_scroll.saturating_sub(1);
+                self.notif_sel = self.notif_sel.saturating_sub(1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                // Clamp to the last event so scrolling past the end can't blank the feed.
+                // Clamp to the last event so the cursor can't run off the feed.
                 let max = self.notifications.len().saturating_sub(1);
-                self.notif_scroll = (self.notif_scroll + 1).min(max);
+                self.notif_sel = (self.notif_sel + 1).min(max);
+            }
+            // Dismiss the selected event (the feed is newest-first; the deque is newest-last).
+            KeyCode::Char('d') if !self.notifications.is_empty() => {
+                let idx = self.notifications.len() - 1 - self.notif_sel;
+                self.notifications.remove(idx);
+                let max = self.notifications.len().saturating_sub(1);
+                self.notif_sel = self.notif_sel.min(max);
             }
             KeyCode::Char('c') => {
                 self.notifications.clear();
-                self.notif_scroll = 0;
+                self.notif_sel = 0;
             }
-            // The feed renders newest-first with `notif_scroll` as the top row; ↵ opens the
-            // lane behind that top event (marked ▸).
-            KeyCode::Enter | KeyCode::Right => {
-                if let Some(id) = self
-                    .notifications
-                    .iter()
-                    .rev()
-                    .nth(self.notif_scroll)
-                    .map(|e| e.lane_id)
-                {
-                    self.jump_to_lane(id);
-                }
-            }
+            KeyCode::Enter | KeyCode::Right => self.open_selected_notif(false),
+            KeyCode::Char('t') => self.open_selected_notif(true),
             KeyCode::Esc | KeyCode::Left => self.view = View::Fleet,
             KeyCode::Char('q') => self.should_quit = true,
             _ => {}
+        }
+    }
+
+    /// Open the lane behind the cursor's event in Focus, pointed at the exact session that
+    /// fired (when the event recorded one). `attach` goes all the way into its tmux pane.
+    fn open_selected_notif(&mut self, attach: bool) {
+        let Some((lane_id, sid)) = self
+            .notifications
+            .iter()
+            .rev()
+            .nth(self.notif_sel)
+            .map(|e| (e.lane_id, e.session_id.clone()))
+        else {
+            return;
+        };
+        self.jump_to_lane(lane_id);
+        // jump_to_lane reports a stale lane via status; only proceed if it landed.
+        if self.selected_lane().map(|l| l.id) != Some(lane_id) {
+            return;
+        }
+        self.select_session(lane_id, sid.as_deref());
+        if attach {
+            self.attach_request = Some(lane_id);
+        }
+    }
+
+    /// Point the session cursor at `session_id` on the selected lane (no-op when the session
+    /// is gone or wasn't recorded — the lane's current selection stands).
+    fn select_session(&mut self, lane_id: LaneId, session_id: Option<&str>) {
+        let Some(sid) = session_id else { return };
+        let idx = self.lanes.iter().find(|l| l.id == lane_id).and_then(|l| {
+            l.agent_sessions
+                .iter()
+                .position(|s| s.session_id.as_deref() == Some(sid))
+        });
+        if let Some(i) = idx {
+            self.session_lane = Some(lane_id); // keep sync_session_cursor from resetting it
+            self.session_idx = i;
         }
     }
 
@@ -2589,7 +2724,13 @@ impl App {
                     }
                     View::Agents => self.enter_agents(None).await,
                     View::Settings => self.load_settings().await,
-                    View::Notifications => self.notif_scroll = 0,
+                    View::Notifications => {
+                        self.notif_sel = 0;
+                        // Opening the feed counts as catching up — clears the ⚑ unread badge.
+                        for ev in self.notifications.iter_mut() {
+                            ev.read = true;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -2637,6 +2778,7 @@ impl App {
                 };
             }
             Action::JumpNeedsYou => self.jump_attention(),
+            Action::AttachNeedsYou => self.jump_attention_attach(),
             Action::FindLane => self.enter_lane_jump(),
             Action::ToggleUrgent => {
                 self.urgent_only = !self.urgent_only;
@@ -3302,6 +3444,7 @@ mod tests {
             resume_at: None,
             inferred,
             tmux_window: None,
+            last_message: None,
         }
     }
 

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -31,6 +31,8 @@ pub enum View {
     Notifications,
     /// Quick picker for which agent to spawn on the selected lane.
     SpawnPick,
+    /// Fuzzy lane switcher: type a few characters, jump to any lane across repos.
+    LaneJump,
 }
 
 /// A user intent derived from a key press in navigation mode.
@@ -57,6 +59,10 @@ pub enum Action {
     AttachTerminal,
     ToggleMouse,
     ToggleAutoContinue,
+    /// Open the fuzzy lane switcher.
+    FindLane,
+    /// Show only lanes needing attention (waiting / stuck on a limit).
+    ToggleUrgent,
     Goto(View),
 }
 
@@ -86,6 +92,8 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('T') => Some(Action::AttachTerminal),
         KeyCode::Char('y') => Some(Action::ToggleMouse),
         KeyCode::Char('C') => Some(Action::ToggleAutoContinue),
+        KeyCode::Char('f') => Some(Action::FindLane),
+        KeyCode::Char('!') => Some(Action::ToggleUrgent),
         KeyCode::Char(' ') => Some(Action::ToggleBabysit),
         KeyCode::Char('1') => Some(Action::Goto(View::Fleet)),
         KeyCode::Char('2') => Some(Action::Goto(View::Timeline)),

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -59,6 +59,9 @@ pub enum Action {
     AttachTerminal,
     ToggleMouse,
     ToggleAutoContinue,
+    /// Like [`Action::JumpNeedsYou`], but goes all the way: jump to the alerting lane, select
+    /// the session that fired, and attach into its tmux pane.
+    AttachNeedsYou,
     /// Open the fuzzy lane switcher.
     FindLane,
     /// Show only lanes needing attention (waiting / stuck on a limit).
@@ -80,6 +83,7 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('r') => Some(Action::Refresh),
         KeyCode::Char('c') => Some(Action::CdToLane),
         KeyCode::Char('g') => Some(Action::JumpNeedsYou),
+        KeyCode::Char('G') => Some(Action::AttachNeedsYou),
         KeyCode::Char('a') => Some(Action::Goto(View::AddRepo)),
         KeyCode::Char('A') => Some(Action::Goto(View::Agents)),
         KeyCode::Char(',') => Some(Action::Goto(View::Settings)),

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -27,6 +27,8 @@ pub enum View {
     Agents,
     /// Settings: accent color, auto-continue, etc.
     Settings,
+    /// History of fired agent-state notifications.
+    Notifications,
 }
 
 /// A user intent derived from a key press in navigation mode.
@@ -87,6 +89,7 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('2') => Some(Action::Goto(View::Timeline)),
         KeyCode::Char('3') => Some(Action::Goto(View::Sessions)),
         KeyCode::Char('4') => Some(Action::Goto(View::Search)),
+        KeyCode::Char('5') => Some(Action::Goto(View::Notifications)),
         _ => None,
     }
 }

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -29,6 +29,8 @@ pub enum View {
     Settings,
     /// History of fired agent-state notifications.
     Notifications,
+    /// Quick picker for which agent to spawn on the selected lane.
+    SpawnPick,
 }
 
 /// A user intent derived from a key press in navigation mode.

--- a/crates/repomon-tui/src/lib.rs
+++ b/crates/repomon-tui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod cli;
 pub mod client;
 pub mod keybinds;
+pub mod notify;
 pub mod theme;
 pub mod view;
 

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -116,6 +116,17 @@ fn truncate(s: &str, max: usize) -> String {
     out
 }
 
+/// Play the notification chime once, off-thread — a preview used when the user enables sound in
+/// Settings so they can confirm it's audible without waiting for an agent to change state.
+pub fn play_chime() {
+    #[cfg(target_os = "macos")]
+    std::thread::spawn(|| {
+        let _ = std::process::Command::new("afplay")
+            .arg(NOTIFY_SOUND_FILE)
+            .output();
+    });
+}
+
 /// Fire a native desktop notification, best-effort and without blocking the caller: the actual
 /// `osascript`/`notify-send` invocation runs (and is reaped) on a detached thread.
 pub fn send_native(title: &str, body: &str, sound: bool) {
@@ -125,18 +136,30 @@ pub fn send_native(title: &str, body: &str, sound: bool) {
     });
 }
 
+/// A system sound file played for an audible notification (see [`run_native`]).
+#[cfg(target_os = "macos")]
+const NOTIFY_SOUND_FILE: &str = "/System/Library/Sounds/Glass.aiff";
+
 #[cfg(target_os = "macos")]
 fn run_native(title: &str, body: &str, sound: bool) {
+    // Show the visual banner. We deliberately do NOT use osascript's own `sound name`: on recent
+    // macOS the notification is attributed to "Script Editor", whose notification sound is usually
+    // off, so the chime is silently dropped even though the call succeeds.
     let script = format!(
-        "display notification \"{}\" with title \"{}\"{}",
+        "display notification \"{}\" with title \"{}\"",
         escape(body),
         escape(title),
-        if sound { " sound name \"Ping\"" } else { "" },
     );
     let _ = std::process::Command::new("osascript")
         .arg("-e")
         .arg(script)
         .output();
+    // Play the sound directly instead — `afplay` is audible regardless of notification settings.
+    if sound {
+        let _ = std::process::Command::new("afplay")
+            .arg(NOTIFY_SOUND_FILE)
+            .output();
+    }
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Local};
 use repomon_core::model::{AgentSession, Lane};
 
 /// The kind of agent state-change that fired a notification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NotifKind {
     /// Agent finished its turn / is waiting on you.
     NeedsYou,

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -1,9 +1,10 @@
 //! Desktop + in-app notifications for agent state changes.
 //!
-//! The TUI watches each lane's agent status across refreshes (see `App::detect_notifications`)
-//! and, on a meaningful transition, composes a notification here: a native macOS popup (via
-//! `osascript`, fired on a short-lived thread so it never blocks the event loop) plus an in-app
-//! banner and a scrollable history feed. Edge detection and the config toggles live in `app`.
+//! The TUI watches each agent session's status across refreshes (see
+//! `App::detect_notifications`) and, on a meaningful transition, composes a notification here:
+//! a native macOS popup (via `osascript`, fired on a short-lived thread so it never blocks the
+//! event loop) plus an in-app banner and a scrollable history feed. Edge detection and the
+//! config toggles live in `app`.
 
 use chrono::{DateTime, Local};
 
@@ -50,20 +51,12 @@ pub struct NotifEvent {
     pub body: String,
 }
 
-/// The session a notification is about: the managed/primary one if present (skipping the
-/// inferred "file activity" placeholders, which never drive named alerts).
-fn primary_session(lane: &Lane) -> Option<&AgentSession> {
-    lane.agent_sessions
-        .iter()
-        .find(|s| !s.external && !s.inferred)
-        .or_else(|| lane.agent_sessions.iter().find(|s| !s.inferred))
-        .or_else(|| lane.agent_sessions.first())
-}
-
-/// Build the `(title, body)` for a notification about `lane`. The body carries the detail the
-/// user asked for: branch, what they asked the agent, tool count, and any reset time.
-pub fn compose(kind: NotifKind, lane: &Lane) -> (String, String) {
-    let sess = primary_session(lane);
+/// Build the `(title, body)` for a notification about one of `lane`'s sessions. The body
+/// carries the detail the user asked for: branch, what they asked the agent, tool count, and
+/// any reset time. `sess` is `None` when the session vanished from the snapshot (its
+/// disappearance was the trigger) — the text degrades to a generic "agent" line rather than
+/// borrowing another session's name and title.
+pub fn compose(kind: NotifKind, lane: &Lane, sess: Option<&AgentSession>) -> (String, String) {
     let agent = sess
         .map(|s| s.agent.short().to_string())
         .unwrap_or_default();

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -1,0 +1,174 @@
+//! Desktop + in-app notifications for agent state changes.
+//!
+//! The TUI watches each lane's agent status across refreshes (see `App::detect_notifications`)
+//! and, on a meaningful transition, composes a notification here: a native macOS popup (via
+//! `osascript`, fired on a short-lived thread so it never blocks the event loop) plus an in-app
+//! banner and a scrollable history feed. Edge detection and the config toggles live in `app`.
+
+use chrono::{DateTime, Local};
+
+use repomon_core::model::{AgentSession, Lane};
+
+/// The kind of agent state-change that fired a notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotifKind {
+    /// Agent finished its turn / is waiting on you.
+    NeedsYou,
+    /// Agent paused on a usage/rate limit.
+    RateLimited,
+    /// A rate-limited agent was auto-continued and resumed work.
+    Resumed,
+    /// Agent went idle or its session ended.
+    Idle,
+}
+
+impl NotifKind {
+    fn glyph(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "⏸",
+            NotifKind::RateLimited => "⏳",
+            NotifKind::Resumed => "▶",
+            NotifKind::Idle => "○",
+        }
+    }
+    fn verb(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "needs you",
+            NotifKind::RateLimited => "hit a usage limit",
+            NotifKind::Resumed => "resumed",
+            NotifKind::Idle => "went idle",
+        }
+    }
+}
+
+/// A fired notification, kept in the in-app history feed.
+#[derive(Debug, Clone)]
+pub struct NotifEvent {
+    pub when: DateTime<Local>,
+    pub kind: NotifKind,
+    pub title: String,
+    pub body: String,
+}
+
+/// The session a notification is about: the managed/primary one if present (skipping the
+/// inferred "file activity" placeholders, which never drive named alerts).
+fn primary_session(lane: &Lane) -> Option<&AgentSession> {
+    lane.agent_sessions
+        .iter()
+        .find(|s| !s.external && !s.inferred)
+        .or_else(|| lane.agent_sessions.iter().find(|s| !s.inferred))
+        .or_else(|| lane.agent_sessions.first())
+}
+
+/// Build the `(title, body)` for a notification about `lane`. The body carries the detail the
+/// user asked for: branch, what they asked the agent, tool count, and any reset time.
+pub fn compose(kind: NotifKind, lane: &Lane) -> (String, String) {
+    let sess = primary_session(lane);
+    let agent = sess
+        .map(|s| s.agent.short().to_string())
+        .unwrap_or_default();
+    let agent = if agent.is_empty() {
+        "agent".into()
+    } else {
+        agent
+    };
+    let title = format!(
+        "{} {} {} — {}",
+        kind.glyph(),
+        agent,
+        kind.verb(),
+        lane.repo.name
+    );
+
+    let mut parts = vec![lane
+        .state
+        .branch
+        .clone()
+        .unwrap_or_else(|| lane.worktree.name.clone())];
+    if let Some(t) = sess.and_then(|s| s.title.as_deref()) {
+        let t = t.trim();
+        if !t.is_empty() {
+            parts.push(format!("“{}”", truncate(t, 60)));
+        }
+    }
+    if let Some(s) = sess {
+        if s.tool_call_count > 0 {
+            parts.push(format!("{} tools", s.tool_call_count));
+        }
+    }
+    if kind == NotifKind::RateLimited {
+        if let Some(r) = sess.and_then(|s| s.resume_at) {
+            parts.push(format!(
+                "resets {}",
+                r.with_timezone(&Local).format("%H:%M")
+            ));
+        }
+    }
+    (title, parts.join(" · "))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Fire a native desktop notification, best-effort and without blocking the caller: the actual
+/// `osascript`/`notify-send` invocation runs (and is reaped) on a detached thread.
+pub fn send_native(title: &str, body: &str, sound: bool) {
+    let (title, body) = (title.to_string(), body.to_string());
+    std::thread::spawn(move || {
+        run_native(&title, &body, sound);
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn run_native(title: &str, body: &str, sound: bool) {
+    let script = format!(
+        "display notification \"{}\" with title \"{}\"{}",
+        escape(body),
+        escape(title),
+        if sound { " sound name \"Ping\"" } else { "" },
+    );
+    let _ = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_native(title: &str, body: &str, _sound: bool) {
+    let _ = std::process::Command::new("notify-send")
+        .arg(title)
+        .arg(body)
+        .output();
+}
+
+/// Escape a string for embedding in an AppleScript double-quoted literal.
+#[cfg(target_os = "macos")]
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_adds_ellipsis_only_when_over() {
+        assert_eq!(truncate("short", 60), "short");
+        let t = truncate("0123456789", 5);
+        assert_eq!(t.chars().count(), 5);
+        assert!(t.ends_with('…'));
+        assert_eq!(t, "0123…");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn escape_neutralizes_applescript_quotes() {
+        assert_eq!(escape(r#"say "hi" \ now"#), r#"say \"hi\" \\ now"#);
+    }
+}

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -8,7 +8,7 @@
 
 use chrono::{DateTime, Local};
 
-use repomon_core::model::{AgentSession, Lane};
+use repomon_core::model::{AgentSession, Lane, LaneId};
 
 /// The kind of agent state-change that fired a notification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -47,6 +47,8 @@ impl NotifKind {
 pub struct NotifEvent {
     pub when: DateTime<Local>,
     pub kind: NotifKind,
+    /// The lane the alert was about — lets the feed jump straight to it.
+    pub lane_id: LaneId,
     pub title: String,
     pub body: String,
 }

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -40,6 +40,14 @@ impl NotifKind {
             NotifKind::Idle => "went idle",
         }
     }
+    fn verb_plural(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "need you",
+            NotifKind::RateLimited => "hit a usage limit",
+            NotifKind::Resumed => "resumed",
+            NotifKind::Idle => "went idle",
+        }
+    }
 }
 
 /// A fired notification, kept in the in-app history feed.
@@ -49,16 +57,29 @@ pub struct NotifEvent {
     pub kind: NotifKind,
     /// The lane the alert was about — lets the feed jump straight to it.
     pub lane_id: LaneId,
+    /// The session that fired (Claude transcript id) — lets the feed open/attach the exact
+    /// agent in a multi-agent lane. `None` when the session couldn't be identified.
+    pub session_id: Option<String>,
+    /// False until the user opens the Notifications view; drives the ⚑ unread badge.
+    pub read: bool,
     pub title: String,
     pub body: String,
 }
 
 /// Build the `(title, body)` for a notification about one of `lane`'s sessions. The body
-/// carries the detail the user asked for: branch, what they asked the agent, tool count, and
-/// any reset time. `sess` is `None` when the session vanished from the snapshot (its
-/// disappearance was the trigger) — the text degrades to a generic "agent" line rather than
-/// borrowing another session's name and title.
-pub fn compose(kind: NotifKind, lane: &Lane, sess: Option<&AgentSession>) -> (String, String) {
+/// carries the detail that makes the alert actionable: branch, which of the lane's
+/// side-by-side agents fired (`slot` = (index, count), tagged only when several run), the
+/// *why* — the agent's actual last message when `show_why` is on (falling back to what you
+/// originally asked) — tool count, and any reset time. `sess` is `None` when the session
+/// vanished from the snapshot (its disappearance was the trigger) — the text degrades to a
+/// generic "agent" line rather than borrowing another session's name and title.
+pub fn compose(
+    kind: NotifKind,
+    lane: &Lane,
+    sess: Option<&AgentSession>,
+    slot: Option<(usize, usize)>,
+    show_why: bool,
+) -> (String, String) {
     let agent = sess
         .map(|s| s.agent.short().to_string())
         .unwrap_or_default();
@@ -80,10 +101,18 @@ pub fn compose(kind: NotifKind, lane: &Lane, sess: Option<&AgentSession>) -> (St
         .branch
         .clone()
         .unwrap_or_else(|| lane.worktree.name.clone())];
-    if let Some(t) = sess.and_then(|s| s.title.as_deref()) {
+    if let Some((i, n)) = slot {
+        if n > 1 {
+            parts.push(format!("agent {}/{}", i + 1, n));
+        }
+    }
+    let why = show_why
+        .then(|| sess.and_then(|s| s.last_message.as_deref()))
+        .flatten();
+    if let Some(t) = why.or_else(|| sess.and_then(|s| s.title.as_deref())) {
         let t = t.trim();
         if !t.is_empty() {
-            parts.push(format!("“{}”", truncate(t, 60)));
+            parts.push(format!("“{}”", truncate(t, 100)));
         }
     }
     if let Some(s) = sess {
@@ -100,6 +129,29 @@ pub fn compose(kind: NotifKind, lane: &Lane, sess: Option<&AgentSession>) -> (St
         }
     }
     (title, parts.join(" · "))
+}
+
+/// One popup for a burst of simultaneous alerts: the title counts them (with the kind's glyph
+/// and verb when the whole burst is one kind, a generic ⚑ otherwise), the body lists the first
+/// few lanes. `fires` pairs each alert's `repo/worktree` label with its kind.
+pub fn compose_burst(fires: &[(String, NotifKind)]) -> (String, String) {
+    let n = fires.len();
+    let first = fires.first().map(|(_, k)| *k);
+    let uniform = fires.iter().all(|(_, k)| Some(*k) == first);
+    let title = match (uniform, first) {
+        (true, Some(k)) => format!("{} {} agents {}", k.glyph(), n, k.verb_plural()),
+        _ => format!("⚑ {n} agents need attention"),
+    };
+    let mut body = fires
+        .iter()
+        .take(3)
+        .map(|(l, _)| l.as_str())
+        .collect::<Vec<_>>()
+        .join(" · ");
+    if n > 3 {
+        body.push_str(&format!(" · +{} more", n - 3));
+    }
+    (title, body)
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -124,10 +176,12 @@ pub fn play_chime() {
 
 /// Fire a native desktop notification, best-effort and without blocking the caller: the actual
 /// `osascript`/`notify-send` invocation runs (and is reaped) on a detached thread.
-pub fn send_native(title: &str, body: &str, sound: bool) {
+/// `click_focus` makes the popup click-to-focus the terminal when `terminal-notifier` is
+/// installed (plain popup otherwise).
+pub fn send_native(title: &str, body: &str, sound: bool, click_focus: bool) {
     let (title, body) = (title.to_string(), body.to_string());
     std::thread::spawn(move || {
-        run_native(&title, &body, sound);
+        run_native(&title, &body, sound, click_focus);
     });
 }
 
@@ -136,19 +190,24 @@ pub fn send_native(title: &str, body: &str, sound: bool) {
 const NOTIFY_SOUND_FILE: &str = "/System/Library/Sounds/Glass.aiff";
 
 #[cfg(target_os = "macos")]
-fn run_native(title: &str, body: &str, sound: bool) {
-    // Show the visual banner. We deliberately do NOT use osascript's own `sound name`: on recent
-    // macOS the notification is attributed to "Script Editor", whose notification sound is usually
-    // off, so the chime is silently dropped even though the call succeeds.
-    let script = format!(
-        "display notification \"{}\" with title \"{}\"",
-        escape(body),
-        escape(title),
-    );
-    let _ = std::process::Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .output();
+fn run_native(title: &str, body: &str, sound: bool, click_focus: bool) {
+    // Prefer the clickable popup; fall back to osascript when terminal-notifier isn't
+    // installed (or click-to-focus is off). We deliberately do NOT use osascript's own
+    // `sound name`: on recent macOS the notification is attributed to "Script Editor", whose
+    // notification sound is usually off, so the chime is silently dropped even though the
+    // call succeeds.
+    let clickable = click_focus && notify_clickable(title, body);
+    if !clickable {
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            escape(body),
+            escape(title),
+        );
+        let _ = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .output();
+    }
     // Play the sound directly instead — `afplay` is audible regardless of notification settings.
     if sound {
         let _ = std::process::Command::new("afplay")
@@ -157,8 +216,61 @@ fn run_native(title: &str, body: &str, sound: bool) {
     }
 }
 
+/// Post a click-to-focus popup via `terminal-notifier`: clicking it activates the terminal
+/// the TUI runs in (resolved from `$TERM_PROGRAM`). Returns false when terminal-notifier
+/// isn't installed, so the caller can fall back to a plain popup.
+#[cfg(target_os = "macos")]
+fn notify_clickable(title: &str, body: &str) -> bool {
+    let Some(bin) = terminal_notifier() else {
+        return false;
+    };
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["-title", title, "-message", body]);
+    if let Some(bundle) = std::env::var("TERM_PROGRAM")
+        .ok()
+        .as_deref()
+        .and_then(terminal_bundle_id)
+    {
+        cmd.args(["-activate", bundle]);
+    }
+    cmd.output().is_ok()
+}
+
+/// The installed `terminal-notifier` binary, located once per process. `None` = not installed.
+#[cfg(target_os = "macos")]
+fn terminal_notifier() -> Option<&'static str> {
+    fn locate() -> Option<String> {
+        let out = std::process::Command::new("which")
+            .arg("terminal-notifier")
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        (!p.is_empty()).then_some(p)
+    }
+    static FOUND: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    FOUND.get_or_init(locate).as_deref()
+}
+
+/// The macOS bundle id behind a `$TERM_PROGRAM` value — what a clicked notification focuses.
+/// Unknown terminals (including `tmux`, which masks the real one) get no `-activate`.
+#[cfg(target_os = "macos")]
+fn terminal_bundle_id(term_program: &str) -> Option<&'static str> {
+    match term_program {
+        "iTerm.app" => Some("com.googlecode.iterm2"),
+        "Apple_Terminal" => Some("com.apple.Terminal"),
+        "WezTerm" => Some("com.github.wez.wezterm"),
+        "ghostty" => Some("com.mitchellh.ghostty"),
+        "vscode" => Some("com.microsoft.VSCode"),
+        "kitty" => Some("net.kovidgoyal.kitty"),
+        _ => None,
+    }
+}
+
 #[cfg(not(target_os = "macos"))]
-fn run_native(title: &str, body: &str, _sound: bool) {
+fn run_native(title: &str, body: &str, _sound: bool, _click_focus: bool) {
     let _ = std::process::Command::new("notify-send")
         .arg(title)
         .arg(body)
@@ -174,6 +286,140 @@ fn escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use repomon_core::model::{
+        AgentKind, AgentSession, AgentStatus, Repo, Worktree, WorktreeState,
+    };
+
+    fn lane() -> Lane {
+        let head = gix::ObjectId::null(gix::hash::Kind::Sha1);
+        Lane {
+            id: 7,
+            repo: Repo {
+                id: 1,
+                path: "/code/alpha".into(),
+                name: "alpha".into(),
+                added_at: Utc::now(),
+                worktree_root_template: None,
+            },
+            worktree: Worktree {
+                id: 1,
+                repo_id: 1,
+                path: "/code/alpha".into(),
+                branch: Some("main".into()),
+                head,
+                is_main: true,
+                name: "main".into(),
+            },
+            state: WorktreeState {
+                worktree_id: 1,
+                head,
+                branch: Some("feat/x".into()),
+                upstream: None,
+                ahead: 0,
+                behind: 0,
+                dirty: Default::default(),
+                last_commit_at: None,
+                locked: false,
+                prunable: false,
+                last_change_at: None,
+            },
+            agent_sessions: vec![],
+            last_activity_at: Utc::now(),
+            pinned: false,
+        }
+    }
+
+    fn sess() -> AgentSession {
+        AgentSession {
+            id: 0,
+            agent: AgentKind::ClaudeCode,
+            repo_id: 1,
+            worktree_id: Some(1),
+            started_at: Utc::now(),
+            last_activity_at: Utc::now(),
+            ended_at: None,
+            manifest_path: std::path::PathBuf::new(),
+            tool_call_count: 3,
+            title: Some("build the parser".into()),
+            status: AgentStatus::Waiting,
+            external: false,
+            session_id: Some("abc".into()),
+            resume_at: None,
+            inferred: false,
+            tmux_window: None,
+            last_message: Some("Should I also update the integration tests?".into()),
+        }
+    }
+
+    #[test]
+    fn compose_shows_the_why_and_the_slot() {
+        let (title, body) = compose(
+            NotifKind::NeedsYou,
+            &lane(),
+            Some(&sess()),
+            Some((1, 3)),
+            true,
+        );
+        assert!(
+            title.contains("needs you") && title.contains("alpha"),
+            "{title}"
+        );
+        assert!(body.contains("agent 2/3"), "{body}");
+        assert!(body.contains("Should I also update"), "{body}");
+        assert!(
+            !body.contains("build the parser"),
+            "why replaces the ask: {body}"
+        );
+    }
+
+    #[test]
+    fn compose_without_why_falls_back_to_the_ask_and_skips_solo_slot() {
+        let (_, body) = compose(
+            NotifKind::NeedsYou,
+            &lane(),
+            Some(&sess()),
+            Some((0, 1)),
+            false,
+        );
+        assert!(body.contains("build the parser"), "{body}");
+        assert!(!body.contains("agent 1/1"), "{body}");
+    }
+
+    #[test]
+    fn burst_counts_kinds_and_overflow() {
+        let f = |l: &str, k: NotifKind| (l.to_string(), k);
+        let (t, b) = compose_burst(&[
+            f("alpha/main", NotifKind::NeedsYou),
+            f("beta/x", NotifKind::NeedsYou),
+        ]);
+        assert_eq!(t, "⏸ 2 agents need you");
+        assert_eq!(b, "alpha/main · beta/x");
+        let (t, b) = compose_burst(&[
+            f("a/1", NotifKind::NeedsYou),
+            f("b/2", NotifKind::Idle),
+            f("c/3", NotifKind::NeedsYou),
+            f("d/4", NotifKind::NeedsYou),
+        ]);
+        assert_eq!(t, "⚑ 4 agents need attention");
+        assert!(b.ends_with("+1 more"), "{b}");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bundle_ids_cover_known_terminals_only() {
+        assert_eq!(
+            terminal_bundle_id("iTerm.app"),
+            Some("com.googlecode.iterm2")
+        );
+        assert_eq!(
+            terminal_bundle_id("Apple_Terminal"),
+            Some("com.apple.Terminal")
+        );
+        // tmux masks the real terminal; unknowns get no -activate.
+        assert_eq!(terminal_bundle_id("tmux"), None);
+        assert_eq!(terminal_bundle_id(""), None);
+    }
 
     #[test]
     fn truncate_adds_ellipsis_only_when_over() {

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -13,6 +13,8 @@ pub const CLEAN: &str = "○";
 pub const AGENT_ACTIVE: &str = "▶";
 pub const WAITING: &str = "⏸";
 pub const RATE_LIMITED: &str = "⏳";
+/// An *inferred* active agent (worktree file activity we can't attribute to a named session).
+pub const INFERRED_ACTIVE: &str = "◐";
 pub const UP: char = '↑';
 pub const DOWN: char = '↓';
 

--- a/crates/repomon-tui/src/theme.rs
+++ b/crates/repomon-tui/src/theme.rs
@@ -155,6 +155,41 @@ impl Theme {
             _ => self.idle(),
         }
     }
+
+    /// The accent as RGB, for gradients. Named ANSI accents map to representative truecolor
+    /// values (only used for shading — everything else stays palette-respecting ANSI).
+    fn accent_rgb(&self) -> Option<(u8, u8, u8)> {
+        match self.accent? {
+            Color::Rgb(r, g, b) => Some((r, g, b)),
+            Color::Red => Some((224, 82, 82)),
+            Color::Green => Some((80, 200, 120)),
+            Color::Yellow => Some((229, 192, 78)),
+            Color::Blue => Some((86, 134, 230)),
+            Color::Magenta => Some((197, 100, 221)),
+            Color::Cyan => Some((64, 192, 208)),
+            Color::White => Some((229, 229, 229)),
+            Color::Gray => Some((150, 150, 150)),
+            _ => None,
+        }
+    }
+
+    /// Style for a commit-density level (0–5): a ramp of accent shades, dark to full, so the
+    /// timeline reads in the same hue as the rest of the UI. Monochrome themes keep the plain
+    /// block glyphs (which already encode the level).
+    pub fn density(&self, level: u8) -> Style {
+        if level == 0 {
+            return self.muted();
+        }
+        match (self.colored, self.accent_rgb()) {
+            (true, Some((r, g, b))) => {
+                // ~35% → 100% brightness across levels 1..=5.
+                let f = 0.35 + 0.1625 * (level.min(5) - 1) as f32;
+                let scale = |c: u8| (c as f32 * f).round().clamp(0.0, 255.0) as u8;
+                Style::default().fg(Color::Rgb(scale(r), scale(g), scale(b)))
+            }
+            _ => Style::default(),
+        }
+    }
 }
 
 /// Map a config color value to a ratatui color: a named ANSI color or a `#rrggbb`/`#rgb` hex.

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -22,7 +22,7 @@ const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
 const FOCUS_CMD_KEYS: &str =
-    "↵/→ open (real terminal) · i quick-type · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g next · f find  ·  ←/esc back";
+    "↵/→ open (real terminal) · i quick-type · tab agent · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g next · f find  ·  ←/esc back";
 const FOCUS_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O command-mode";
 const GRID_KEYS: &str =
     "←→ move · click focus (type in place) · dbl terminal · ↵ open  ·  e spawn · s stop · p pin · g next · f find  ·  spc/esc fleet · q quit";
@@ -269,7 +269,7 @@ fn render_settings(f: &mut Frame, app: &App) {
 }
 
 const ADDREPO_KEYS: &str =
-    "↑↓ select · ↵/→ enter · ←/h up  ·  a add repo · d discover here  ·  esc back";
+    "↑↓ select · ↵/→ enter · ←/h up  ·  a add repo · d discover here · x x remove (+ only)  ·  esc back";
 
 fn render_addrepo(f: &mut Frame, app: &App) {
     let area = f.area();
@@ -778,7 +778,7 @@ fn render_focus(f: &mut Frame, app: &App) {
     let mut body: Vec<Line> = Vec::new();
     if let Some(l) = lane {
         body.push(Line::from(Span::styled(
-            focus_status_line(l),
+            focus_status_line(l, app.session_idx),
             app.theme.dim(),
         )));
     }
@@ -1146,14 +1146,25 @@ fn focus_output(
         .collect()
 }
 
-fn focus_status_line(lane: &Lane) -> String {
+fn focus_status_line(lane: &Lane, idx: usize) -> String {
     let s = &lane.state;
     let branch = lane_branch(lane);
     let ab = ahead_behind_str(s.ahead, s.behind);
-    match lane.agent_sessions.first() {
+    let n = lane.agent_sessions.len();
+    let sess = lane
+        .agent_sessions
+        .get(idx)
+        .or_else(|| lane.agent_sessions.first());
+    match sess {
         Some(sess) => format!(
-            "{} · {} {} · {} · {} calls{}",
+            "{}{} · {} {} · {} · {} calls{}",
             sess.agent.short(),
+            // Several agents share this lane: show which one the keys/pane are on.
+            if n > 1 {
+                format!(" {}/{n} (tab switches)", idx.min(n - 1) + 1)
+            } else {
+                String::new()
+            },
             branch,
             ab,
             sess.status.as_str(),

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -56,6 +56,7 @@ pub fn render(f: &mut Frame, app: &App) {
         View::Agents => render_agents(f, app),
         View::Settings => render_settings(f, app),
         View::Notifications => render_notifications(f, app),
+        View::SpawnPick => render_spawn_pick(f, app),
     }
 }
 
@@ -186,7 +187,7 @@ fn render_settings(f: &mut Frame, app: &App) {
         s.default_agent.clone()
     };
     let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
-    let items: [(&str, String, &str); 11] = [
+    let items: [(&str, String, &str); 12] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
         ("auto-continue", onoff(s.auto_continue), "space toggles"),
@@ -199,6 +200,11 @@ fn render_settings(f: &mut Frame, app: &App) {
             "worktree template",
             format!("{}{}", s.worktree_template, cur(4)),
             "↵ edit",
+        ),
+        (
+            "ask which agent on spawn",
+            onoff(s.spawn_prompt),
+            "space toggles",
         ),
         // Notifications group — the master switch then per-trigger toggles (indented).
         ("notifications", onoff(s.notify_enabled), "master · space"),
@@ -467,6 +473,84 @@ fn render_notifications(f: &mut Frame, app: &App) {
     f.render_widget(
         footer("↑↓ scroll · c clear  ·  1 fleet · ←/esc back · q quit", app),
         rows[1],
+    );
+}
+
+/// The quick agent picker shown when spawning onto a lane (when "ask which agent on spawn" is
+/// on). Lists the same agents as the Agents view, with the default highlighted; ↑↓ or a number
+/// picks, ↵ spawns, esc cancels.
+fn render_spawn_pick(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    let lane_label = app
+        .spawn_pick_lane
+        .and_then(|id| app.lanes.iter().find(|l| l.id == id))
+        .map(|l| format!("{} / {}", l.repo.name, lane_branch(l)))
+        .unwrap_or_default();
+    f.render_widget(
+        Paragraph::new(vec![
+            header_line(area.width, "REPOMON · SPAWN AGENT", &lane_label, app),
+            rule(area.width, true, app),
+        ]),
+        rows[0],
+    );
+
+    let mut lines = vec![
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  choose an agent to spawn:".to_string(),
+            app.theme.dim(),
+        )),
+        Line::raw(""),
+    ];
+    if app.nl_agents.is_empty() {
+        lines.push(Line::raw(
+            "  no agents detected — press A to manage launch commands".to_string(),
+        ));
+    }
+    for (i, a) in app.nl_agents.iter().enumerate() {
+        let num = i + 1;
+        let cursor = if i == app.spawn_pick_idx { "‣" } else { " " };
+        // A short tag: the default star, or a PATH warning for an undetected command.
+        let tag = if a.default {
+            "★ default"
+        } else if !a.detected {
+            "✗ not on PATH"
+        } else {
+            ""
+        };
+        if i == app.spawn_pick_idx {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  {cursor} {num}  {:<18} {:<14} {}",
+                    trunc(&a.name, 18),
+                    tag,
+                    trunc(&a.command, 40)
+                ),
+                app.theme.selected(),
+            )));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {cursor} {num}  ")),
+                Span::styled(format!("{:<18}", trunc(&a.name, 18)), app.theme.accented()),
+                Span::styled(format!(" {tag:<14}"), app.theme.muted()),
+                Span::styled(format!(" {}", trunc(&a.command, 40)), app.theme.dim()),
+            ]));
+        }
+    }
+    if !app.status.is_empty() {
+        lines.push(Line::raw(""));
+        lines.push(Line::raw(format!("  {}", app.status)));
+    }
+    f.render_widget(Paragraph::new(lines), rows[1]);
+    f.render_widget(
+        footer("↑↓ pick · 1-9 jump · ↵ spawn · esc cancel", app),
+        rows[2],
     );
 }
 

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -13,6 +13,7 @@ use repomon_core::model::{Commit, DirtyState, Lane, LaneId, RepoId};
 
 use crate::app::{AgField, App, ClickZone};
 use crate::keybinds::View;
+use crate::notify::NotifKind;
 use crate::theme;
 
 const FLEET_KEYS: &str =
@@ -54,6 +55,7 @@ pub fn render(f: &mut Frame, app: &App) {
         View::AddRepo => render_addrepo(f, app),
         View::Agents => render_agents(f, app),
         View::Settings => render_settings(f, app),
+        View::Notifications => render_notifications(f, app),
     }
 }
 
@@ -183,14 +185,11 @@ fn render_settings(f: &mut Frame, app: &App) {
     } else {
         s.default_agent.clone()
     };
-    let items: [(&str, String, &str); 5] = [
+    let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
+    let items: [(&str, String, &str); 11] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
-        (
-            "auto-continue",
-            if s.auto_continue { "on" } else { "off" }.to_string(),
-            "space toggles",
-        ),
+        ("auto-continue", onoff(s.auto_continue), "space toggles"),
         (
             "continue message",
             format!("{}{}", s.auto_continue_message, cur(3)),
@@ -201,6 +200,17 @@ fn render_settings(f: &mut Frame, app: &App) {
             format!("{}{}", s.worktree_template, cur(4)),
             "↵ edit",
         ),
+        // Notifications group — the master switch then per-trigger toggles (indented).
+        ("notifications", onoff(s.notify_enabled), "master · space"),
+        ("  · needs you", onoff(s.notify_needs_you), "space toggles"),
+        (
+            "  · usage limit",
+            onoff(s.notify_rate_limited),
+            "space toggles",
+        ),
+        ("  · auto-resumed", onoff(s.notify_resumed), "space toggles"),
+        ("  · went idle", onoff(s.notify_idle), "space toggles"),
+        ("  · sound", onoff(s.notify_sound), "space toggles"),
     ];
     // Items start one row below the body top (after a leading blank) — record it for clicks.
     app.settings_geom.set(rows[1].y + 1);
@@ -402,6 +412,60 @@ fn render_sessions(f: &mut Frame, app: &App) {
             "e export-md  ·  1 fleet · 2 timeline · 3 sessions · 4 search  ·  q quit",
             app,
         ),
+        rows[1],
+    );
+}
+
+fn notif_style(app: &App, kind: NotifKind) -> Style {
+    match kind {
+        NotifKind::NeedsYou => app.theme.needs_you(),
+        NotifKind::RateLimited => app.theme.rate_limited(),
+        NotifKind::Resumed => app.theme.running(),
+        NotifKind::Idle => app.theme.muted(),
+    }
+}
+
+fn render_notifications(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+    let mut lines = vec![
+        header_line(area.width, "REPOMON · NOTIFICATIONS", &fmt_clock(), app),
+        rule(area.width, true, app),
+        Line::raw(""),
+        Line::from(Span::styled(
+            format!("{} event(s) · newest first", app.notifications.len()),
+            app.theme.dim(),
+        )),
+        Line::raw(""),
+    ];
+    if app.notifications.is_empty() {
+        lines.push(Line::raw(
+            "  no notifications yet — agent state changes show up here".to_string(),
+        ));
+    }
+    // Two lines per event (title + detail); reserve room for the header block already pushed.
+    let budget = (rows[0].height as usize).saturating_sub(lines.len()) / 2;
+    for ev in app
+        .notifications
+        .iter()
+        .rev()
+        .skip(app.notif_scroll)
+        .take(budget)
+    {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(ev.when.format("%H:%M:%S").to_string(), app.theme.muted()),
+            Span::raw("  "),
+            Span::styled(ev.title.clone(), notif_style(app, ev.kind)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("            "),
+            Span::styled(ev.body.clone(), app.theme.dim()),
+        ]));
+    }
+    f.render_widget(Paragraph::new(lines), rows[0]);
+    f.render_widget(
+        footer("↑↓ scroll · c clear  ·  1 fleet · ←/esc back · q quit", app),
         rows[1],
     );
 }
@@ -1254,6 +1318,16 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
 // ---- atoms -------------------------------------------------------------------
 
 fn footer(keys: &str, app: &App) -> Paragraph<'static> {
+    use ratatui::style::Modifier;
+    // A fresh notification takes over the footer line briefly (then the key hints return).
+    if let Some((msg, since)) = &app.notif_banner {
+        if since.elapsed() < crate::app::NOTIF_BANNER_TTL {
+            return Paragraph::new(Line::from(Span::styled(
+                format!("🔔 {msg}"),
+                app.theme.needs_you().add_modifier(Modifier::BOLD),
+            )));
+        }
+    }
     Paragraph::new(Line::from(Span::styled(
         keys.to_string(),
         app.theme.muted(),
@@ -1323,15 +1397,29 @@ fn repo_header(width: u16, name: &str, app: &App) -> Line<'static> {
 }
 
 fn lane_row(lane: &Lane, now: DateTime<Utc>, app: &App, selected: bool) -> Line<'static> {
+    use ratatui::style::Modifier;
     use repomon_core::model::AgentStatus;
     let glyph = status_glyph(lane);
-    let any = |st: AgentStatus| lane.agent_sessions.iter().any(|s| s.status == st);
+    // Only *real* (non-inferred) sessions drive the named status glyphs; an inferred "file
+    // activity" session falls through to the soft ◐ so we never claim a specific agent.
+    let any = |st: AgentStatus| {
+        lane.agent_sessions
+            .iter()
+            .any(|s| !s.inferred && s.status == st)
+    };
+    let any_inferred = lane.agent_sessions.iter().any(|s| s.inferred);
     let (active, active_style) = if any(AgentStatus::RateLimited) {
         (theme::RATE_LIMITED, app.theme.rate_limited()) // ⏳ paused on a usage limit
     } else if any(AgentStatus::Waiting) {
         (theme::WAITING, app.theme.needs_you()) // ⏸ needs you
     } else if any(AgentStatus::Running) {
         (theme::AGENT_ACTIVE, app.theme.running()) // ▶ working
+    } else if any_inferred {
+        // ◐ active — files are changing but we can't name the agent (worktree subagent).
+        (
+            theme::INFERRED_ACTIVE,
+            app.theme.running().add_modifier(Modifier::DIM),
+        )
     } else {
         (" ", app.theme.dim())
     };

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -17,15 +17,15 @@ use crate::notify::NotifKind;
 use crate::theme;
 
 const FLEET_KEYS: &str =
-    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · g needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
+    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · f find · ! urgent · g needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
 const FOCUS_CMD_KEYS: &str =
-    "↵/→ open (real terminal) · i quick-type · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  ←/esc back";
+    "↵/→ open (real terminal) · i quick-type · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g next · f find  ·  ←/esc back";
 const FOCUS_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O command-mode";
 const GRID_KEYS: &str =
-    "←→ move · click focus (type in place) · dbl terminal · ↵ open  ·  e spawn · s stop · p pin  ·  spc/esc fleet · q quit";
+    "←→ move · click focus (type in place) · dbl terminal · ↵ open  ·  e spawn · s stop · p pin · g next · f find  ·  spc/esc fleet · q quit";
 const GRID_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
 const NEWLANE_KEYS: &str =
     "↑↓ repo · tab agent · ^a manage  ·  type branch · ↵ create + spawn  ·  esc cancel";
@@ -57,6 +57,7 @@ pub fn render(f: &mut Frame, app: &App) {
         View::Settings => render_settings(f, app),
         View::Notifications => render_notifications(f, app),
         View::SpawnPick => render_spawn_pick(f, app),
+        View::LaneJump => render_lane_jump(f, app),
     }
 }
 
@@ -461,15 +462,18 @@ fn render_notifications(f: &mut Frame, app: &App) {
     }
     // Two lines per event (title + detail); reserve room for the header block already pushed.
     let budget = (rows[0].height as usize).saturating_sub(lines.len()) / 2;
-    for ev in app
+    for (i, ev) in app
         .notifications
         .iter()
         .rev()
         .skip(app.notif_scroll)
         .take(budget)
+        .enumerate()
     {
+        // The top row is the one ↵ opens (see `App::notifications_key`).
+        let mark = if i == 0 { "▸ " } else { "  " };
         lines.push(Line::from(vec![
-            Span::raw("  "),
+            Span::styled(mark, app.theme.accented()),
             Span::styled(ev.when.format("%H:%M:%S").to_string(), app.theme.muted()),
             Span::raw("  "),
             Span::styled(ev.title.clone(), notif_style(app, ev.kind)),
@@ -481,7 +485,10 @@ fn render_notifications(f: &mut Frame, app: &App) {
     }
     f.render_widget(Paragraph::new(lines), rows[0]);
     f.render_widget(
-        footer("↑↓ scroll · c clear  ·  1 fleet · ←/esc back · q quit", app),
+        footer(
+            "↑↓ scroll · ↵ open lane · c clear  ·  1 fleet · ←/esc back · q quit",
+            app,
+        ),
         rows[1],
     );
 }
@@ -560,6 +567,71 @@ fn render_spawn_pick(f: &mut Frame, app: &App) {
     f.render_widget(Paragraph::new(lines), rows[1]);
     f.render_widget(
         footer("↑↓ pick · 1-9 jump · ↵ spawn · esc cancel", app),
+        rows[2],
+    );
+}
+
+/// The fuzzy lane switcher (`f`): type to filter every lane across all repos, ↵ opens the
+/// highlighted one in Focus. Matches rank by query score, then by how urgently the lane needs
+/// you, then recency — so with an empty query the most pressing lanes are already on top.
+fn render_lane_jump(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let rows = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    f.render_widget(
+        Paragraph::new(vec![
+            header_line(area.width, "REPOMON · FIND LANE", &fmt_clock(), app),
+            rule(area.width, true, app),
+        ]),
+        rows[0],
+    );
+
+    let mut lines = vec![
+        Line::raw(""),
+        Line::raw(format!("  find: {}_", app.jump_query)),
+        Line::raw(""),
+    ];
+    let matches = app.lane_jump_matches();
+    if matches.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no lanes match".to_string(),
+            app.theme.dim(),
+        )));
+    }
+    let budget = (rows[1].height as usize).saturating_sub(lines.len()).max(1);
+    for (i, lane) in matches.iter().take(budget).enumerate() {
+        let cursor = if i == app.jump_idx { "‣" } else { " " };
+        let name = format!("{}/{}", lane.repo.name, lane.worktree.name);
+        let (badge, style) = agent_badge(lane, app);
+        if i == app.jump_idx {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  {cursor} {:<32} {:<24} {}",
+                    trunc(&name, 32),
+                    trunc(&lane_branch(lane), 24),
+                    badge
+                ),
+                app.theme.selected(),
+            )));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {cursor} ")),
+                Span::styled(format!("{:<32}", trunc(&name, 32)), app.theme.accented()),
+                Span::styled(
+                    format!(" {:<24}", trunc(&lane_branch(lane), 24)),
+                    app.theme.dim(),
+                ),
+                Span::styled(format!(" {badge}"), style),
+            ]));
+        }
+    }
+    f.render_widget(Paragraph::new(lines), rows[1]);
+    f.render_widget(
+        footer("type to filter · ↑↓ pick · ↵ open · esc cancel", app),
         rows[2],
     );
 }
@@ -1161,8 +1233,13 @@ fn fleet_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
         .iter()
         .filter(|l| l.agent_sessions.iter().any(|s| s.status.needs_you()))
         .count();
+    let urgent = if app.urgent_only {
+        " · URGENT only"
+    } else {
+        ""
+    };
     let rest = format!(
-        "  {} lanes · {repos} repos · {needs} need you",
+        "  {} lanes · {repos} repos · {needs} need you{urgent}",
         visible.len()
     );
     let right = format!("today · {} commits", app.commits.len());

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -330,20 +330,25 @@ fn render_timeline(f: &mut Frame, app: &App) {
     ];
     match &app.timeline {
         Some(t) if !t.rows.is_empty() => {
-            let zoom = match app.timeline_zoom {
-                crate::app::Zoom::Day => "day",
-                crate::app::Zoom::Week => "week",
-                crate::app::Zoom::Month => "month",
+            let (zoom, axis_fmt) = match app.timeline_zoom {
+                crate::app::Zoom::Day => ("day", "%H:%M"),
+                crate::app::Zoom::Week => ("week", "%a %d"),
+                crate::app::Zoom::Month => ("month", "%b %d"),
             };
-            lines.push(Line::from(Span::styled(
-                format!(
-                    "{} · {} buckets   [d]ay [w]eek [m]onth",
-                    zoom,
-                    t.rows.first().map(|r| r.density.len()).unwrap_or(0)
+            let (from, to) = (t.from.with_timezone(&Local), t.to.with_timezone(&Local));
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!(
+                        "{zoom} · {} – {}   ",
+                        from.format("%b %d %H:%M"),
+                        to.format("%b %d %H:%M")
+                    ),
+                    app.theme.dim(),
                 ),
-                app.theme.dim(),
-            )));
+                Span::styled("[d]ay [w]eek [m]onth", app.theme.muted()),
+            ]));
             lines.push(Line::raw(""));
+
             let label_w = t
                 .rows
                 .iter()
@@ -351,14 +356,46 @@ fn render_timeline(f: &mut Frame, app: &App) {
                 .max()
                 .unwrap_or(8)
                 .min(20);
+            // The strip fills the terminal: resample each row to the available width (peaks
+            // survive shrinking), so the chart adapts instantly to resizes between refetches.
+            let avail = (area.width as usize).saturating_sub(label_w + 6).max(10);
             for row in &t.rows {
-                let bars: String = row.density.iter().map(|&l| analytics_char(l)).collect();
-                lines.push(Line::raw(format!(
-                    "  {:<label_w$}  {}",
-                    trunc(&row.repo_name, label_w),
-                    bars
-                )));
+                let levels = repomon_core::analytics::resample_max(&row.density, avail);
+                let active = levels.iter().any(|&l| l > 0);
+                let mut spans = vec![Span::styled(
+                    format!("  {:<label_w$}  ", trunc(&row.repo_name, label_w)),
+                    if active {
+                        app.theme.accented()
+                    } else {
+                        app.theme.muted()
+                    },
+                )];
+                spans.extend(density_spans(&levels, app));
+                lines.push(Line::from(spans));
             }
+            // Time axis: start, midpoint, and "now" labels under the strip.
+            let mid = from + (to - from) / 2;
+            let (l, m, r) = (
+                from.format(axis_fmt).to_string(),
+                mid.format(axis_fmt).to_string(),
+                to.format(axis_fmt).to_string(),
+            );
+            let mut axis = l.clone();
+            let mid_start = avail.saturating_sub(m.chars().count()) / 2;
+            while axis.chars().count() < mid_start {
+                axis.push(' ');
+            }
+            axis.push_str(&m);
+            let right_start = avail.saturating_sub(r.chars().count());
+            while axis.chars().count() < right_start {
+                axis.push(' ');
+            }
+            axis.push_str(&r);
+            lines.push(Line::from(Span::styled(
+                format!("  {:<label_w$}  {axis}", ""),
+                app.theme.muted(),
+            )));
+
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled("CORRELATIONS", app.theme.bold())));
             lines.push(rule(area.width, false, app));
@@ -366,11 +403,33 @@ fn render_timeline(f: &mut Frame, app: &App) {
             if t.correlations.is_empty() {
                 lines.push(Line::raw("  (none above threshold)".to_string()));
             }
+            let pair_w = t
+                .correlations
+                .iter()
+                .take(8)
+                .flat_map(|c| [c.a.len(), c.b.len()])
+                .max()
+                .unwrap_or(8)
+                .min(20);
             for c in t.correlations.iter().take(8) {
-                lines.push(Line::raw(format!(
-                    "  {} ↔ {}     {} windows     {:.2} overlap",
-                    c.a, c.b, c.windows, c.overlap
-                )));
+                // A 10-cell meter in the accent ramp makes overlap comparable at a glance.
+                let filled = ((c.overlap * 10.0).round() as usize).min(10);
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        format!("{:<pair_w$}", trunc(&c.a, pair_w)),
+                        app.theme.accented(),
+                    ),
+                    Span::styled(" ↔ ", app.theme.muted()),
+                    Span::styled(
+                        format!("{:<pair_w$}", trunc(&c.b, pair_w)),
+                        app.theme.accented(),
+                    ),
+                    Span::styled(format!("  {:>3} windows  ", c.windows), app.theme.muted()),
+                    Span::styled("█".repeat(filled), app.theme.density(5)),
+                    Span::styled("░".repeat(10 - filled), app.theme.muted()),
+                    Span::raw(format!(" {:.2} overlap", c.overlap)),
+                ]));
             }
         }
         _ => lines.push(Line::raw(
@@ -379,6 +438,26 @@ fn render_timeline(f: &mut Frame, app: &App) {
     }
     f.render_widget(Paragraph::new(lines), rows[0]);
     f.render_widget(footer(DASH_KEYS, app), rows[1]);
+}
+
+/// Density levels → styled block spans, adjacent equal levels merged into one span. The blocks
+/// use shades of the configured accent (see `Theme::density`) so the chart matches the UI.
+fn density_spans(levels: &[u8], app: &App) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i < levels.len() {
+        let lvl = levels[i];
+        let mut j = i;
+        while j < levels.len() && levels[j] == lvl {
+            j += 1;
+        }
+        spans.push(Span::styled(
+            analytics_char(lvl).repeat(j - i),
+            app.theme.density(lvl),
+        ));
+        i = j;
+    }
+    spans
 }
 
 fn render_sessions(f: &mut Frame, app: &App) {

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -17,15 +17,15 @@ use crate::notify::NotifKind;
 use crate::theme;
 
 const FLEET_KEYS: &str =
-    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · f find · ! urgent · g needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
+    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
 const FOCUS_CMD_KEYS: &str =
-    "↵/→ open (real terminal) · i quick-type · tab agent · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g next · f find  ·  ←/esc back";
+    "↵/→ open (real terminal) · i quick-type · tab agent · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g/G next · f find  ·  ←/esc back";
 const FOCUS_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O command-mode";
 const GRID_KEYS: &str =
-    "←→ move · click focus (type in place) · dbl terminal · ↵ open  ·  e spawn · s stop · p pin · g next · f find  ·  spc/esc fleet · q quit";
+    "←→ move · click focus (type in place) · dbl terminal · ↵ open  ·  e spawn · s stop · p pin · g/G next · f find  ·  spc/esc fleet · q quit";
 const GRID_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
 const NEWLANE_KEYS: &str =
     "↑↓ repo · tab agent · ^a manage  ·  type branch · ↵ create + spawn  ·  esc cancel";
@@ -188,7 +188,7 @@ fn render_settings(f: &mut Frame, app: &App) {
         s.default_agent.clone()
     };
     let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
-    let items: [(&str, String, &str); 12] = [
+    let items: [(&str, String, &str); 15] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
         ("auto-continue", onoff(s.auto_continue), "space toggles"),
@@ -218,6 +218,21 @@ fn render_settings(f: &mut Frame, app: &App) {
         ("  · auto-resumed", onoff(s.notify_resumed), "space toggles"),
         ("  · went idle", onoff(s.notify_idle), "space toggles"),
         ("  · sound", onoff(s.notify_sound), "space toggles"),
+        (
+            "  · show agent's question",
+            onoff(s.notify_show_why),
+            "body = its last message",
+        ),
+        (
+            "  · coalesce bursts",
+            onoff(s.notify_coalesce),
+            "one popup for N alerts",
+        ),
+        (
+            "  · click focuses terminal",
+            onoff(s.notify_click_focus),
+            "needs terminal-notifier",
+        ),
     ];
     // Size the columns to the content so values and hints line up no matter how long a label is:
     // the name column fits the widest label (+gap), the value column fits the default worktree
@@ -522,16 +537,24 @@ fn notif_style(app: &App, kind: NotifKind) -> Style {
 }
 
 fn render_notifications(f: &mut Frame, app: &App) {
+    use ratatui::style::Modifier;
     let area = f.area();
     let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+    let unread = app.unread_notifs();
+    let counts = if unread > 0 {
+        format!(
+            "{} event(s) · {} new · newest first",
+            app.notifications.len(),
+            unread
+        )
+    } else {
+        format!("{} event(s) · newest first", app.notifications.len())
+    };
     let mut lines = vec![
         header_line(area.width, "REPOMON · NOTIFICATIONS", &fmt_clock(), app),
         rule(area.width, true, app),
         Line::raw(""),
-        Line::from(Span::styled(
-            format!("{} event(s) · newest first", app.notifications.len()),
-            app.theme.dim(),
-        )),
+        Line::from(Span::styled(counts, app.theme.dim())),
         Line::raw(""),
     ];
     if app.notifications.is_empty() {
@@ -540,32 +563,45 @@ fn render_notifications(f: &mut Frame, app: &App) {
         ));
     }
     // Two lines per event (title + detail); reserve room for the header block already pushed.
-    let budget = (rows[0].height as usize).saturating_sub(lines.len()) / 2;
+    let budget = ((rows[0].height as usize).saturating_sub(lines.len()) / 2).max(1);
+    // Scroll the window just enough to keep the cursor (▸) on screen.
+    let skip = app.notif_sel.saturating_sub(budget.saturating_sub(1));
     for (i, ev) in app
         .notifications
         .iter()
         .rev()
-        .skip(app.notif_scroll)
-        .take(budget)
         .enumerate()
+        .skip(skip)
+        .take(budget)
     {
-        // The top row is the one ↵ opens (see `App::notifications_key`).
-        let mark = if i == 0 { "▸ " } else { "  " };
+        let mark = if i == app.notif_sel { "▸ " } else { "  " };
+        // Unseen events keep a ● until the feed visit ends (they arrived while it was open).
+        let (dot, dot_style) = if ev.read {
+            ("  ", app.theme.muted())
+        } else {
+            ("● ", app.theme.needs_you())
+        };
+        let title_style = if ev.read {
+            notif_style(app, ev.kind)
+        } else {
+            notif_style(app, ev.kind).add_modifier(Modifier::BOLD)
+        };
         lines.push(Line::from(vec![
             Span::styled(mark, app.theme.accented()),
+            Span::styled(dot, dot_style),
             Span::styled(ev.when.format("%H:%M:%S").to_string(), app.theme.muted()),
             Span::raw("  "),
-            Span::styled(ev.title.clone(), notif_style(app, ev.kind)),
+            Span::styled(ev.title.clone(), title_style),
         ]));
         lines.push(Line::from(vec![
-            Span::raw("            "),
+            Span::raw("              "),
             Span::styled(ev.body.clone(), app.theme.dim()),
         ]));
     }
     f.render_widget(Paragraph::new(lines), rows[0]);
     f.render_widget(
         footer(
-            "↑↓ scroll · ↵ open lane · c clear  ·  1 fleet · ←/esc back · q quit",
+            "↑↓ move · ↵ open · t attach · d dismiss · c clear  ·  1 fleet · ←/esc back · q quit",
             app,
         ),
         rows[1],
@@ -1596,12 +1632,20 @@ fn footer(keys: &str, app: &App) -> Paragraph<'static> {
 }
 
 fn header_line(width: u16, left: &str, right: &str, app: &App) -> Line<'static> {
-    // The view title is the accent; the clock on the right is muted.
-    let used = left.chars().count() + right.chars().count();
+    // The view title is the accent; the clock on the right is muted. Unseen notifications get
+    // a ⚑ badge beside the clock, visible from every view (`5` opens the feed and clears it).
+    let unread = app.unread_notifs();
+    let badge = if unread > 0 {
+        format!("⚑ {unread} · ")
+    } else {
+        String::new()
+    };
+    let used = left.chars().count() + badge.chars().count() + right.chars().count();
     let pad = (width as usize).saturating_sub(used);
     Line::from(vec![
         Span::styled(left.to_string(), app.theme.header_style()),
         Span::raw(" ".repeat(pad)),
+        Span::styled(badge, app.theme.needs_you()),
         Span::styled(right.to_string(), app.theme.muted()),
     ])
 }

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -218,6 +218,16 @@ fn render_settings(f: &mut Frame, app: &App) {
         ("  · went idle", onoff(s.notify_idle), "space toggles"),
         ("  · sound", onoff(s.notify_sound), "space toggles"),
     ];
+    // Size the columns to the content so values and hints line up no matter how long a label is:
+    // the name column fits the widest label (+gap), the value column fits the default worktree
+    // template (the longest value). Longer user-typed values just overflow gracefully.
+    let name_w = items
+        .iter()
+        .map(|(n, _, _)| n.chars().count())
+        .max()
+        .unwrap_or(0)
+        + 2;
+    let val_w = 28usize;
     // Items start one row below the body top (after a leading blank) — record it for clicks.
     app.settings_geom.set(rows[1].y + 1);
     let mut lines = vec![Line::raw("")];
@@ -226,14 +236,14 @@ fn render_settings(f: &mut Frame, app: &App) {
         let marker = if selected { "▸" } else { " " };
         let row = if selected {
             Line::from(Span::styled(
-                format!("  {marker} {name:<18}{value:<22}  {hint}"),
+                format!("  {marker} {name:<name_w$}{value:<val_w$}  {hint}"),
                 app.theme.selected(),
             ))
         } else {
             Line::from(vec![
                 Span::raw(format!("  {marker} ")),
-                Span::styled(format!("{name:<18}"), app.theme.muted()),
-                Span::styled(format!("{value:<22}"), app.theme.accented()),
+                Span::styled(format!("{name:<name_w$}"), app.theme.muted()),
+                Span::styled(format!("{value:<val_w$}"), app.theme.accented()),
                 Span::styled(format!("  {hint}"), app.theme.muted()),
             ])
         };

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -139,6 +139,40 @@ async fn renders_fleet_with_a_registered_repo() {
         "miss text missing:\n{jump}"
     );
 
+    // Timeline: the density strip resamples to fill the terminal width; axis + correlation
+    // meter render.
+    use repomon_core::model::{Correlation, TimelineData, TimelineRow};
+    app.timeline = Some(TimelineData {
+        from: chrono::Utc::now() - chrono::Duration::days(30),
+        to: chrono::Utc::now(),
+        bucket_secs: 24 * 3600,
+        rows: vec![TimelineRow {
+            repo_id: 1,
+            repo_name: "alpha".into(),
+            density: vec![0, 1, 2, 3, 4, 5],
+        }],
+        correlations: vec![Correlation {
+            a: "alpha".into(),
+            b: "beta".into(),
+            windows: 5,
+            overlap: 0.42,
+        }],
+    });
+    app.view = View::Timeline;
+    let tl = render_to_string(&app, 100, 40).unwrap();
+    assert!(tl.contains("TIMELINE"), "header missing:\n{tl}");
+    assert!(tl.contains("CORRELATIONS"), "correlations missing:\n{tl}");
+    assert!(tl.contains("0.42 overlap"), "overlap missing:\n{tl}");
+    // 6 source buckets must stretch to fill ~all of the 100-col width, ending in a full block.
+    let strip = tl
+        .lines()
+        .find(|l| l.contains("alpha") && l.contains('█'))
+        .expect("density strip missing");
+    assert!(
+        strip.trim_end().chars().count() > 80,
+        "strip not stretched to width:\n{tl}"
+    );
+
     // Settings: columns line up even with the longest label and value present.
     app.settings.accent = "amber".into();
     app.settings.default_agent = "claude-work".into();

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -173,6 +173,48 @@ async fn renders_fleet_with_a_registered_repo() {
         "strip not stretched to width:\n{tl}"
     );
 
+    // Notifications: the unread ⚑ badge shows in every view's header; the feed renders a
+    // cursor (▸) on the selected row, an unread dot, the new-count, and the action footer.
+    use repomon_tui::notify::{NotifEvent, NotifKind};
+    app.notifications.push_back(NotifEvent {
+        when: chrono::Local::now(),
+        kind: NotifKind::NeedsYou,
+        lane_id: app.lanes[0].id,
+        session_id: None,
+        read: true,
+        title: "⏸ claude needs you — alpha".into(),
+        body: "main · “want me to continue?”".into(),
+    });
+    app.notifications.push_back(NotifEvent {
+        when: chrono::Local::now(),
+        kind: NotifKind::RateLimited,
+        lane_id: app.lanes[0].id,
+        session_id: None,
+        read: false,
+        title: "⏳ claude hit a usage limit — beta".into(),
+        body: "main · resets 06:00".into(),
+    });
+    app.view = View::Fleet;
+    let fl = render_to_string(&app, 100, 40).unwrap();
+    assert!(fl.contains("⚑ 1"), "unread badge missing:\n{fl}");
+    app.view = View::Notifications;
+    app.notif_sel = 1; // cursor on the older (read) event, not the top row
+    let nf = render_to_string(&app, 100, 40).unwrap();
+    assert!(
+        nf.contains("2 event(s) · 1 new"),
+        "new count missing:\n{nf}"
+    );
+    assert!(nf.contains("● "), "unread dot missing:\n{nf}");
+    assert!(nf.contains("t attach"), "action footer missing:\n{nf}");
+    let cursor_row = nf
+        .lines()
+        .find(|l| l.trim_start().starts_with('▸'))
+        .expect("cursor row missing");
+    assert!(
+        cursor_row.contains("needs you — alpha"),
+        "cursor not on the selected (older) event:\n{nf}"
+    );
+
     // Settings: columns line up even with the longest label and value present.
     app.settings.accent = "amber".into();
     app.settings.default_agent = "claude-work".into();

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -86,6 +86,41 @@ async fn renders_fleet_with_a_registered_repo() {
     );
     assert!(screen.contains("click select"), "footer missing:\n{screen}");
 
+    // The spawn picker lists the agents for the selected lane, with the default tagged and a
+    // PATH warning for an undetected command.
+    use repomon_core::model::AgentChoice;
+    use repomon_tui::keybinds::View;
+    app.nl_agents = vec![
+        AgentChoice {
+            name: "claude-code".into(),
+            command: "claude".into(),
+            detected: true,
+            custom: false,
+            default: true,
+        },
+        AgentChoice {
+            name: "codex".into(),
+            command: "codex".into(),
+            detected: false,
+            custom: false,
+            default: false,
+        },
+    ];
+    app.spawn_pick_idx = 0;
+    app.spawn_pick_lane = Some(app.lanes[0].id);
+    app.view = View::SpawnPick;
+    let pick = render_to_string(&app, 100, 40).unwrap();
+    assert!(
+        pick.contains("SPAWN AGENT"),
+        "picker header missing:\n{pick}"
+    );
+    assert!(pick.contains("claude-code"), "agent name missing:\n{pick}");
+    assert!(pick.contains("default"), "default tag missing:\n{pick}");
+    assert!(
+        pick.contains("not on PATH"),
+        "PATH warning missing:\n{pick}"
+    );
+
     server.abort();
     let _ = std::fs::remove_file(&sock);
 }

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -121,6 +121,33 @@ async fn renders_fleet_with_a_registered_repo() {
         "PATH warning missing:\n{pick}"
     );
 
+    // Settings: columns line up even with the longest label and value present.
+    app.settings.accent = "amber".into();
+    app.settings.default_agent = "claude-work".into();
+    app.settings.auto_continue = true;
+    app.settings.auto_continue_message = "continue".into();
+    app.settings.worktree_template = "~/code/{repo}-wt/{branch}".into();
+    app.settings.spawn_prompt = true;
+    app.settings.notify_enabled = true;
+    app.view = View::Settings;
+    let st = render_to_string(&app, 120, 40).unwrap();
+    // The long label must not collide with its value (the old "spawnon" bug), and the value
+    // column must start at the same screen column on every row.
+    assert!(!st.contains("spawnon"), "label/value collision:\n{st}");
+    // Value column starts at the same screen column on every row. Measure the column in cells
+    // (chars), not bytes, so the multi-byte ▸ marker on the selected row doesn't skew it. Use
+    // values that are unique (not a word inside any label) so we match the value, not the label.
+    let val_col = |row_label: &str, value: &str| {
+        let line = st.lines().find(|l| l.contains(row_label)).unwrap();
+        let byte = line.find(value).unwrap();
+        line[..byte].chars().count()
+    };
+    let amber = val_col("accent", "amber");
+    let agent = val_col("default agent", "claude-work");
+    let template = val_col("worktree template", "~/code");
+    assert_eq!(amber, agent, "value column misaligned (agent row):\n{st}");
+    assert_eq!(amber, template, "value column misaligned (template):\n{st}");
+
     server.abort();
     let _ = std::fs::remove_file(&sock);
 }

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -121,6 +121,24 @@ async fn renders_fleet_with_a_registered_repo() {
         "PATH warning missing:\n{pick}"
     );
 
+    // The lane switcher lists every lane with an empty query and reports a miss for a query
+    // that matches nothing.
+    app.jump_query = String::new();
+    app.jump_idx = 0;
+    app.view = View::LaneJump;
+    let jump = render_to_string(&app, 100, 40).unwrap();
+    assert!(
+        jump.contains("FIND LANE"),
+        "switcher header missing:\n{jump}"
+    );
+    assert!(jump.contains(&repo_name), "lane row missing:\n{jump}");
+    app.jump_query = "zzzznope".into();
+    let jump = render_to_string(&app, 100, 40).unwrap();
+    assert!(
+        jump.contains("no lanes match"),
+        "miss text missing:\n{jump}"
+    );
+
     // Settings: columns line up even with the longest label and value present.
     app.settings.accent = "amber".into();
     app.settings.default_agent = "claude-work".into();


### PR DESCRIPTION
## Summary

Adds **agent awareness** to repomon — three related features plus fixes, on top of the recent `lane.list` perf work.

### 1. Agent state-change notifications
- The TUI watches each lane's agent status across refreshes and fires on meaningful transitions: **needs you / finished a turn**, **hit a usage limit** (with reset time), **auto-resumed**, **went idle**.
- Delivery: a native macOS popup (`osascript`) + a reliably audible chime (`afplay`), an in-app banner, and a **Notifications history view** (`5`).
- Each trigger is individually **toggleable in Settings** (`,`), persisted to `config.toml`.
- Edge-detection lives in the TUI (it already holds every lane's status each refresh) and is keyed **per agent session** (Claude transcript id), so two agents sharing a worktree fire independent alerts; the 1s tick refreshes lanes in all views; the first snapshot only seeds (no startup storm); debounce is keyed per `(lane, session, kind)`.

### 2. Worktree-isolated subagents now visible
- Claude Code farms out parallel subagents, each in its own temp git worktree; the worktree showed up as a lane but the agent inside it didn't — those subagents run in the parent process and leave **no transcript or process** in the worktree for the detector to find.
- Added a **file-activity proxy**: the per-worktree `gix status` walk also captures the newest changed-file mtime (`WorktreeState.last_change_at`); a **non-main** worktree active within ~90s with no identified agent surfaces as an inferred **`◐ active`** session (`AgentSession.inferred`), rendered distinctly so it never claims a specific agent and never drives named alerts.

### 3. Spawn-agent picker
- Pressing **`e`** now opens a quick picker (agent list with PATH detection, default highlighted; ↑↓ or a number key to choose) instead of always spawning the configured default. `e ↵` still spawns the default fast; `e 3` picks another.
- It's a toggle — **"ask which agent on spawn"** (`spawn_prompt`, default on) — flip it off to restore instant default-spawn.

### 4. Fleet triage (managing many agents at once)
- **`g` cycles** through every lane blocked on you (waiting, or rate-limited with no auto-continue coming) — from Fleet, Split, Focus (retargets in place), and Grid (hops tiles). While a notification banner is fresh, the first press jumps to the lane that just alerted.
- **Attention-sorted Fleet**: within each repo group, pinned > waiting > stuck-rate-limited > running > recency (stable sort; the cursor is remapped by lane id so the 1s refresh can't yank the selection). **`!`** toggles an urgent-only filter; the Grid reuses the same comparator.
- **`f` fuzzy lane switcher** from any live view: dependency-free subsequence scoring over `repo/worktree` and branch, ranked by score → attention → recency; ↵ opens the lane in Focus.
- **Actionable notifications**: each event carries its lane id; ↵ on the top (▸) event in the feed jumps to that lane, clearing any filter hiding it.

### 5. Multi-agent lanes + repo removal
- **Several agents side by side in one lane**: spawning no longer kills the running agent — each agent gets its own tmux slot window (`lane-7`, `lane-7-2`, …). Sessions are paired to their windows, and **Tab genuinely switches agents**: the pane, insert-mode typing, deep capture, paste, stop, and ↵ attach all follow the selected session. Exact `session:=window` targeting prevents `lane-1` resolving onto `lane-1-2`.
- **Repo removal from the TUI**: in the add-repo browser, `x x` (two-press confirm) unregisters a `+` repo — same as `repomon remove`; files, worktrees, and running agents on disk are untouched.

### 6. Timeline polish + terminal title
- The timeline chart now fills the terminal: bucket count derives from the width at load, `Event::Resize` refetches, and the renderer max-pool resamples rows so the strip adapts instantly between refetches. A time axis (start/mid/now) sits under the strip.
- Density renders as a brightness ramp of the configured **accent** (`Theme::density`), so the chart matches the UI hue; `mono` keeps plain glyphs. Correlations get aligned columns + a 10-cell accent meter.
- The terminal window title tracks the selection (`repomon · repo/worktree`) via OSC 2, re-asserted after tmux attaches, reset on exit.

### 6. Timeline facelift + terminal title
- **Accent-shaded density chart**: a 6-step ramp of the configured accent colors the commit-density blocks (mono accent keeps plain glyphs), with a date-range header, a start/mid/now time axis, and a 10-cell overlap meter per correlation.
- **Resize friendly**: bucket count now follows terminal width (24–240, per-zoom minimum durations); the renderer max-pool resamples rows to the live width so the chart fills the screen and adapts instantly, and a resize event refetches at the new resolution.
- **Terminal title** (OSC 2) shows the open lane — `repomon · repo/worktree` — re-asserted after tmux attaches, cleared on exit.

### 7. Notifications v2: the why, interactive feed, coalescing, click-to-focus
- **Show the why**: bodies now carry the agent's actual last message — the question it ended its turn on, parsed from the transcript tail (`AgentSession.last_message`) — instead of just your original ask (which stays as the fallback). Multi-agent lanes tag which one fired (`agent 2/3`).
- **Interactive feed**: the Notifications view gets a real cursor — `↵` opens the exact session that fired (not just the lane), `t` attaches straight into its tmux pane, `d` dismisses one, `c` clears all. Events are tracked **unread** until the feed is opened, with a `⚑ N` badge in every view's header.
- **Burst coalescing**: ≥2 alerts in one refresh collapse into a single popup/banner (`⏸ 3 agents need you — a/main · b/x · +1 more`); each event still lands individually (and unread) in the feed. New `G` key = `g` + attach into the alerting agent's pane.
- **Click-to-focus popups**: when `terminal-notifier` is installed, clicking the macOS popup activates your terminal (`$TERM_PROGRAM` → bundle id; iTerm2/Terminal/WezTerm/ghostty/VS Code/kitty); plain `osascript` popups otherwise.
- All three behaviors are **Settings toggles** (default on): *show agent's question*, *coalesce bursts*, *click focuses terminal* — persisted via `config.set` like the other notify switches.
- **Permission prompts now alert**: a transcript that ends in a tool call reads *Running*, but the pane may be sitting on "Do you want to proceed? ❯ 1. Yes …" with nothing in the JSONL to say so. The daemon now sniffs managed Running panes during `lane.list` (`agent::prompt::detect_pending_prompt` — bottom-most ❯-cursor numbered menu, anchored on the question line, usage-limit menu excluded) and flips those sessions to **Waiting** with a box-header summary (`Bash command — Do you want to proceed?`) as the why — so permission asks, plan approvals, trust dialogs, and option questions all fire "needs you". Verified live: a staged dialog flipped its lane to ⏸ in one refresh and reverted on close.

### Fixes
- **Auto-continue reads the usage-limit menu before selecting**: Claude moves the menu options around between occurrences, so the old blind Enter (assuming "Stop and wait…" was the pre-selected option 1) could confirm "Upgrade your plan" instead. The watcher now parses the menu from the pane (cursor `❯`, option numbers, ANSI-stripped, anchored on the wait phrase so ordinary numbered output never matches) and sends the arrow/Enter sequence to the wait option wherever it sits — number-key fallback when no cursor is visible.
- Notification **sound** made actually audible — `afplay`, not the unreliable `osascript … sound name` (silently dropped on recent macOS); plus an instant chime preview when you enable it in Settings.
- Settings **column alignment** (long labels/values no longer collide or shove the hints).

## Verification
- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all`, **131 tests** (added: notification transitions, per-session diffing — independent streams, disappearance, fallback→transcript handoff — worktree file-activity detection, spawn-picker render, settings alignment, AppleScript escaping, attention ranking, fuzzy scoring, lane-switcher render, tmux slot-window filtering + a live side-by-side spawn/exact-kill roundtrip).
- Verified live on macOS: `config.get`/`set` round-trips the new fields; a real subagent worktree rendered `◐ active`; the chime is audible.
- Ran a **6-dimension adversarial self-review** over the diff (review → refute each finding); fixed all four confirmed correctness issues (debounce masking, startup-storm seeding, unbounded scroll, map growth).

## Per-session notifications (follow-up, now included)
- Originally edge-detection aggregated status **per lane**, so a "needs you" could be masked by a lane-mate's higher-priority "rate-limited". The final commit moves detection to **per agent session**: each real session keys on its transcript id (with a fallback sentinel for the single no-transcript managed session), disappearance of an active session fires Idle, and the popup names the specific agent. A guard suppresses the spurious Idle when a managed spawn's placeholder hands off to its freshly-parseable transcript.
- Intentional trade-off: a lane with N agents can fire N alerts in quick succession (the banner shows the last; history keeps all). *Resolved in section 7: simultaneous alerts now coalesce into one popup.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)








