### PR TITLE
Remote access: WebSocket bridge, daemon notifications, APNs push, pairing CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # macOS
 .DS_Store
+
+# Secrets that must never land in the repo (APNs signing keys live beside the config)
+*.p8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2557,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "qrcode",
  "ratatui",
  "repomon-core",
  "repomon-daemon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "gix",
  "ratatui",
  "repomon-core",
  "repomon-daemon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "a2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f279fc8b1f1a64138f0f4b9cda9be488ae35bc2f8556c7ffe60730f1c07d005a"
+dependencies = [
+ "base64 0.21.7",
+ "erased-serde",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "parking_lot",
+ "pem",
+ "ring",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,10 +146,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -476,6 +518,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -1608,6 +1659,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1761,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1794,62 @@ name = "human_format"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2154,6 +2303,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2529,7 @@ dependencies = [
 name = "repomon-daemon"
 version = "0.1.0"
 dependencies = [
+ "a2",
  "chrono",
  "clap",
  "futures",
@@ -2398,6 +2558,20 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2449,6 +2623,49 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2700,6 +2917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3038,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +3058,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2866,6 +3113,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2927,6 +3180,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -3016,6 +3275,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3312,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3153,6 +3427,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,6 +3541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3586,6 +3887,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zlib-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,10 +568,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -579,8 +644,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -608,13 +678,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1599,6 +1681,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "human_format"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,9 +2236,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -2230,11 +2372,13 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "futures",
  "repomon-core",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2672,6 +2816,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2927,22 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3394,6 +3566,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
+tokio-tungstenite = "0.29"
 futures = "0.3"
 plist = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ clap = { version = "4.5", features = ["derive"] }
 # --- tui ---
 ratatui = "0.29"
 ansi-to-tui = "7"
+qrcode = { version = "0.14", default-features = false }
 # --- cli / app ergonomics ---
 anyhow = "1"
 # --- dev ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-tungstenite = "0.29"
+a2 = { version = "0.10", default-features = false, features = ["ring"] }
 futures = "0.3"
 plist = "1"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/repomon-core/migrations/0003_devices.sql
+++ b/crates/repomon-core/migrations/0003_devices.sql
@@ -1,0 +1,6 @@
+-- Push-notification device registrations (the iOS companion app). One row per device token;
+-- re-registering refreshes the timestamp, APNs-reported dead tokens are evicted by the daemon.
+CREATE TABLE IF NOT EXISTS devices (
+    device_token  TEXT PRIMARY KEY,
+    registered_at TEXT NOT NULL
+);

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -59,6 +59,7 @@ impl TranscriptSummary {
             tool_call_count: self.tool_call_count,
             title: self.title,
             last_message: self.last_message,
+            pending_prompt: None, // set by the overlay's pane sniffer
             status: self.status,
             external: false, // overlay flips this based on tmux ownership
             session_id: self.session_id,

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -506,6 +506,147 @@ fn truncate(s: &str, n: usize) -> String {
     }
 }
 
+/// How much of a transcript's tail to read for the chat view — bounds the cost of polling a
+/// long session (this file can be many MB).
+const TAIL_BYTES: u64 = 512 * 1024;
+/// Cap per-item text so payloads stay bounded (full messages, not titles).
+const ITEM_TEXT_MAX: usize = 4000;
+
+/// The last `max_items` conversation items from a transcript: user/assistant messages with
+/// their full unwrapped text, tool calls between messages aggregated into one "tools" item
+/// ("Bash ×2 · Edit"). The mobile client renders these natively instead of a desktop-width
+/// pane capture. Only the file tail is read.
+pub fn transcript_tail(path: &Path, max_items: usize) -> Vec<crate::model::TranscriptItem> {
+    use crate::model::TranscriptItem;
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let start = len.saturating_sub(TAIL_BYTES);
+    if start > 0 && f.seek(SeekFrom::Start(start)).is_err() {
+        return Vec::new();
+    }
+    let mut bytes = Vec::new();
+    if f.read_to_end(&mut bytes).is_err() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    let mut lines = text.lines();
+    if start > 0 {
+        lines.next(); // the seek likely landed mid-line — drop the partial one
+    }
+
+    let mut items: Vec<TranscriptItem> = Vec::new();
+    // Tool calls accumulated since the last message, in first-use order.
+    let mut tools: Vec<(String, u32)> = Vec::new();
+    let mut tools_at: Option<DateTime<Utc>> = None;
+
+    fn flush_tools(
+        items: &mut Vec<crate::model::TranscriptItem>,
+        tools: &mut Vec<(String, u32)>,
+        at: &mut Option<DateTime<Utc>>,
+    ) {
+        if tools.is_empty() {
+            return;
+        }
+        let text = tools
+            .iter()
+            .map(|(name, n)| {
+                if *n > 1 {
+                    format!("{name} ×{n}")
+                } else {
+                    name.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" · ");
+        items.push(crate::model::TranscriptItem {
+            role: "tools".into(),
+            text,
+            at: at.take(),
+        });
+        tools.clear();
+    }
+
+    for line in lines {
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let at = v
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|d| d.with_timezone(&Utc));
+        match v.get("type").and_then(Value::as_str) {
+            Some("assistant") => {
+                let Some(arr) = v
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(Value::as_array)
+                else {
+                    continue;
+                };
+                // Blocks in order: a text block flushes pending tools first (they happened
+                // before it), tool_use blocks accumulate.
+                for block in arr {
+                    match block.get("type").and_then(Value::as_str) {
+                        Some("text") => {
+                            if let Some(t) = block.get("text").and_then(Value::as_str) {
+                                let t = t.trim();
+                                if !t.is_empty() {
+                                    flush_tools(&mut items, &mut tools, &mut tools_at);
+                                    items.push(TranscriptItem {
+                                        role: "assistant".into(),
+                                        text: truncate(t, ITEM_TEXT_MAX),
+                                        at,
+                                    });
+                                }
+                            }
+                        }
+                        Some("tool_use") => {
+                            let name = block
+                                .get("name")
+                                .and_then(Value::as_str)
+                                .unwrap_or("tool")
+                                .to_string();
+                            match tools.iter_mut().find(|(n, _)| *n == name) {
+                                Some((_, n)) => *n += 1,
+                                None => tools.push((name, 1)),
+                            }
+                            tools_at = at;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Some("user") => {
+                // Real user text only — tool_result carriers return None here.
+                if let Some(t) = user_text(&v) {
+                    let t = t.trim().to_string();
+                    if !t.is_empty() {
+                        flush_tools(&mut items, &mut tools, &mut tools_at);
+                        items.push(TranscriptItem {
+                            role: "user".into(),
+                            text: truncate(&t, ITEM_TEXT_MAX),
+                            at,
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    flush_tools(&mut items, &mut tools, &mut tools_at);
+
+    if items.len() > max_items {
+        items.drain(..items.len() - max_items);
+    }
+    items
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -638,6 +779,48 @@ mod tests {
         assert_eq!(s.title.as_deref(), Some("add tests"));
         // The "why" behind a needs-you alert: the agent's final message text.
         assert_eq!(s.last_message.as_deref(), Some("Done — want me to also..."));
+    }
+
+    #[test]
+    fn transcript_tail_builds_chat_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let lines = [
+            r#"{"type":"user","timestamp":"2026-06-12T10:00:00Z","message":{"content":"add tests"}}"#,
+            // Text before tools within one entry keeps its position.
+            r#"{"type":"assistant","timestamp":"2026-06-12T10:00:05Z","message":{"content":[{"type":"text","text":"On it."},{"type":"tool_use","name":"Bash"}]}}"#,
+            // Tool-result carrier — not a user message.
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}"#,
+            r#"{"type":"assistant","timestamp":"2026-06-12T10:00:10Z","message":{"content":[{"type":"tool_use","name":"Bash"},{"type":"tool_use","name":"Edit"}]}}"#,
+            r#"{"type":"assistant","timestamp":"2026-06-12T10:01:00Z","message":{"content":[{"type":"text","text":"Done — tests pass."}]}}"#,
+        ];
+        let path = write_transcript(dir.path(), "s.jsonl", &lines);
+        let items = transcript_tail(&path, 50);
+        let view: Vec<(&str, &str)> = items
+            .iter()
+            .map(|i| (i.role.as_str(), i.text.as_str()))
+            .collect();
+        assert_eq!(
+            view,
+            vec![
+                ("user", "add tests"),
+                ("assistant", "On it."),
+                ("tools", "Bash ×2 · Edit"),
+                ("assistant", "Done — tests pass."),
+            ]
+        );
+        assert!(items[0].at.is_some());
+        assert!(
+            items[2].at.is_some(),
+            "tools item carries the last tool's timestamp"
+        );
+
+        // The limit keeps the newest items.
+        let last_two = transcript_tail(&path, 2);
+        assert_eq!(last_two.len(), 2);
+        assert_eq!(last_two[1].text, "Done — tests pass.");
+
+        // Missing file → empty, not an error.
+        assert!(transcript_tail(&dir.path().join("nope.jsonl"), 10).is_empty());
     }
 
     #[test]

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -77,6 +77,8 @@ pub struct Config {
     /// Remote access: the WebSocket JSON-RPC bridge that companion apps (iOS) connect
     /// through. Off by default; `repomon remote enable` fills it in.
     pub remote: RemoteConfig,
+    /// APNs push for the iOS companion: alerts reach the phone even with the app closed.
+    pub push: PushConfig,
 }
 
 impl Default for Config {
@@ -103,6 +105,7 @@ impl Default for Config {
             notify_click_focus: true,
             repos: HashMap::new(),
             remote: RemoteConfig::default(),
+            push: PushConfig::default(),
         }
     }
 }
@@ -112,6 +115,25 @@ impl Default for Config {
 #[serde(default)]
 pub struct RepoConfig {
     pub worktree_template: Option<String>,
+}
+
+/// APNs (Apple push) credentials for the iOS companion. The daemon sends pushes directly to
+/// Apple over HTTP/2 using a `.p8` signing key from the Apple Developer account — keep the key
+/// file beside the config (e.g. `~/.config/repomon/AuthKey_XXXX.p8`), never in a repo. Push is
+/// active only when every field is set and at least one device has registered.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PushConfig {
+    /// Apple Developer team id (10 chars).
+    pub team_id: Option<String>,
+    /// The key id of the `.p8` APNs auth key.
+    pub key_id: Option<String>,
+    /// Path to the `.p8` key file.
+    pub p8_path: Option<PathBuf>,
+    /// The app's bundle id (the APNs topic), e.g. `com.azaleas.repomon`.
+    pub bundle_id: Option<String>,
+    /// Use the APNs sandbox endpoint (Xcode/development builds) instead of production.
+    pub sandbox: bool,
 }
 
 /// Remote-access (companion app) settings: a WebSocket listener speaking the same JSON-RPC

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -74,6 +74,9 @@ pub struct Config {
     pub notify_click_focus: bool,
     /// Per-repo overrides, keyed by repo display name.
     pub repos: HashMap<String, RepoConfig>,
+    /// Remote access: the WebSocket JSON-RPC bridge that companion apps (iOS) connect
+    /// through. Off by default; `repomon remote enable` fills it in.
+    pub remote: RemoteConfig,
 }
 
 impl Default for Config {
@@ -99,6 +102,7 @@ impl Default for Config {
             notify_coalesce: true,
             notify_click_focus: true,
             repos: HashMap::new(),
+            remote: RemoteConfig::default(),
         }
     }
 }
@@ -108,6 +112,20 @@ impl Default for Config {
 #[serde(default)]
 pub struct RepoConfig {
     pub worktree_template: Option<String>,
+}
+
+/// Remote-access (companion app) settings: a WebSocket listener speaking the same JSON-RPC
+/// protocol as the Unix socket, gated by a bearer token. Bind it to a private address —
+/// typically the machine's Tailscale IP — never the open internet.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RemoteConfig {
+    /// Serve the WebSocket bridge.
+    pub enabled: bool,
+    /// Bind address, e.g. the tailnet IP: `"100.101.102.103:7878"`.
+    pub bind: Option<String>,
+    /// The bearer token clients must present at the WebSocket handshake.
+    pub token: Option<String>,
 }
 
 impl Config {

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod git;
 pub mod indexer;
 pub mod lane;
 pub mod model;
+pub mod notify;
 pub mod protocol;
 pub mod registry;
 pub mod service;

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -259,6 +259,11 @@ pub struct AgentSession {
     /// ended a turn. Gives needs-you notifications their "why".
     #[serde(default)]
     pub last_message: Option<String>,
+    /// Set only when the pane is sitting on an interactive dialog (permission prompt, plan
+    /// approval, option question): the dialog's summary. Clients show approve/menu controls
+    /// exactly when this is present — a plain end-of-turn `Waiting` has none.
+    #[serde(default)]
+    pub pending_prompt: Option<String>,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -369,6 +369,19 @@ pub struct TimelineData {
     pub correlations: Vec<Correlation>,
 }
 
+/// One conversation item from an agent transcript, rendered for clients that lay text out
+/// themselves (the mobile chat view): a user or assistant message with the full *unwrapped*
+/// text, or an aggregated run of tool calls between messages.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TranscriptItem {
+    /// "user" | "assistant" | "tools".
+    pub role: String,
+    /// Message text, or for "tools" a compact summary ("Bash ×2 · Edit").
+    pub text: String,
+    /// The entry's timestamp, when the transcript records one.
+    pub at: Option<DateTime<Utc>>,
+}
+
 /// A spawnable agent choice: a built-in kind (detected on PATH) or a configured custom one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentChoice {

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -1,0 +1,576 @@
+//! Agent state-change notifications: the pure, client-agnostic heart.
+//!
+//! Both the TUI (local popups) and the daemon (remote `event.notification` broadcasts + push)
+//! watch per-session agent statuses across refreshes and alert on meaningful transitions.
+//! Everything shared lives here: session keying, the status diff, transition classification,
+//! and the `(title, body)` text composition. Delivery (osascript, APNs, banners) stays with
+//! each client.
+
+use std::collections::{HashMap, HashSet};
+
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+
+use crate::model::{AgentSession, AgentStatus, Lane, LaneId};
+
+/// The kind of agent state-change that fired a notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifKind {
+    /// Agent finished its turn / is waiting on you.
+    NeedsYou,
+    /// Agent paused on a usage/rate limit.
+    RateLimited,
+    /// A rate-limited agent was auto-continued and resumed work.
+    Resumed,
+    /// Agent went idle or its session ended.
+    Idle,
+}
+
+impl NotifKind {
+    pub fn glyph(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "⏸",
+            NotifKind::RateLimited => "⏳",
+            NotifKind::Resumed => "▶",
+            NotifKind::Idle => "○",
+        }
+    }
+    fn verb(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "needs you",
+            NotifKind::RateLimited => "hit a usage limit",
+            NotifKind::Resumed => "resumed",
+            NotifKind::Idle => "went idle",
+        }
+    }
+    fn verb_plural(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "need you",
+            NotifKind::RateLimited => "hit a usage limit",
+            NotifKind::Resumed => "resumed",
+            NotifKind::Idle => "went idle",
+        }
+    }
+}
+
+/// Identifies one real agent session within a lane across refreshes.
+///
+/// Transcript-backed sessions key on the Claude session id (the transcript filename stem),
+/// which is stable across polls. `claude --resume` may continue the same logical work in a new
+/// transcript; that reads as one session vanishing and another appearing — acceptable noise. A
+/// lane has at most one real session *without* a transcript id per snapshot (the managed
+/// no-transcript placeholder or the generic process monitor — mutually exclusive branches in
+/// the daemon's `overlay_agents`), so a single `Fallback` sentinel covers it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SessKey {
+    Transcript(String),
+    Fallback,
+}
+
+/// Key/status pairs for one lane's *real* agent sessions. Inferred "file activity" placeholders
+/// are dropped so they never drive named alerts. On a (theoretically impossible) duplicate key,
+/// the higher-priority status wins — the same order the old per-lane rollup used.
+pub fn session_statuses(
+    lane_id: LaneId,
+    sessions: &[AgentSession],
+) -> Vec<((LaneId, SessKey), AgentStatus)> {
+    let mut out: Vec<((LaneId, SessKey), AgentStatus)> = Vec::new();
+    for s in sessions.iter().filter(|s| !s.inferred) {
+        let key = (
+            lane_id,
+            s.session_id
+                .clone()
+                .map(SessKey::Transcript)
+                .unwrap_or(SessKey::Fallback),
+        );
+        match out.iter_mut().find(|(k, _)| *k == key) {
+            Some((_, st)) if status_priority(s.status) < status_priority(*st) => *st = s.status,
+            Some(_) => {}
+            None => out.push((key, s.status)),
+        }
+    }
+    out
+}
+
+/// Notification priority of a status (lower = more urgent).
+pub fn status_priority(s: AgentStatus) -> usize {
+    use AgentStatus::*;
+    [RateLimited, Waiting, Running, Idle, Ended]
+        .iter()
+        .position(|&x| x == s)
+        .unwrap_or(usize::MAX)
+}
+
+/// Diff the previous and current per-session status maps into the notifications to fire.
+///
+/// Sessions present in `now` are edge-detected against their previous status. Sessions that
+/// vanished fire as a transition to `None` (→ Idle if they were active), except when their
+/// whole lane is gone (deleting a lane isn't an agent going quiet) or when a lane's `Fallback`
+/// key was handed off to a transcript-backed key (`lanes_with_managed`): the managed
+/// no-transcript placeholder disappears the moment the agent's transcript becomes parseable,
+/// and firing Idle there would alert on every spawn.
+pub fn diff_session_transitions(
+    prev: &HashMap<(LaneId, SessKey), AgentStatus>,
+    now: &HashMap<(LaneId, SessKey), AgentStatus>,
+    live_lanes: &HashSet<LaneId>,
+    lanes_with_managed: &HashSet<LaneId>,
+) -> Vec<((LaneId, SessKey), NotifKind)> {
+    let mut out = Vec::new();
+    for (key, &status) in now {
+        let was = prev.get(key).copied();
+        if was == Some(status) {
+            continue;
+        }
+        if let Some(kind) = transition_kind(was, Some(status)) {
+            out.push((key.clone(), kind));
+        }
+    }
+    for (key, &was) in prev {
+        if now.contains_key(key) || !live_lanes.contains(&key.0) {
+            continue;
+        }
+        if key.1 == SessKey::Fallback && lanes_with_managed.contains(&key.0) {
+            continue;
+        }
+        if let Some(kind) = transition_kind(Some(was), None) {
+            out.push((key.clone(), kind));
+        }
+    }
+    out
+}
+
+/// Resolve a session key back to the lane's session, for composing the notification text.
+/// `None` when the session vanished (i.e. its disappearance was the trigger).
+pub fn session_by_key<'a>(lane: &'a Lane, key: &SessKey) -> Option<&'a AgentSession> {
+    lane.agent_sessions
+        .iter()
+        .filter(|s| !s.inferred)
+        .find(|s| match key {
+            SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
+            SessKey::Fallback => s.session_id.is_none(),
+        })
+}
+
+/// Which of the lane's real sessions `key` resolves to: `(index, count)`, for the
+/// "agent 2/3" tag in multi-agent lanes. `None` when the session vanished.
+pub fn slot_by_key(lane: &Lane, key: &SessKey) -> Option<(usize, usize)> {
+    let real: Vec<&AgentSession> = lane.agent_sessions.iter().filter(|s| !s.inferred).collect();
+    let i = real.iter().position(|s| match key {
+        SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
+        SessKey::Fallback => s.session_id.is_none(),
+    })?;
+    Some((i, real.len()))
+}
+
+/// Map a session's status transition to the notification it should fire, if any. `None` means
+/// the session was absent from that snapshot. Priority resolves cases like
+/// `Running → RateLimited` to the limit.
+pub fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> Option<NotifKind> {
+    use AgentStatus::*;
+    match (prev, now) {
+        // Hit a usage limit.
+        (p, Some(RateLimited)) if p != Some(RateLimited) => Some(NotifKind::RateLimited),
+        // Auto-resumed after a limit.
+        (Some(RateLimited), Some(Running)) => Some(NotifKind::Resumed),
+        // Finished its turn / needs you.
+        (p, Some(Waiting)) if p != Some(Waiting) => Some(NotifKind::NeedsYou),
+        // Was active, now quiet (idle / ended / the session went away).
+        (Some(Running) | Some(Waiting), Some(Idle) | Some(Ended) | None) => Some(NotifKind::Idle),
+        _ => None,
+    }
+}
+
+/// Build the `(title, body)` for a notification about one of `lane`'s sessions. The body
+/// carries the detail that makes the alert actionable: branch, which of the lane's
+/// side-by-side agents fired (`slot` = (index, count), tagged only when several run), the
+/// *why* — the agent's actual last message when `show_why` is on (falling back to what you
+/// originally asked) — tool count, and any reset time. `sess` is `None` when the session
+/// vanished from the snapshot (its disappearance was the trigger) — the text degrades to a
+/// generic "agent" line rather than borrowing another session's name and title.
+pub fn compose(
+    kind: NotifKind,
+    lane: &Lane,
+    sess: Option<&AgentSession>,
+    slot: Option<(usize, usize)>,
+    show_why: bool,
+) -> (String, String) {
+    let agent = sess
+        .map(|s| s.agent.short().to_string())
+        .unwrap_or_default();
+    let agent = if agent.is_empty() {
+        "agent".into()
+    } else {
+        agent
+    };
+    let title = format!(
+        "{} {} {} — {}",
+        kind.glyph(),
+        agent,
+        kind.verb(),
+        lane.repo.name
+    );
+
+    let mut parts = vec![lane
+        .state
+        .branch
+        .clone()
+        .unwrap_or_else(|| lane.worktree.name.clone())];
+    if let Some((i, n)) = slot {
+        if n > 1 {
+            parts.push(format!("agent {}/{}", i + 1, n));
+        }
+    }
+    let why = show_why
+        .then(|| sess.and_then(|s| s.last_message.as_deref()))
+        .flatten();
+    if let Some(t) = why.or_else(|| sess.and_then(|s| s.title.as_deref())) {
+        let t = t.trim();
+        if !t.is_empty() {
+            parts.push(format!("“{}”", truncate(t, 100)));
+        }
+    }
+    if let Some(s) = sess {
+        if s.tool_call_count > 0 {
+            parts.push(format!("{} tools", s.tool_call_count));
+        }
+    }
+    if kind == NotifKind::RateLimited {
+        if let Some(r) = sess.and_then(|s| s.resume_at) {
+            parts.push(format!(
+                "resets {}",
+                r.with_timezone(&Local).format("%H:%M")
+            ));
+        }
+    }
+    (title, parts.join(" · "))
+}
+
+/// One popup for a burst of simultaneous alerts: the title counts them (with the kind's glyph
+/// and verb when the whole burst is one kind, a generic ⚑ otherwise), the body lists the first
+/// few lanes. `fires` pairs each alert's `repo/worktree` label with its kind.
+pub fn compose_burst(fires: &[(String, NotifKind)]) -> (String, String) {
+    let n = fires.len();
+    let first = fires.first().map(|(_, k)| *k);
+    let uniform = fires.iter().all(|(_, k)| Some(*k) == first);
+    let title = match (uniform, first) {
+        (true, Some(k)) => format!("{} {} agents {}", k.glyph(), n, k.verb_plural()),
+        _ => format!("⚑ {n} agents need attention"),
+    };
+    let mut body = fires
+        .iter()
+        .take(3)
+        .map(|(l, _)| l.as_str())
+        .collect::<Vec<_>>()
+        .join(" · ");
+    if n > 3 {
+        body.push_str(&format!(" · +{} more", n - 3));
+    }
+    (title, body)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AgentKind, Repo, Worktree, WorktreeState};
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    /// A minimal real-or-inferred session, mirroring the daemon's `overlay_agents` literals.
+    fn sess(session_id: Option<&str>, status: AgentStatus, inferred: bool) -> AgentSession {
+        AgentSession {
+            id: 0,
+            agent: AgentKind::ClaudeCode,
+            repo_id: 1,
+            worktree_id: None,
+            started_at: Utc::now(),
+            last_activity_at: Utc::now(),
+            ended_at: None,
+            manifest_path: PathBuf::new(),
+            tool_call_count: 0,
+            title: None,
+            status,
+            external: false,
+            session_id: session_id.map(str::to_string),
+            resume_at: None,
+            inferred,
+            tmux_window: None,
+            last_message: None,
+        }
+    }
+
+    fn lane() -> Lane {
+        let head = gix::ObjectId::null(gix::hash::Kind::Sha1);
+        Lane {
+            id: 7,
+            repo: Repo {
+                id: 1,
+                path: "/code/alpha".into(),
+                name: "alpha".into(),
+                added_at: Utc::now(),
+                worktree_root_template: None,
+            },
+            worktree: Worktree {
+                id: 1,
+                repo_id: 1,
+                path: "/code/alpha".into(),
+                branch: Some("main".into()),
+                head,
+                is_main: true,
+                name: "main".into(),
+            },
+            state: WorktreeState {
+                worktree_id: 1,
+                head,
+                branch: Some("feat/x".into()),
+                upstream: None,
+                ahead: 0,
+                behind: 0,
+                dirty: Default::default(),
+                last_commit_at: None,
+                locked: false,
+                prunable: false,
+                last_change_at: None,
+            },
+            agent_sessions: vec![],
+            last_activity_at: Utc::now(),
+            pinned: false,
+        }
+    }
+
+    #[test]
+    fn notification_transitions() {
+        use AgentStatus::*;
+        // The headline alerts.
+        assert_eq!(
+            transition_kind(Some(Running), Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        assert_eq!(
+            transition_kind(None, Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        assert_eq!(
+            transition_kind(Some(Running), Some(RateLimited)),
+            Some(NotifKind::RateLimited)
+        );
+        assert_eq!(
+            transition_kind(Some(RateLimited), Some(Running)),
+            Some(NotifKind::Resumed)
+        );
+        // Gave up on the limit and now needs you.
+        assert_eq!(
+            transition_kind(Some(RateLimited), Some(Waiting)),
+            Some(NotifKind::NeedsYou)
+        );
+        // Went quiet (idle / ended / the agent went away).
+        assert_eq!(
+            transition_kind(Some(Running), Some(Idle)),
+            Some(NotifKind::Idle)
+        );
+        assert_eq!(transition_kind(Some(Waiting), None), Some(NotifKind::Idle));
+        // Non-events: you replied, work simply started, or nothing changed.
+        assert_eq!(transition_kind(Some(Waiting), Some(Running)), None);
+        assert_eq!(transition_kind(None, Some(Running)), None);
+        assert_eq!(transition_kind(Some(Idle), Some(Running)), None);
+        assert_eq!(transition_kind(Some(Waiting), Some(Waiting)), None);
+    }
+
+    #[test]
+    fn session_statuses_keys_and_filters() {
+        use AgentStatus::*;
+        let sessions = vec![
+            sess(Some("a"), Waiting, false),
+            sess(Some("b"), RateLimited, false),
+            sess(None, Running, true), // inferred file-activity placeholder — excluded
+            sess(None, Running, false),
+        ];
+        let got = session_statuses(7, &sessions);
+        assert_eq!(got.len(), 3);
+        assert!(got.contains(&((7, SessKey::Transcript("a".into())), Waiting)));
+        assert!(got.contains(&((7, SessKey::Transcript("b".into())), RateLimited)));
+        assert!(got.contains(&((7, SessKey::Fallback), Running)));
+
+        // Defensive: a duplicate key keeps the higher-priority status.
+        let dup = vec![sess(None, Idle, false), sess(None, Waiting, false)];
+        assert_eq!(
+            session_statuses(7, &dup),
+            vec![((7, SessKey::Fallback), Waiting)]
+        );
+    }
+
+    #[test]
+    fn two_sessions_fire_independent_streams() {
+        use AgentStatus::*;
+        let k = |id: &str| (1, SessKey::Transcript(id.into()));
+        let live: HashSet<LaneId> = [1].into();
+        let managed = HashSet::new();
+
+        // One agent finishes its turn while its lane-mate is still rate-limited. The old
+        // per-lane rollup saw "RateLimited" before and after and fired nothing — the masking
+        // this change exists to fix.
+        let prev: HashMap<_, _> = [(k("a"), Running), (k("b"), RateLimited)].into();
+        let now: HashMap<_, _> = [(k("a"), Waiting), (k("b"), RateLimited)].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &now, &live, &managed),
+            vec![(k("a"), NotifKind::NeedsYou)]
+        );
+
+        // And the rate-limited lane-mate resumes independently.
+        let now2: HashMap<_, _> = [(k("a"), Waiting), (k("b"), Running)].into();
+        assert_eq!(
+            diff_session_transitions(&now, &now2, &live, &managed),
+            vec![(k("b"), NotifKind::Resumed)]
+        );
+    }
+
+    #[test]
+    fn disappearance_fires_idle_only_when_lane_lives() {
+        use AgentStatus::*;
+        let k = (1, SessKey::Transcript("a".into()));
+        let prev: HashMap<_, _> = [(k.clone(), Waiting)].into();
+        let now = HashMap::new();
+        let managed = HashSet::new();
+
+        let live: HashSet<LaneId> = [1].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &now, &live, &managed),
+            vec![(k, NotifKind::Idle)]
+        );
+        // The whole lane went away (deleted): not an agent going quiet.
+        assert!(diff_session_transitions(&prev, &now, &HashSet::new(), &managed).is_empty());
+    }
+
+    #[test]
+    fn fallback_handoff_does_not_fire_idle() {
+        use AgentStatus::*;
+        let live: HashSet<LaneId> = [1].into();
+        let prev: HashMap<_, _> = [((1, SessKey::Fallback), Running)].into();
+        let now: HashMap<_, _> = [((1, SessKey::Transcript("a".into())), Running)].into();
+
+        // The managed spawn's transcript became parseable: Fallback hands off to Transcript
+        // within one refresh. The agent didn't stop, so nothing fires.
+        let managed: HashSet<LaneId> = [1].into();
+        assert!(diff_session_transitions(&prev, &now, &live, &managed).is_empty());
+
+        // But with no managed session left in the lane, a vanished fallback is a real stop.
+        let gone = HashMap::new();
+        assert_eq!(
+            diff_session_transitions(&prev, &gone, &live, &HashSet::new()),
+            vec![((1, SessKey::Fallback), NotifKind::Idle)]
+        );
+    }
+
+    #[test]
+    fn new_session_already_waiting_fires_needs_you() {
+        use AgentStatus::*;
+        let live: HashSet<LaneId> = [1].into();
+        let managed = HashSet::new();
+        let prev = HashMap::new();
+        let k = (1, SessKey::Transcript("a".into()));
+
+        // A second agent appearing mid-run already waiting (e.g. a parallel session that
+        // finished between refreshes) is exactly the alert the user wants.
+        let waiting: HashMap<_, _> = [(k.clone(), Waiting)].into();
+        assert_eq!(
+            diff_session_transitions(&prev, &waiting, &live, &managed),
+            vec![(k.clone(), NotifKind::NeedsYou)]
+        );
+        // Appearing already-running is just work starting; stay quiet.
+        let running: HashMap<_, _> = [(k, Running)].into();
+        assert!(diff_session_transitions(&prev, &running, &live, &managed).is_empty());
+    }
+
+    #[test]
+    fn compose_shows_the_why_and_the_slot() {
+        let mut s = sess(Some("abc"), AgentStatus::Waiting, false);
+        s.title = Some("build the parser".into());
+        s.last_message = Some("Should I also update the integration tests?".into());
+        s.tool_call_count = 3;
+        let (title, body) = compose(NotifKind::NeedsYou, &lane(), Some(&s), Some((1, 3)), true);
+        assert!(
+            title.contains("needs you") && title.contains("alpha"),
+            "{title}"
+        );
+        assert!(body.contains("agent 2/3"), "{body}");
+        assert!(body.contains("Should I also update"), "{body}");
+        assert!(
+            !body.contains("build the parser"),
+            "why replaces the ask: {body}"
+        );
+    }
+
+    #[test]
+    fn compose_without_why_falls_back_to_the_ask_and_skips_solo_slot() {
+        let mut s = sess(Some("abc"), AgentStatus::Waiting, false);
+        s.title = Some("build the parser".into());
+        s.last_message = Some("Should I also update the integration tests?".into());
+        let (_, body) = compose(NotifKind::NeedsYou, &lane(), Some(&s), Some((0, 1)), false);
+        assert!(body.contains("build the parser"), "{body}");
+        assert!(!body.contains("agent 1/1"), "{body}");
+    }
+
+    #[test]
+    fn slot_by_key_indexes_real_sessions() {
+        let mut l = lane();
+        l.agent_sessions = vec![
+            sess(Some("a"), AgentStatus::Running, false),
+            sess(None, AgentStatus::Running, true), // inferred — not a slot
+            sess(Some("b"), AgentStatus::Waiting, false),
+        ];
+        assert_eq!(
+            slot_by_key(&l, &SessKey::Transcript("b".into())),
+            Some((1, 2))
+        );
+        assert_eq!(slot_by_key(&l, &SessKey::Transcript("zz".into())), None);
+    }
+
+    #[test]
+    fn burst_counts_kinds_and_overflow() {
+        let f = |l: &str, k: NotifKind| (l.to_string(), k);
+        let (t, b) = compose_burst(&[
+            f("alpha/main", NotifKind::NeedsYou),
+            f("beta/x", NotifKind::NeedsYou),
+        ]);
+        assert_eq!(t, "⏸ 2 agents need you");
+        assert_eq!(b, "alpha/main · beta/x");
+        let (t, b) = compose_burst(&[
+            f("a/1", NotifKind::NeedsYou),
+            f("b/2", NotifKind::Idle),
+            f("c/3", NotifKind::NeedsYou),
+            f("d/4", NotifKind::NeedsYou),
+        ]);
+        assert_eq!(t, "⚑ 4 agents need attention");
+        assert!(b.ends_with("+1 more"), "{b}");
+    }
+
+    #[test]
+    fn truncate_adds_ellipsis_only_when_over() {
+        assert_eq!(truncate("short", 60), "short");
+        let t = truncate("0123456789", 5);
+        assert_eq!(t.chars().count(), 5);
+        assert!(t.ends_with('…'));
+        assert_eq!(t, "0123…");
+    }
+
+    #[test]
+    fn kind_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&NotifKind::NeedsYou).unwrap(),
+            "\"needs_you\""
+        );
+        assert_eq!(
+            serde_json::to_string(&NotifKind::RateLimited).unwrap(),
+            "\"rate_limited\""
+        );
+    }
+}

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -305,6 +305,7 @@ mod tests {
             inferred,
             tmux_window: None,
             last_message: None,
+            pending_prompt: None,
         }
     }
 

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -645,6 +645,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         inferred: false,
         tmux_window: None,
         last_message: None,
+        pending_prompt: None,
     })
 }
 
@@ -871,6 +872,7 @@ mod tests {
             inferred: false,
             tmux_window: None,
             last_message: None,
+            pending_prompt: None,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -20,6 +20,7 @@ use crate::model::*;
 const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0001_init.sql"),
     include_str!("../../migrations/0002_agent_kind.sql"),
+    include_str!("../../migrations/0003_devices.sql"),
 ];
 
 type Job = Box<dyn FnOnce(&mut Connection) + Send + 'static>;
@@ -301,6 +302,41 @@ impl Store {
                 params![lane_id, window],
             )?;
             Ok(())
+        })
+        .await
+    }
+
+    /// Register (or refresh) a push-notification device token.
+    pub async fn register_device(&self, token: String) -> Result<()> {
+        self.call(move |c| {
+            c.execute(
+                "INSERT INTO devices (device_token, registered_at) VALUES (?1, ?2)
+                 ON CONFLICT(device_token) DO UPDATE SET registered_at = ?2",
+                params![token, Utc::now().to_rfc3339()],
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Drop a device token (user unregistered, or APNs reported it dead).
+    pub async fn unregister_device(&self, token: String) -> Result<()> {
+        self.call(move |c| {
+            c.execute(
+                "DELETE FROM devices WHERE device_token = ?1",
+                params![token],
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// All registered push device tokens.
+    pub async fn list_devices(&self) -> Result<Vec<String>> {
+        self.call(|c| {
+            let mut stmt = c.prepare("SELECT device_token FROM devices")?;
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+            collect(rows)
         })
         .await
     }

--- a/crates/repomon-daemon/Cargo.toml
+++ b/crates/repomon-daemon/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 repomon-core = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
+a2 = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/repomon-daemon/Cargo.toml
+++ b/crates/repomon-daemon/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/main.rs"
 [dependencies]
 repomon-core = { workspace = true }
 tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod auto_continue;
 pub mod pubsub;
+pub mod remote;
 pub mod rpc;
 pub mod socket;
 

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod auto_continue;
 pub mod notify_watch;
 pub mod pubsub;
+pub mod push;
 pub mod remote;
 pub mod rpc;
 pub mod socket;

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -5,6 +5,7 @@
 //! wrapper around [`serve`]; the integration tests drive [`Ctx`] + [`serve`] directly.
 
 pub mod auto_continue;
+pub mod notify_watch;
 pub mod pubsub;
 pub mod remote;
 pub mod rpc;

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -127,6 +127,11 @@ async fn main() {
         ctx.clone(),
     ));
 
+    // Daemon-side notification engine for remote clients (event.notification + push). Spawned
+    // unconditionally — it self-gates per tick on `[remote] enabled`, so flipping the config
+    // live (config.set) starts/stops it without a restart.
+    tokio::spawn(repomon_daemon::notify_watch::notify_watch(ctx.clone()));
+
     // Index commit history in the background (timeline / sessions / search).
     {
         let indexer = repomon_core::Indexer::new(ctx.store.clone(), ctx.registry.clone());

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -99,6 +99,29 @@ async fn main() {
     // Stream visible agents' output to subscribed TUIs.
     tokio::spawn(repomon_daemon::stream_output(ctx.clone()));
 
+    // Remote-access bridge (companion apps over Tailscale) — only when explicitly enabled
+    // and a token exists; without both, no network listener is ever opened.
+    {
+        let remote = ctx.config.read().await.remote.clone();
+        if remote.enabled {
+            match (remote.bind, remote.token) {
+                (Some(bind), Some(token)) if !token.is_empty() => {
+                    let ctx_r = ctx.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) =
+                            repomon_daemon::remote::serve_remote(ctx_r, &bind, token).await
+                        {
+                            tracing::error!("remote bridge failed: {e}");
+                        }
+                    });
+                }
+                _ => tracing::warn!(
+                    "[remote] enabled but bind/token missing — run `repomon remote enable`"
+                ),
+            }
+        }
+    }
+
     // Auto-continue agents paused on a usage limit (resume at the reset time).
     tokio::spawn(repomon_daemon::auto_continue::auto_continue_watcher(
         ctx.clone(),

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -97,8 +97,12 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
                 slot_by_key(lane, &key),
                 cfg.notify_show_why,
             );
-            // The agent's pending question verbatim — what a push's Approve acts on.
-            let prompt = sess.and_then(|s| s.last_message.clone());
+            // The actual on-screen dialog, when there is one — what a push's Approve acts on.
+            let dialog = sess.and_then(|s| s.pending_prompt.clone());
+            // The payload's "prompt" falls back to the agent's last message for context.
+            let prompt = dialog
+                .clone()
+                .or_else(|| sess.and_then(|s| s.last_message.clone()));
             let payload = json!({
                 "lane_id": lane_id,
                 "session_id": sess.and_then(|s| s.session_id.clone()),
@@ -111,7 +115,9 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
 
             // Lock-screen push: a NeedsYou with a pending question gets the actionable
             // category (Approve / Open); everything else is a plain alert.
-            let category = if kind == NotifKind::NeedsYou && prompt.is_some() {
+            // Approve-from-lock-screen only when an actual dialog is up — a plain "finished
+            // its turn" Enter would be a no-op (or worse, submit an empty reply).
+            let category = if kind == NotifKind::NeedsYou && dialog.is_some() {
                 push::CATEGORY_PROMPT
             } else {
                 push::CATEGORY_ALERT

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -1,0 +1,124 @@
+//! Daemon-side notification engine, for clients that aren't on this machine.
+//!
+//! The TUI does its own edge detection for local popups; remote clients (the iOS companion)
+//! can't — they may not even be connected when an agent starts waiting. So the daemon runs the
+//! same shared detection (`repomon_core::notify`) over the lane list and, on each meaningful
+//! transition, broadcasts an `event.notification` to subscribed clients (and, with push
+//! configured, sends APNs — see `push`). Self-gating: each tick re-reads the config and does
+//! nothing unless the remote bridge is enabled, so the watcher costs nothing for TUI-only use
+//! and reacts live when `[remote]` is switched on.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use repomon_core::model::{AgentStatus, LaneId};
+use repomon_core::notify::{
+    compose, diff_session_transitions, session_by_key, session_statuses, slot_by_key, NotifKind,
+    SessKey,
+};
+use repomon_core::Config;
+use serde_json::json;
+
+use crate::{rpc, Ctx};
+
+/// How often the watcher re-reads the fleet. Matches the TUI's refresh order of magnitude;
+/// the heavy parts underneath (transcript parses, process probes) are cached.
+const TICK: Duration = Duration::from_secs(4);
+/// Don't re-fire the same session's notification within this window (status flapping).
+const DEBOUNCE: Duration = Duration::from_secs(30);
+
+pub async fn notify_watch(ctx: Arc<Ctx>) {
+    let mut tick = tokio::time::interval(TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let mut prev: HashMap<(LaneId, SessKey), AgentStatus> = HashMap::new();
+    let mut seeded = false;
+    let mut debounce: HashMap<(LaneId, SessKey, NotifKind), Instant> = HashMap::new();
+
+    loop {
+        tick.tick().await;
+        let cfg = ctx.config.read().await.clone();
+        if !cfg.remote.enabled || !cfg.notify_enabled {
+            // Drop state while disabled so re-enabling re-seeds instead of firing a backlog.
+            prev.clear();
+            seeded = false;
+            debounce.clear();
+            continue;
+        }
+
+        let Ok(lanes) = rpc::lanes_with_agents(&ctx).await else {
+            continue;
+        };
+        let now: HashMap<(LaneId, SessKey), AgentStatus> = lanes
+            .iter()
+            .flat_map(|l| session_statuses(l.id, &l.agent_sessions))
+            .collect();
+        if !seeded {
+            prev = now;
+            seeded = true;
+            continue;
+        }
+
+        let live: HashSet<LaneId> = lanes.iter().map(|l| l.id).collect();
+        let managed: HashSet<LaneId> = lanes
+            .iter()
+            .filter(|l| l.agent_sessions.iter().any(|s| !s.external && !s.inferred))
+            .map(|l| l.id)
+            .collect();
+
+        let mut fires: Vec<((LaneId, SessKey), NotifKind)> = Vec::new();
+        for (key, kind) in diff_session_transitions(&prev, &now, &live, &managed) {
+            if !kind_enabled(&cfg, kind) {
+                continue;
+            }
+            let dkey = (key.0, key.1.clone(), kind);
+            if debounce.get(&dkey).is_some_and(|t| t.elapsed() < DEBOUNCE) {
+                continue;
+            }
+            debounce.insert(dkey, Instant::now());
+            fires.push((key, kind));
+        }
+        prev = now;
+        let snapshot = &prev;
+        debounce.retain(|(lane, sess, _), t| {
+            snapshot.contains_key(&(*lane, sess.clone())) || t.elapsed() < DEBOUNCE
+        });
+
+        for ((lane_id, key), kind) in fires {
+            let Some(lane) = lanes.iter().find(|l| l.id == lane_id) else {
+                continue;
+            };
+            let sess = session_by_key(lane, &key);
+            let (title, body) = compose(
+                kind,
+                lane,
+                sess,
+                slot_by_key(lane, &key),
+                cfg.notify_show_why,
+            );
+            ctx.broadcast(
+                "event.notification",
+                json!({
+                    "lane_id": lane_id,
+                    "session_id": sess.and_then(|s| s.session_id.clone()),
+                    "kind": kind,
+                    "title": title,
+                    "body": body,
+                    // The agent's pending question verbatim — what a push's Approve acts on.
+                    "prompt": sess.and_then(|s| s.last_message.clone()),
+                }),
+            );
+        }
+    }
+}
+
+/// Whether this notification kind is enabled (master switch checked by the caller).
+fn kind_enabled(cfg: &Config, kind: NotifKind) -> bool {
+    match kind {
+        NotifKind::NeedsYou => cfg.notify_needs_you,
+        NotifKind::RateLimited => cfg.notify_rate_limited,
+        NotifKind::Resumed => cfg.notify_resumed,
+        NotifKind::Idle => cfg.notify_idle,
+    }
+}

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -20,7 +20,7 @@ use repomon_core::notify::{
 use repomon_core::Config;
 use serde_json::json;
 
-use crate::{rpc, Ctx};
+use crate::{push, rpc, Ctx};
 
 /// How often the watcher re-reads the fleet. Matches the TUI's refresh order of magnitude;
 /// the heavy parts underneath (transcript parses, process probes) are cached.
@@ -97,18 +97,26 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
                 slot_by_key(lane, &key),
                 cfg.notify_show_why,
             );
-            ctx.broadcast(
-                "event.notification",
-                json!({
-                    "lane_id": lane_id,
-                    "session_id": sess.and_then(|s| s.session_id.clone()),
-                    "kind": kind,
-                    "title": title,
-                    "body": body,
-                    // The agent's pending question verbatim — what a push's Approve acts on.
-                    "prompt": sess.and_then(|s| s.last_message.clone()),
-                }),
-            );
+            // The agent's pending question verbatim — what a push's Approve acts on.
+            let prompt = sess.and_then(|s| s.last_message.clone());
+            let payload = json!({
+                "lane_id": lane_id,
+                "session_id": sess.and_then(|s| s.session_id.clone()),
+                "kind": kind,
+                "title": title,
+                "body": body,
+                "prompt": prompt,
+            });
+            ctx.broadcast("event.notification", payload.clone());
+
+            // Lock-screen push: a NeedsYou with a pending question gets the actionable
+            // category (Approve / Open); everything else is a plain alert.
+            let category = if kind == NotifKind::NeedsYou && prompt.is_some() {
+                push::CATEGORY_PROMPT
+            } else {
+                push::CATEGORY_ALERT
+            };
+            push::send_all(&ctx, &title, &body, category, &payload).await;
         }
     }
 }

--- a/crates/repomon-daemon/src/push.rs
+++ b/crates/repomon-daemon/src/push.rs
@@ -1,0 +1,132 @@
+//! APNs push — how agent alerts reach the phone when the companion app is closed.
+//!
+//! The daemon talks to Apple directly over HTTP/2 (`a2`), signing with the `.p8` key from
+//! `[push]` in the config; no relay in between. `notify_watch` calls [`send_all`] with the
+//! same title/body it broadcast as `event.notification`. Pushes carry the lane/session/prompt
+//! as custom data so the app can deep-link, and a category — `AGENT_PROMPT` when there's a
+//! pending question to act on (the app attaches an Approve action), `AGENT_ALERT` otherwise.
+//! Tokens APNs reports dead (`Unregistered`/`BadDeviceToken`) are evicted from the store.
+
+use std::sync::Arc;
+
+use a2::{
+    Client, ClientConfig, DefaultNotificationBuilder, Endpoint, ErrorReason, NotificationBuilder,
+    NotificationOptions, Priority,
+};
+use repomon_core::config::PushConfig;
+use serde_json::Value;
+
+use crate::Ctx;
+
+/// Notification categories the app registers actions for.
+pub const CATEGORY_PROMPT: &str = "AGENT_PROMPT";
+pub const CATEGORY_ALERT: &str = "AGENT_ALERT";
+
+/// A ready APNs sender, built from a complete `[push]` config. `None` when push isn't
+/// (fully) configured — callers just skip sending.
+pub struct Push {
+    client: Client,
+    topic: String,
+}
+
+impl Push {
+    /// Build a sender from the config: needs team id, key id, p8 path, and bundle id.
+    pub fn from_config(cfg: &PushConfig) -> Option<Push> {
+        let (team, key, p8, topic) = (
+            cfg.team_id.as_deref()?,
+            cfg.key_id.as_deref()?,
+            cfg.p8_path.as_deref()?,
+            cfg.bundle_id.as_deref()?,
+        );
+        let pem = match std::fs::File::open(p8) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!("push: cannot open p8 key {}: {e}", p8.display());
+                return None;
+            }
+        };
+        let endpoint = if cfg.sandbox {
+            Endpoint::Sandbox
+        } else {
+            Endpoint::Production
+        };
+        match Client::token(pem, key, team, ClientConfig::new(endpoint)) {
+            Ok(client) => Some(Push {
+                client,
+                topic: topic.to_string(),
+            }),
+            Err(e) => {
+                tracing::warn!("push: APNs client init failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Send one alert to one device. Returns `Ok(false)` when APNs says the token is dead
+    /// (the caller should evict it), `Ok(true)` on success.
+    pub async fn send(
+        &self,
+        device_token: &str,
+        title: &str,
+        body: &str,
+        category: &str,
+        data: &Value,
+    ) -> Result<bool, a2::Error> {
+        let builder = DefaultNotificationBuilder::new()
+            .set_title(title)
+            .set_body(body)
+            .set_sound("default")
+            .set_category(category);
+        let options = NotificationOptions {
+            apns_topic: Some(&self.topic),
+            apns_priority: Some(Priority::High),
+            ..Default::default()
+        };
+        let mut payload = builder.build(device_token, options);
+        let _ = payload.add_custom_data("repomon", data);
+        match self.client.send(payload).await {
+            Ok(_) => Ok(true),
+            Err(a2::Error::ResponseError(resp)) => {
+                let dead = resp.error.as_ref().is_some_and(|e| {
+                    matches!(
+                        e.reason,
+                        ErrorReason::Unregistered | ErrorReason::BadDeviceToken
+                    )
+                });
+                if dead {
+                    Ok(false)
+                } else {
+                    Err(a2::Error::ResponseError(resp))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Push `title`/`body` to every registered device, evicting tokens APNs reports dead.
+/// Builds the sender fresh per call — alerts are rare and the key parse is cheap, and this
+/// way `[push]` config changes apply immediately.
+pub async fn send_all(ctx: &Arc<Ctx>, title: &str, body: &str, category: &str, data: &Value) {
+    let devices = ctx.store.list_devices().await.unwrap_or_default();
+    if devices.is_empty() {
+        return;
+    }
+    let cfg = ctx.config.read().await.push.clone();
+    let Some(push) = Push::from_config(&cfg) else {
+        return;
+    };
+    for token in devices {
+        match push.send(&token, title, body, category, data).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::info!(
+                    "push: evicting dead device token {}…",
+                    &token[..8.min(token.len())]
+                );
+                let _ = ctx.store.unregister_device(token).await;
+            }
+            Err(e) => tracing::warn!("push: send failed: {e}"),
+        }
+    }
+}

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -1,0 +1,181 @@
+//! The remote-access WebSocket server — how companion apps (iOS) reach the daemon.
+//!
+//! Speaks the exact same JSON-RPC protocol as the Unix socket (`socket.rs`), with WebSocket
+//! text frames replacing the 4-byte length prefix: one frame = one envelope. Auth is a bearer
+//! token checked **before** the WebSocket upgrade completes (`Authorization: Bearer …` header,
+//! or `?token=…` for clients that can't set headers); a bad token is rejected with 401 and no
+//! connection state. Bind this to a private address — typically the machine's Tailscale IP —
+//! never the open internet.
+
+use std::sync::Arc;
+
+use futures::{SinkExt, StreamExt};
+use repomon_core::protocol::{Request, Response, RpcError};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast::error::RecvError;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HsRequest, Response as HsResponse,
+};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::{rpc, Ctx};
+
+/// Bind the WebSocket bridge and serve until shutdown is requested.
+pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str, token: String) -> std::io::Result<()> {
+    let listener = TcpListener::bind(bind).await?;
+    tracing::info!("remote bridge listening on ws://{bind}");
+    let token = Arc::new(token);
+
+    loop {
+        tokio::select! {
+            _ = ctx.shutdown.notified() => break,
+            accepted = listener.accept() => match accepted {
+                Ok((stream, addr)) => {
+                    let ctx = ctx.clone();
+                    let token = token.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conn(ctx, stream, &token).await {
+                            tracing::debug!("remote conn {addr}: {e}");
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!("remote accept error: {e}"),
+            },
+        }
+    }
+    Ok(())
+}
+
+// `result_large_err`: the auth closure's Err type (a full http::Response) is dictated by
+// tungstenite's `Callback` contract — nothing to box here.
+#[allow(clippy::result_large_err)]
+async fn handle_conn(
+    ctx: Arc<Ctx>,
+    stream: TcpStream,
+    token: &str,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    // Check the token during the handshake — an unauthorized client never completes the
+    // upgrade and learns nothing but "401".
+    let ws =
+        tokio_tungstenite::accept_hdr_async(stream, |req: &HsRequest, resp| auth(req, resp, token))
+            .await?;
+    let (mut sink, mut source) = ws.split();
+
+    // Every connection holds an event receiver, but only forwards once subscribed —
+    // mirroring the Unix-socket connection loop.
+    let mut events = ctx.events.subscribe();
+    let mut forwarding = false;
+
+    loop {
+        tokio::select! {
+            incoming = source.next() => {
+                let msg = match incoming {
+                    Some(Ok(m)) => m,
+                    Some(Err(e)) => return Err(e),
+                    None => break,
+                };
+                let text = match msg {
+                    Message::Text(t) => t,
+                    Message::Close(_) => break,
+                    // Ping/pong are answered by tungstenite itself; ignore binary frames.
+                    _ => continue,
+                };
+                let req: Request = match serde_json::from_str(&text) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let resp = Response::err(None, RpcError::new(-32700, format!("parse error: {e}")));
+                        send_json(&mut sink, &resp).await?;
+                        continue;
+                    }
+                };
+                if req.method == "subscribe" {
+                    forwarding = true;
+                }
+                let id = req.id;
+                let resp = match rpc::dispatch(&ctx, &req.method, req.params).await {
+                    Ok(value) => Response::ok(id, value),
+                    Err(err) => Response::err(id, err),
+                };
+                send_json(&mut sink, &resp).await?;
+            }
+            event = events.recv() => match event {
+                Ok(value) => {
+                    if forwarding {
+                        send_json(&mut sink, &value).await?;
+                    }
+                }
+                Err(RecvError::Lagged(n)) => {
+                    tracing::debug!("remote subscriber lagged {n} events");
+                }
+                Err(RecvError::Closed) => break,
+            },
+        }
+    }
+    Ok(())
+}
+
+async fn send_json<S, T>(
+    sink: &mut S,
+    value: &T,
+) -> Result<(), tokio_tungstenite::tungstenite::Error>
+where
+    S: SinkExt<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+    T: serde::Serialize,
+{
+    let text = serde_json::to_string(value).unwrap_or_default();
+    sink.send(Message::text(text)).await
+}
+
+/// The handshake gatekeeper: pass the upgrade through when the token matches, else 401.
+#[allow(clippy::result_large_err)] // the signature is tungstenite's Callback contract
+fn auth(req: &HsRequest, resp: HsResponse, token: &str) -> Result<HsResponse, ErrorResponse> {
+    if request_authorized(req, token) {
+        Ok(resp)
+    } else {
+        let mut deny = ErrorResponse::new(Some("unauthorized".into()));
+        *deny.status_mut() = tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
+        Err(deny)
+    }
+}
+
+/// Whether the handshake request carries the right token: `Authorization: Bearer <token>` or a
+/// `token=<token>` query parameter (for clients that can't set headers on a WS dial).
+fn request_authorized(req: &HsRequest, token: &str) -> bool {
+    let presented = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::to_string)
+        .or_else(|| {
+            req.uri().query().and_then(|q| {
+                q.split('&')
+                    .find_map(|kv| kv.strip_prefix("token=").map(str::to_string))
+            })
+        });
+    match presented {
+        Some(p) => constant_time_eq(p.as_bytes(), token.as_bytes()),
+        None => false,
+    }
+}
+
+/// Compare two byte strings without early exit on the first mismatch (timing side channel).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_basics() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+        assert!(!constant_time_eq(b"secret", b"secrex"));
+        assert!(!constant_time_eq(b"secret", b"secret1"));
+        assert!(constant_time_eq(b"", b""));
+    }
+}

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1126,6 +1126,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 inferred: false,
                 tmux_window: lane_windows.first().cloned(),
                 last_message: None,
+                pending_prompt: None,
             });
         } else if let Some(changed) = lane.state.last_change_at {
             // No identified agent, but a *non-main* worktree's files changed very recently — infer
@@ -1156,6 +1157,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     inferred: true,
                     tmux_window: None,
                     last_message: None,
+                    pending_prompt: None,
                 });
             }
         }
@@ -1172,10 +1174,12 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         }
     }
 
-    // Permission prompts: a transcript that ends in a tool call reads **Running**, but the
-    // pane may be sitting on an interactive "Do you want…?" dialog — blocked on the user with
-    // nothing in the JSONL to say so. Sniff the panes of managed Running sessions and flip
-    // those to Waiting, carrying the dialog summary as the notification-ready "why".
+    // Interactive dialogs: a transcript that ends in a tool call reads **Running**, but the
+    // pane may be sitting on a permission "Do you want…?" dialog; a turn ending in text reads
+    // **Waiting**, but the pane may be showing an option menu (plan approval, a question with
+    // choices). Neither is in the JSONL. Sniff the panes of managed Running/Waiting sessions:
+    // a detected dialog sets `pending_prompt` (clients gate approve/menu controls on it),
+    // becomes the notification-ready "why", and flips Running → Waiting.
     let candidates: Vec<(usize, usize, String)> = lanes
         .iter()
         .enumerate()
@@ -1184,7 +1188,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 .iter()
                 .enumerate()
                 .filter_map(move |(si, s)| {
-                    (!s.external && !s.inferred && s.status == AgentStatus::Running)
+                    let sniffable = !s.external
+                        && !s.inferred
+                        && matches!(s.status, AgentStatus::Running | AgentStatus::Waiting);
+                    sniffable
                         .then(|| s.tmux_window.clone().map(|w| (li, si, w)))
                         .flatten()
                 })
@@ -1209,7 +1216,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             if let Some(summary) = found {
                 let s = &mut lanes[li].agent_sessions[si];
                 s.status = AgentStatus::Waiting;
-                s.last_message = Some(summary);
+                s.last_message = Some(summary.clone());
+                s.pending_prompt = Some(summary);
             }
         }
     }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -315,11 +315,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         }
 
         // ---- lanes ----
-        "lane.list" => {
-            let mut lanes = ctx.lanes.list().await.map_err(internal)?;
-            overlay_agents(ctx, &mut lanes).await;
-            to_value(lanes)
-        }
+        "lane.list" => to_value(lanes_with_agents(ctx).await?),
         "lane.get" => {
             let p: LaneId = parse(params)?;
             let lane = ctx.lanes.get(p.lane_id).await.map_err(internal)?;
@@ -970,6 +966,14 @@ const MAX_SESSIONS_PER_LANE: usize = 8;
 /// agent in it — the fallback that surfaces Claude Code worktree-isolated subagents, which leave
 /// no transcript or process of their own. Short, so the indicator tracks actual work.
 const ACTIVITY_WINDOW_SECS: i64 = 90;
+
+/// The full lane list with live agent sessions overlaid — the composite `lane.list` serves.
+/// Shared with the daemon-side notification watcher (`notify_watch`), which diffs it.
+pub(crate) async fn lanes_with_agents(ctx: &Ctx) -> Result<Vec<Lane>, RpcError> {
+    let mut lanes = ctx.lanes.list().await.map_err(internal)?;
+    overlay_agents(ctx, &mut lanes).await;
+    Ok(lanes)
+}
 
 async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let paths: Vec<std::path::PathBuf> = lanes.iter().map(|l| l.worktree.path.clone()).collect();

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -201,6 +201,18 @@ struct PushDevice {
     device_token: String,
 }
 #[derive(Deserialize)]
+struct AgentTranscript {
+    lane_id: repomon_core::model::LaneId,
+    /// Which session's transcript; `None` = the lane's most recent.
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default = "default_transcript_limit")]
+    limit: usize,
+}
+fn default_transcript_limit() -> usize {
+    50
+}
+#[derive(Deserialize)]
 struct AgentAdopt {
     lane_id: repomon_core::model::LaneId,
     /// Resume this exact session (`claude --resume <id>`); `None` resumes the most recent.
@@ -925,6 +937,29 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "subscribe" => Ok(Value::Null),
         // Liveness probe for remote clients (the WS bridge) and a cheap connectivity check.
         "ping" => Ok(json!("pong")),
+        // The conversation itself, for clients that render text natively (the mobile chat
+        // view) instead of a desktop-width pane capture.
+        "agent.transcript" => {
+            let p: AgentTranscript = parse(params)?;
+            let path = ctx.lanes.focus(p.lane_id).await.map_err(internal)?;
+            let items = tokio::task::spawn_blocking(move || {
+                let within = chrono::Duration::hours(SESSION_WINDOW_HOURS);
+                let summaries = agent::claude::summaries_for(&path, within, MAX_SESSIONS_PER_LANE);
+                let manifest = match &p.session_id {
+                    Some(id) => summaries
+                        .iter()
+                        .find(|s| s.session_id.as_deref() == Some(id.as_str()))
+                        .map(|s| s.manifest_path.clone()),
+                    None => summaries.first().map(|s| s.manifest_path.clone()),
+                };
+                manifest
+                    .map(|m| agent::claude::transcript_tail(&m, p.limit))
+                    .unwrap_or_default()
+            })
+            .await
+            .unwrap_or_default();
+            to_value(items)
+        }
         // Push-notification device registration (the iOS companion).
         "push.register" => {
             let p: PushDevice = parse(params)?;

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -197,6 +197,10 @@ struct ConfigSet {
     notify_click_focus: Option<bool>,
 }
 #[derive(Deserialize)]
+struct PushDevice {
+    device_token: String,
+}
+#[derive(Deserialize)]
 struct AgentAdopt {
     lane_id: repomon_core::model::LaneId,
     /// Resume this exact session (`claude --resume <id>`); `None` resumes the most recent.
@@ -921,6 +925,23 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         "subscribe" => Ok(Value::Null),
         // Liveness probe for remote clients (the WS bridge) and a cheap connectivity check.
         "ping" => Ok(json!("pong")),
+        // Push-notification device registration (the iOS companion).
+        "push.register" => {
+            let p: PushDevice = parse(params)?;
+            ctx.store
+                .register_device(p.device_token)
+                .await
+                .map_err(internal)?;
+            Ok(Value::Null)
+        }
+        "push.unregister" => {
+            let p: PushDevice = parse(params)?;
+            ctx.store
+                .unregister_device(p.device_token)
+                .await
+                .map_err(internal)?;
+            Ok(Value::Null)
+        }
         "viewport.set" => {
             let p: ViewportSet = parse(params)?;
             *ctx.viewport.lock().await = p.lane_ids;

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -923,6 +923,8 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
 
         // ---- subscription is handled in the socket layer ----
         "subscribe" => Ok(Value::Null),
+        // Liveness probe for remote clients (the WS bridge) and a cheap connectivity check.
+        "ping" => Ok(json!("pong")),
         "viewport.set" => {
             let p: ViewportSet = parse(params)?;
             *ctx.viewport.lock().await = p.lane_ids;

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -1,0 +1,107 @@
+//! End-to-end for the remote WebSocket bridge: token gate, RPC round-trip, event push.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use repomon_core::{Config, Store};
+use repomon_daemon::{remote, Ctx};
+use serde_json::{json, Value};
+use tokio_tungstenite::tungstenite::Message;
+
+/// A free localhost port (bind :0, read it back, release).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let addr = format!("127.0.0.1:{}", free_port());
+    {
+        let ctx = ctx.clone();
+        let addr = addr.clone();
+        let token = token.to_string();
+        tokio::spawn(async move { remote::serve_remote(ctx, &addr, token).await });
+    }
+    // Wait for the listener to come up (connect attempts, not sleeps).
+    for _ in 0..100 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    (ctx, addr)
+}
+
+#[tokio::test]
+async fn bridge_round_trips_rpc_and_events_with_token() {
+    let (ctx, addr) = start_bridge("sekrit-token").await;
+
+    // Connect with the token in the query (the header path is equivalent).
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token=sekrit-token"))
+        .await
+        .expect("authorized connect");
+
+    // ping → pong.
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":1,"method":"ping"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    let resp: Value = match ws.next().await.unwrap().unwrap() {
+        Message::Text(t) => serde_json::from_str(&t).unwrap(),
+        m => panic!("unexpected frame: {m:?}"),
+    };
+    assert_eq!(resp["result"], json!("pong"));
+
+    // A real method works over the bridge.
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":2,"method":"repo.list"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    let resp: Value = match ws.next().await.unwrap().unwrap() {
+        Message::Text(t) => serde_json::from_str(&t).unwrap(),
+        m => panic!("unexpected frame: {m:?}"),
+    };
+    assert_eq!(resp["result"], json!([]));
+
+    // subscribe, then a broadcast arrives as an event frame.
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":3,"method":"subscribe"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    let _sub_ack = ws.next().await.unwrap().unwrap();
+    ctx.broadcast("event.test", json!({ "x": 1 }));
+    let event: Value = match tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("event within 2s")
+        .unwrap()
+        .unwrap()
+    {
+        Message::Text(t) => serde_json::from_str(&t).unwrap(),
+        m => panic!("unexpected frame: {m:?}"),
+    };
+    assert_eq!(event["method"], json!("event.test"));
+    assert_eq!(event["params"]["x"], json!(1));
+}
+
+#[tokio::test]
+async fn bridge_rejects_bad_or_missing_token_before_upgrade() {
+    let (_ctx, addr) = start_bridge("right-token").await;
+
+    let wrong = tokio_tungstenite::connect_async(format!("ws://{addr}/?token=wrong-token")).await;
+    assert!(wrong.is_err(), "wrong token must not complete the upgrade");
+
+    let missing = tokio_tungstenite::connect_async(format!("ws://{addr}/")).await;
+    assert!(
+        missing.is_err(),
+        "missing token must not complete the upgrade"
+    );
+}

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -71,6 +71,26 @@ async fn bridge_round_trips_rpc_and_events_with_token() {
     };
     assert_eq!(resp["result"], json!([]));
 
+    // Device registration for push round-trips (idempotent re-register, then unregister).
+    for (id, method) in [
+        (10, "push.register"),
+        (11, "push.register"),
+        (12, "push.unregister"),
+    ] {
+        ws.send(Message::text(
+            json!({"jsonrpc":"2.0","id":id,"method":method,
+                   "params":{"device_token":"feedcafe"}})
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+        let resp: Value = match ws.next().await.unwrap().unwrap() {
+            Message::Text(t) => serde_json::from_str(&t).unwrap(),
+            m => panic!("unexpected frame: {m:?}"),
+        };
+        assert!(resp["error"].is_null(), "{method} errored: {resp}");
+    }
+
     // subscribe, then a broadcast arrives as an event frame.
     ws.send(Message::text(
         json!({"jsonrpc":"2.0","id":3,"method":"subscribe"}).to_string(),

--- a/crates/repomon-tui/Cargo.toml
+++ b/crates/repomon-tui/Cargo.toml
@@ -30,6 +30,3 @@ ansi-to-tui = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-# Only for building Lane/Worktree fixtures (ObjectId) in unit tests; already compiled anyway
-# via repomon-core.
-gix = { workspace = true }

--- a/crates/repomon-tui/Cargo.toml
+++ b/crates/repomon-tui/Cargo.toml
@@ -27,6 +27,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 ratatui = { workspace = true }
 ansi-to-tui = { workspace = true }
+qrcode = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -16,6 +16,9 @@ use repomon_core::model::{
     AgentChoice, AgentSession, AgentStatus, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo,
     TimelineData, WorkSession,
 };
+use repomon_core::notify::{
+    diff_session_transitions, session_by_key, session_statuses, slot_by_key, SessKey,
+};
 use repomon_core::protocol::Notification;
 use serde_json::json;
 use tokio::sync::{broadcast, mpsc};
@@ -703,12 +706,7 @@ impl App {
         let Some((title, body, session_id)) = self.lanes.iter().find(|l| l.id == id).map(|l| {
             let sess = session_by_key(l, key);
             // Which of the lane's side-by-side agents this is (1-based in the body when >1).
-            let slot = sess.and_then(|hit| {
-                let real: Vec<&AgentSession> =
-                    l.agent_sessions.iter().filter(|s| !s.inferred).collect();
-                let i = real.iter().position(|s| std::ptr::eq(*s, hit))?;
-                Some((i, real.len()))
-            });
+            let slot = slot_by_key(l, key);
             let (t, b) = notify::compose(kind, l, sess, slot, self.settings.notify_show_why);
             (t, b, sess.and_then(|s| s.session_id.clone()))
         }) else {
@@ -2906,122 +2904,6 @@ fn fuzzy_score(haystack: &str, needle: &str) -> Option<u32> {
     Some(score)
 }
 
-/// Identifies one real agent session within a lane across refreshes.
-///
-/// Transcript-backed sessions key on the Claude session id (the transcript filename stem),
-/// which is stable across polls. `claude --resume` may continue the same logical work in a new
-/// transcript; that reads as one session vanishing and another appearing — acceptable noise. A
-/// lane has at most one real session *without* a transcript id per snapshot (the managed
-/// no-transcript placeholder or the generic process monitor — mutually exclusive branches in
-/// the daemon's `overlay_agents`), so a single `Fallback` sentinel covers it.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum SessKey {
-    Transcript(String),
-    Fallback,
-}
-
-/// Key/status pairs for one lane's *real* agent sessions. Inferred "file activity" placeholders
-/// are dropped so they never drive named alerts. On a (theoretically impossible) duplicate key,
-/// the higher-priority status wins — the same order the old per-lane rollup used.
-fn session_statuses(
-    lane_id: LaneId,
-    sessions: &[AgentSession],
-) -> Vec<((LaneId, SessKey), AgentStatus)> {
-    let mut out: Vec<((LaneId, SessKey), AgentStatus)> = Vec::new();
-    for s in sessions.iter().filter(|s| !s.inferred) {
-        let key = (
-            lane_id,
-            s.session_id
-                .clone()
-                .map(SessKey::Transcript)
-                .unwrap_or(SessKey::Fallback),
-        );
-        match out.iter_mut().find(|(k, _)| *k == key) {
-            Some((_, st)) if status_priority(s.status) < status_priority(*st) => *st = s.status,
-            Some(_) => {}
-            None => out.push((key, s.status)),
-        }
-    }
-    out
-}
-
-/// Notification priority of a status (lower = more urgent).
-fn status_priority(s: AgentStatus) -> usize {
-    use AgentStatus::*;
-    [RateLimited, Waiting, Running, Idle, Ended]
-        .iter()
-        .position(|&x| x == s)
-        .unwrap_or(usize::MAX)
-}
-
-/// Diff the previous and current per-session status maps into the notifications to fire.
-///
-/// Sessions present in `now` are edge-detected against their previous status. Sessions that
-/// vanished fire as a transition to `None` (→ Idle if they were active), except when their
-/// whole lane is gone (deleting a lane isn't an agent going quiet) or when a lane's `Fallback`
-/// key was handed off to a transcript-backed key (`lanes_with_managed`): the managed
-/// no-transcript placeholder disappears the moment the agent's transcript becomes parseable,
-/// and firing Idle there would alert on every spawn.
-fn diff_session_transitions(
-    prev: &HashMap<(LaneId, SessKey), AgentStatus>,
-    now: &HashMap<(LaneId, SessKey), AgentStatus>,
-    live_lanes: &HashSet<LaneId>,
-    lanes_with_managed: &HashSet<LaneId>,
-) -> Vec<((LaneId, SessKey), NotifKind)> {
-    let mut out = Vec::new();
-    for (key, &status) in now {
-        let was = prev.get(key).copied();
-        if was == Some(status) {
-            continue;
-        }
-        if let Some(kind) = transition_kind(was, Some(status)) {
-            out.push((key.clone(), kind));
-        }
-    }
-    for (key, &was) in prev {
-        if now.contains_key(key) || !live_lanes.contains(&key.0) {
-            continue;
-        }
-        if key.1 == SessKey::Fallback && lanes_with_managed.contains(&key.0) {
-            continue;
-        }
-        if let Some(kind) = transition_kind(Some(was), None) {
-            out.push((key.clone(), kind));
-        }
-    }
-    out
-}
-
-/// Resolve a session key back to the lane's session, for composing the notification text.
-/// `None` when the session vanished (i.e. its disappearance was the trigger).
-fn session_by_key<'a>(lane: &'a Lane, key: &SessKey) -> Option<&'a AgentSession> {
-    lane.agent_sessions
-        .iter()
-        .filter(|s| !s.inferred)
-        .find(|s| match key {
-            SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
-            SessKey::Fallback => s.session_id.is_none(),
-        })
-}
-
-/// Map a session's status transition to the notification it should fire, if any. `None` means
-/// the session was absent from that snapshot. Priority resolves cases like
-/// `Running → RateLimited` to the limit.
-fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> Option<NotifKind> {
-    use AgentStatus::*;
-    match (prev, now) {
-        // Hit a usage limit.
-        (p, Some(RateLimited)) if p != Some(RateLimited) => Some(NotifKind::RateLimited),
-        // Auto-resumed after a limit.
-        (Some(RateLimited), Some(Running)) => Some(NotifKind::Resumed),
-        // Finished its turn / needs you.
-        (p, Some(Waiting)) if p != Some(Waiting) => Some(NotifKind::NeedsYou),
-        // Was active, now quiet (idle / ended / the session went away).
-        (Some(Running) | Some(Waiting), Some(Idle) | Some(Ended) | None) => Some(NotifKind::Idle),
-        _ => None,
-    }
-}
-
 /// Cycle `current` to the next/previous option (wrapping). Returns `current` if `options` is empty.
 fn cycle(options: &[&str], current: &str, forward: bool) -> String {
     if options.is_empty() {
@@ -3387,44 +3269,6 @@ async fn next_note(rx: &mut broadcast::Receiver<Notification>) -> Option<Notific
 mod tests {
     use super::*;
 
-    #[test]
-    fn notification_transitions() {
-        use AgentStatus::*;
-        // The headline alerts.
-        assert_eq!(
-            transition_kind(Some(Running), Some(Waiting)),
-            Some(NotifKind::NeedsYou)
-        );
-        assert_eq!(
-            transition_kind(None, Some(Waiting)),
-            Some(NotifKind::NeedsYou)
-        );
-        assert_eq!(
-            transition_kind(Some(Running), Some(RateLimited)),
-            Some(NotifKind::RateLimited)
-        );
-        assert_eq!(
-            transition_kind(Some(RateLimited), Some(Running)),
-            Some(NotifKind::Resumed)
-        );
-        // Gave up on the limit and now needs you.
-        assert_eq!(
-            transition_kind(Some(RateLimited), Some(Waiting)),
-            Some(NotifKind::NeedsYou)
-        );
-        // Went quiet (idle / ended / the agent went away).
-        assert_eq!(
-            transition_kind(Some(Running), Some(Idle)),
-            Some(NotifKind::Idle)
-        );
-        assert_eq!(transition_kind(Some(Waiting), None), Some(NotifKind::Idle));
-        // Non-events: you replied, work simply started, or nothing changed.
-        assert_eq!(transition_kind(Some(Waiting), Some(Running)), None);
-        assert_eq!(transition_kind(None, Some(Running)), None);
-        assert_eq!(transition_kind(Some(Idle), Some(Running)), None);
-        assert_eq!(transition_kind(Some(Waiting), Some(Waiting)), None);
-    }
-
     /// A minimal real-or-inferred session, mirroring the daemon's `overlay_agents` literals.
     fn sess(session_id: Option<&str>, status: AgentStatus, inferred: bool) -> AgentSession {
         AgentSession {
@@ -3446,111 +3290,6 @@ mod tests {
             tmux_window: None,
             last_message: None,
         }
-    }
-
-    #[test]
-    fn session_statuses_keys_and_filters() {
-        use AgentStatus::*;
-        let sessions = vec![
-            sess(Some("a"), Waiting, false),
-            sess(Some("b"), RateLimited, false),
-            sess(None, Running, true), // inferred file-activity placeholder — excluded
-            sess(None, Running, false),
-        ];
-        let got = session_statuses(7, &sessions);
-        assert_eq!(got.len(), 3);
-        assert!(got.contains(&((7, SessKey::Transcript("a".into())), Waiting)));
-        assert!(got.contains(&((7, SessKey::Transcript("b".into())), RateLimited)));
-        assert!(got.contains(&((7, SessKey::Fallback), Running)));
-
-        // Defensive: a duplicate key keeps the higher-priority status.
-        let dup = vec![sess(None, Idle, false), sess(None, Waiting, false)];
-        assert_eq!(
-            session_statuses(7, &dup),
-            vec![((7, SessKey::Fallback), Waiting)]
-        );
-    }
-
-    #[test]
-    fn two_sessions_fire_independent_streams() {
-        use AgentStatus::*;
-        let k = |id: &str| (1, SessKey::Transcript(id.into()));
-        let live: HashSet<LaneId> = [1].into();
-        let managed = HashSet::new();
-
-        // One agent finishes its turn while its lane-mate is still rate-limited. The old
-        // per-lane rollup saw "RateLimited" before and after and fired nothing — the masking
-        // this change exists to fix.
-        let prev: HashMap<_, _> = [(k("a"), Running), (k("b"), RateLimited)].into();
-        let now: HashMap<_, _> = [(k("a"), Waiting), (k("b"), RateLimited)].into();
-        assert_eq!(
-            diff_session_transitions(&prev, &now, &live, &managed),
-            vec![(k("a"), NotifKind::NeedsYou)]
-        );
-
-        // And the rate-limited lane-mate resumes independently.
-        let now2: HashMap<_, _> = [(k("a"), Waiting), (k("b"), Running)].into();
-        assert_eq!(
-            diff_session_transitions(&now, &now2, &live, &managed),
-            vec![(k("b"), NotifKind::Resumed)]
-        );
-    }
-
-    #[test]
-    fn disappearance_fires_idle_only_when_lane_lives() {
-        use AgentStatus::*;
-        let k = (1, SessKey::Transcript("a".into()));
-        let prev: HashMap<_, _> = [(k.clone(), Waiting)].into();
-        let now = HashMap::new();
-        let managed = HashSet::new();
-
-        let live: HashSet<LaneId> = [1].into();
-        assert_eq!(
-            diff_session_transitions(&prev, &now, &live, &managed),
-            vec![(k, NotifKind::Idle)]
-        );
-        // The whole lane went away (deleted): not an agent going quiet.
-        assert!(diff_session_transitions(&prev, &now, &HashSet::new(), &managed).is_empty());
-    }
-
-    #[test]
-    fn fallback_handoff_does_not_fire_idle() {
-        use AgentStatus::*;
-        let live: HashSet<LaneId> = [1].into();
-        let prev: HashMap<_, _> = [((1, SessKey::Fallback), Running)].into();
-        let now: HashMap<_, _> = [((1, SessKey::Transcript("a".into())), Running)].into();
-
-        // The managed spawn's transcript became parseable: Fallback hands off to Transcript
-        // within one refresh. The agent didn't stop, so nothing fires.
-        let managed: HashSet<LaneId> = [1].into();
-        assert!(diff_session_transitions(&prev, &now, &live, &managed).is_empty());
-
-        // But with no managed session left in the lane, a vanished fallback is a real stop.
-        let gone = HashMap::new();
-        assert_eq!(
-            diff_session_transitions(&prev, &gone, &live, &HashSet::new()),
-            vec![((1, SessKey::Fallback), NotifKind::Idle)]
-        );
-    }
-
-    #[test]
-    fn new_session_already_waiting_fires_needs_you() {
-        use AgentStatus::*;
-        let live: HashSet<LaneId> = [1].into();
-        let managed = HashSet::new();
-        let prev = HashMap::new();
-        let k = (1, SessKey::Transcript("a".into()));
-
-        // A second agent appearing mid-run already waiting (e.g. a parallel session that
-        // finished between refreshes) is exactly the alert the user wants.
-        let waiting: HashMap<_, _> = [(k.clone(), Waiting)].into();
-        assert_eq!(
-            diff_session_transitions(&prev, &waiting, &live, &managed),
-            vec![(k.clone(), NotifKind::NeedsYou)]
-        );
-        // Appearing already-running is just work starting; stay quiet.
-        let running: HashMap<_, _> = [(k, Running)].into();
-        assert!(diff_session_transitions(&prev, &running, &live, &managed).is_empty());
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -3289,6 +3289,7 @@ mod tests {
             inferred,
             tmux_window: None,
             last_message: None,
+            pending_prompt: None,
         }
     }
 

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -38,6 +38,11 @@ pub enum Command {
         #[command(subcommand)]
         cmd: DaemonCmd,
     },
+    /// Remote access for companion apps (iOS): enable the bridge, pair a phone.
+    Remote {
+        #[command(subcommand)]
+        cmd: RemoteCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -61,6 +66,26 @@ pub enum LaneCmd {
         #[arg(long)]
         delete_branch: bool,
     },
+}
+
+#[derive(Subcommand)]
+pub enum RemoteCmd {
+    /// Turn the WebSocket bridge on: generate a token, detect the Tailscale address, write
+    /// the config. Restart the daemon afterwards to apply.
+    Enable {
+        /// Bind address override (default: the Tailscale IPv4 on port 7878).
+        #[arg(long)]
+        bind: Option<String>,
+        /// Rotate the token even if one already exists.
+        #[arg(long)]
+        rotate_token: bool,
+    },
+    /// Show a QR code for the companion app to scan (encodes address + token).
+    Pair,
+    /// Show the remote-access configuration (token masked).
+    Status,
+    /// Turn the bridge off (keeps the token for re-enabling).
+    Disable,
 }
 
 #[derive(Subcommand)]
@@ -131,8 +156,121 @@ pub async fn handle(cmd: Command, config: &Config, socket: Option<PathBuf>) -> R
         }
         Command::Lane { cmd } => handle_lane(cmd, config, socket).await?,
         Command::Daemon { cmd } => handle_daemon(cmd, config).await?,
+        Command::Remote { cmd } => handle_remote(cmd)?,
     }
     Ok(())
+}
+
+/// `repomon remote …` — manage the companion-app bridge. These edit the config *file* (the
+/// token never crosses the RPC surface); the daemon picks changes up on restart.
+fn handle_remote(cmd: RemoteCmd) -> Result<()> {
+    let path = config::config_path();
+    let mut cfg = Config::load().unwrap_or_default();
+    match cmd {
+        RemoteCmd::Enable { bind, rotate_token } => {
+            let bind = match bind.or_else(|| cfg.remote.bind.clone()) {
+                Some(b) => b,
+                None => {
+                    let ip = tailscale_ip().ok_or_else(|| {
+                        anyhow!(
+                            "couldn't detect a Tailscale IP — is Tailscale running? \
+                             (or pass --bind <ip:port> explicitly)"
+                        )
+                    })?;
+                    format!("{ip}:7878")
+                }
+            };
+            if cfg.remote.token.is_none() || rotate_token {
+                cfg.remote.token = Some(generate_token());
+            }
+            cfg.remote.bind = Some(bind.clone());
+            cfg.remote.enabled = true;
+            cfg.save_to(&path)?;
+            println!("remote bridge enabled on ws://{bind}");
+            println!("apply with: repomon daemon restart");
+            println!("then pair your phone with: repomon remote pair");
+        }
+        RemoteCmd::Disable => {
+            cfg.remote.enabled = false;
+            cfg.save_to(&path)?;
+            println!("remote bridge disabled (token kept) — repomon daemon restart to apply");
+        }
+        RemoteCmd::Pair => {
+            let (Some(bind), Some(token), true) =
+                (&cfg.remote.bind, &cfg.remote.token, cfg.remote.enabled)
+            else {
+                return Err(anyhow!(
+                    "remote access is not enabled — run `repomon remote enable` first"
+                ));
+            };
+            let url = format!("repomon://{bind}#{token}");
+            let code = qrcode::QrCode::new(url.as_bytes())?;
+            let art = code
+                .render::<qrcode::render::unicode::Dense1x2>()
+                .quiet_zone(true)
+                .build();
+            println!("{art}");
+            println!("scan with the repomon iOS app · {url}");
+            println!("(anyone with this QR can drive your agents — share it with no one)");
+        }
+        RemoteCmd::Status => {
+            let state = if cfg.remote.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            };
+            let bind = cfg.remote.bind.as_deref().unwrap_or("(unset)");
+            let token = match &cfg.remote.token {
+                Some(t) if t.len() >= 8 => format!("{}…{}", &t[..4], &t[t.len() - 4..]),
+                Some(_) => "(set)".into(),
+                None => "(unset)".into(),
+            };
+            println!("remote: {state}");
+            println!("bind:   ws://{bind}");
+            println!("token:  {token}");
+            let push_ready = cfg.push.team_id.is_some()
+                && cfg.push.key_id.is_some()
+                && cfg.push.p8_path.is_some()
+                && cfg.push.bundle_id.is_some();
+            println!(
+                "push:   {}",
+                if push_ready {
+                    "configured"
+                } else {
+                    "not configured ([push] in config.toml: team_id, key_id, p8_path, bundle_id)"
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A fresh 32-byte hex bearer token from the OS entropy pool (no extra deps).
+fn generate_token() -> String {
+    let mut buf = [0u8; 32];
+    use std::io::Read;
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut buf))
+        .expect("read /dev/urandom");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// The machine's Tailscale IPv4, via the `tailscale` CLI (PATH, then the Mac app bundle).
+fn tailscale_ip() -> Option<String> {
+    for bin in [
+        "tailscale",
+        "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    ] {
+        if let Ok(out) = std::process::Command::new(bin).args(["ip", "-4"]).output() {
+            if out.status.success() {
+                let ip = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !ip.is_empty() {
+                    return Some(ip);
+                }
+            }
+        }
+    }
+    None
 }
 
 async fn handle_lane(cmd: LaneCmd, config: &Config, socket: Option<PathBuf>) -> Result<()> {

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -1,54 +1,19 @@
-//! Desktop + in-app notifications for agent state changes.
+//! Desktop + in-app notification *delivery* for agent state changes.
 //!
 //! The TUI watches each agent session's status across refreshes (see
-//! `App::detect_notifications`) and, on a meaningful transition, composes a notification here:
-//! a native macOS popup (via `osascript`, fired on a short-lived thread so it never blocks the
-//! event loop) plus an in-app banner and a scrollable history feed. Edge detection and the
-//! config toggles live in `app`.
+//! `App::detect_notifications`) and, on a meaningful transition, delivers a notification here:
+//! a native macOS popup (terminal-notifier/`osascript`, fired on a short-lived thread so it
+//! never blocks the event loop) plus an in-app banner and a scrollable history feed. The pure
+//! parts — kinds, edge detection, text composition — live in `repomon_core::notify`, shared
+//! with the daemon's remote engine; the config toggles live in `app`.
 
 use chrono::{DateTime, Local};
 
-use repomon_core::model::{AgentSession, Lane, LaneId};
+use repomon_core::model::LaneId;
 
-/// The kind of agent state-change that fired a notification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NotifKind {
-    /// Agent finished its turn / is waiting on you.
-    NeedsYou,
-    /// Agent paused on a usage/rate limit.
-    RateLimited,
-    /// A rate-limited agent was auto-continued and resumed work.
-    Resumed,
-    /// Agent went idle or its session ended.
-    Idle,
-}
-
-impl NotifKind {
-    fn glyph(self) -> &'static str {
-        match self {
-            NotifKind::NeedsYou => "⏸",
-            NotifKind::RateLimited => "⏳",
-            NotifKind::Resumed => "▶",
-            NotifKind::Idle => "○",
-        }
-    }
-    fn verb(self) -> &'static str {
-        match self {
-            NotifKind::NeedsYou => "needs you",
-            NotifKind::RateLimited => "hit a usage limit",
-            NotifKind::Resumed => "resumed",
-            NotifKind::Idle => "went idle",
-        }
-    }
-    fn verb_plural(self) -> &'static str {
-        match self {
-            NotifKind::NeedsYou => "need you",
-            NotifKind::RateLimited => "hit a usage limit",
-            NotifKind::Resumed => "resumed",
-            NotifKind::Idle => "went idle",
-        }
-    }
-}
+// The pure heart (kinds, edge detection, text composition) lives in core, shared with the
+// daemon's remote notification engine; this module keeps the local delivery.
+pub use repomon_core::notify::{compose, compose_burst, NotifKind};
 
 /// A fired notification, kept in the in-app history feed.
 #[derive(Debug, Clone)]
@@ -64,103 +29,6 @@ pub struct NotifEvent {
     pub read: bool,
     pub title: String,
     pub body: String,
-}
-
-/// Build the `(title, body)` for a notification about one of `lane`'s sessions. The body
-/// carries the detail that makes the alert actionable: branch, which of the lane's
-/// side-by-side agents fired (`slot` = (index, count), tagged only when several run), the
-/// *why* — the agent's actual last message when `show_why` is on (falling back to what you
-/// originally asked) — tool count, and any reset time. `sess` is `None` when the session
-/// vanished from the snapshot (its disappearance was the trigger) — the text degrades to a
-/// generic "agent" line rather than borrowing another session's name and title.
-pub fn compose(
-    kind: NotifKind,
-    lane: &Lane,
-    sess: Option<&AgentSession>,
-    slot: Option<(usize, usize)>,
-    show_why: bool,
-) -> (String, String) {
-    let agent = sess
-        .map(|s| s.agent.short().to_string())
-        .unwrap_or_default();
-    let agent = if agent.is_empty() {
-        "agent".into()
-    } else {
-        agent
-    };
-    let title = format!(
-        "{} {} {} — {}",
-        kind.glyph(),
-        agent,
-        kind.verb(),
-        lane.repo.name
-    );
-
-    let mut parts = vec![lane
-        .state
-        .branch
-        .clone()
-        .unwrap_or_else(|| lane.worktree.name.clone())];
-    if let Some((i, n)) = slot {
-        if n > 1 {
-            parts.push(format!("agent {}/{}", i + 1, n));
-        }
-    }
-    let why = show_why
-        .then(|| sess.and_then(|s| s.last_message.as_deref()))
-        .flatten();
-    if let Some(t) = why.or_else(|| sess.and_then(|s| s.title.as_deref())) {
-        let t = t.trim();
-        if !t.is_empty() {
-            parts.push(format!("“{}”", truncate(t, 100)));
-        }
-    }
-    if let Some(s) = sess {
-        if s.tool_call_count > 0 {
-            parts.push(format!("{} tools", s.tool_call_count));
-        }
-    }
-    if kind == NotifKind::RateLimited {
-        if let Some(r) = sess.and_then(|s| s.resume_at) {
-            parts.push(format!(
-                "resets {}",
-                r.with_timezone(&Local).format("%H:%M")
-            ));
-        }
-    }
-    (title, parts.join(" · "))
-}
-
-/// One popup for a burst of simultaneous alerts: the title counts them (with the kind's glyph
-/// and verb when the whole burst is one kind, a generic ⚑ otherwise), the body lists the first
-/// few lanes. `fires` pairs each alert's `repo/worktree` label with its kind.
-pub fn compose_burst(fires: &[(String, NotifKind)]) -> (String, String) {
-    let n = fires.len();
-    let first = fires.first().map(|(_, k)| *k);
-    let uniform = fires.iter().all(|(_, k)| Some(*k) == first);
-    let title = match (uniform, first) {
-        (true, Some(k)) => format!("{} {} agents {}", k.glyph(), n, k.verb_plural()),
-        _ => format!("⚑ {n} agents need attention"),
-    };
-    let mut body = fires
-        .iter()
-        .take(3)
-        .map(|(l, _)| l.as_str())
-        .collect::<Vec<_>>()
-        .join(" · ");
-    if n > 3 {
-        body.push_str(&format!(" · +{} more", n - 3));
-    }
-    (title, body)
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
-    out.push('…');
-    out
 }
 
 /// Play the notification chime once, off-thread — a preview used when the user enables sound in
@@ -286,124 +154,6 @@ fn escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use repomon_core::model::{
-        AgentKind, AgentSession, AgentStatus, Repo, Worktree, WorktreeState,
-    };
-
-    fn lane() -> Lane {
-        let head = gix::ObjectId::null(gix::hash::Kind::Sha1);
-        Lane {
-            id: 7,
-            repo: Repo {
-                id: 1,
-                path: "/code/alpha".into(),
-                name: "alpha".into(),
-                added_at: Utc::now(),
-                worktree_root_template: None,
-            },
-            worktree: Worktree {
-                id: 1,
-                repo_id: 1,
-                path: "/code/alpha".into(),
-                branch: Some("main".into()),
-                head,
-                is_main: true,
-                name: "main".into(),
-            },
-            state: WorktreeState {
-                worktree_id: 1,
-                head,
-                branch: Some("feat/x".into()),
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                dirty: Default::default(),
-                last_commit_at: None,
-                locked: false,
-                prunable: false,
-                last_change_at: None,
-            },
-            agent_sessions: vec![],
-            last_activity_at: Utc::now(),
-            pinned: false,
-        }
-    }
-
-    fn sess() -> AgentSession {
-        AgentSession {
-            id: 0,
-            agent: AgentKind::ClaudeCode,
-            repo_id: 1,
-            worktree_id: Some(1),
-            started_at: Utc::now(),
-            last_activity_at: Utc::now(),
-            ended_at: None,
-            manifest_path: std::path::PathBuf::new(),
-            tool_call_count: 3,
-            title: Some("build the parser".into()),
-            status: AgentStatus::Waiting,
-            external: false,
-            session_id: Some("abc".into()),
-            resume_at: None,
-            inferred: false,
-            tmux_window: None,
-            last_message: Some("Should I also update the integration tests?".into()),
-        }
-    }
-
-    #[test]
-    fn compose_shows_the_why_and_the_slot() {
-        let (title, body) = compose(
-            NotifKind::NeedsYou,
-            &lane(),
-            Some(&sess()),
-            Some((1, 3)),
-            true,
-        );
-        assert!(
-            title.contains("needs you") && title.contains("alpha"),
-            "{title}"
-        );
-        assert!(body.contains("agent 2/3"), "{body}");
-        assert!(body.contains("Should I also update"), "{body}");
-        assert!(
-            !body.contains("build the parser"),
-            "why replaces the ask: {body}"
-        );
-    }
-
-    #[test]
-    fn compose_without_why_falls_back_to_the_ask_and_skips_solo_slot() {
-        let (_, body) = compose(
-            NotifKind::NeedsYou,
-            &lane(),
-            Some(&sess()),
-            Some((0, 1)),
-            false,
-        );
-        assert!(body.contains("build the parser"), "{body}");
-        assert!(!body.contains("agent 1/1"), "{body}");
-    }
-
-    #[test]
-    fn burst_counts_kinds_and_overflow() {
-        let f = |l: &str, k: NotifKind| (l.to_string(), k);
-        let (t, b) = compose_burst(&[
-            f("alpha/main", NotifKind::NeedsYou),
-            f("beta/x", NotifKind::NeedsYou),
-        ]);
-        assert_eq!(t, "⏸ 2 agents need you");
-        assert_eq!(b, "alpha/main · beta/x");
-        let (t, b) = compose_burst(&[
-            f("a/1", NotifKind::NeedsYou),
-            f("b/2", NotifKind::Idle),
-            f("c/3", NotifKind::NeedsYou),
-            f("d/4", NotifKind::NeedsYou),
-        ]);
-        assert_eq!(t, "⚑ 4 agents need attention");
-        assert!(b.ends_with("+1 more"), "{b}");
-    }
 
     #[cfg(target_os = "macos")]
     #[test]
@@ -419,15 +169,6 @@ mod tests {
         // tmux masks the real terminal; unknowns get no -activate.
         assert_eq!(terminal_bundle_id("tmux"), None);
         assert_eq!(terminal_bundle_id(""), None);
-    }
-
-    #[test]
-    fn truncate_adds_ellipsis_only_when_over() {
-        assert_eq!(truncate("short", 60), "short");
-        let t = truncate("0123456789", 5);
-        assert_eq!(t.chars().count(), 5);
-        assert!(t.ends_with('…'));
-        assert_eq!(t, "0123…");
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -70,6 +70,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.set_default` | `{ name? }` | `null` (set/clear the New Lane default; `name` may be a built-in or custom) |
 | `agent.spawn` | `{ lane_id, agent, task? }` | `{ lane_id, window, agent }` |
 | `agent.capture` | `{ lane_id, lines? }` | `{ content }` (ANSI-colored) |
+| `agent.transcript` | `{ lane_id, session_id?, limit=50 }` | `[TranscriptItem]` — `{ role, text, at? }` with role `user`/`assistant`/`tools`; full unwrapped message text for clients that lay text out themselves (the mobile chat view). Claude sessions only (empty otherwise). |
 | `agent.send_input` | `{ lane_id, text }` | `null` (types text + Enter) |
 | `agent.key` | `{ lane_id, key, literal=false }` | `null` (one keystroke: literal char or key name) |
 | `agent.signal` | `{ lane_id, key }` | `null` |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -12,6 +12,21 @@ little-endian `u32`** length, then that many bytes of UTF-8 JSON.
 Test it by hand: `nc -U /tmp/repomon-$USER.sock` and send framed JSON, or use the `repomon`
 CLI which speaks this protocol.
 
+## Remote transport (WebSocket)
+
+Companion apps (the iOS client) reach the daemon over a **WebSocket bridge** speaking the
+exact same JSON-RPC envelopes — one WS *text frame* per message, no length prefix. Disabled by
+default; `repomon remote enable` generates a bearer token, detects the Tailscale address, and
+writes `[remote] enabled/bind/token` to the config (apply with a daemon restart; pair a phone
+with `repomon remote pair`, which renders a `repomon://<host:port>#<token>` QR).
+
+- **Auth:** checked before the upgrade completes — `Authorization: Bearer <token>` header or a
+  `?token=<token>` query parameter; anything else gets a 401 and no connection.
+- **Bind it privately** (the Tailscale IP). The bridge is full-control: anyone holding the
+  token can read panes and type into agents.
+- `ping` → `"pong"` serves as an application-level keep-alive; events flow after `subscribe`
+  exactly as on the Unix socket.
+
 ## Envelope
 
 ```jsonc
@@ -68,6 +83,9 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `fs.browse` | `{ path? }` | `BrowseResult` (subdirs, repos, added flags) |
 | `viewport.set` | `{ lane_ids }` | `null` |
 | `subscribe` | `{ topics? }` | `null` |
+| `ping` | — | `"pong"` (remote keep-alive / connectivity probe) |
+| `push.register` | `{ device_token }` | `null` (register an APNs device for push; idempotent) |
+| `push.unregister` | `{ device_token }` | `null` |
 | `daemon.status` | — | `{ uptime_secs, repos, lanes, db_size_bytes, version }` |
 | `daemon.shutdown` | — | `null` |
 
@@ -85,5 +103,6 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `event.agent.status` | `{ lane_id, status }` |
 | `event.agent.output` | `{ lane_id, content }` |
 | `event.agent.changed` | `{ name }` or `{ default }` (a custom agent was added/removed, or the default changed) |
+| `event.notification` | `{ lane_id, session_id?, kind, title, body, prompt? }` — daemon-side agent alert (kinds: `needs_you`, `rate_limited`, `resumed`, `idle`; `prompt` is the agent's pending question verbatim). Emitted only while `[remote]` is enabled; the same alert goes to APNs devices with category `AGENT_PROMPT` (actionable) or `AGENT_ALERT`. |
 
 Object ids travel as lowercase hex strings; timestamps as RFC3339 UTC.


### PR DESCRIPTION
The daemon side of the iOS companion (repomon-ios). Four pieces:

### 1. WebSocket JSON-RPC bridge (`remote.rs`)
Same protocol as the Unix socket, one WS text frame per envelope; bearer token checked **before** the upgrade (constant-time compare; `Authorization: Bearer` or `?token=`), per-connection handling mirrors `socket.rs` (dispatch + subscribe-gated event forwarding). Off by default — `[remote] enabled/bind/token`, intended for the Tailscale IP. New `ping` RPC.

### 2. Daemon-side notification engine (`notify_watch.rs`)
The pure notification heart moved from the TUI into `repomon_core::notify` (kinds, SessKey, per-session diffing, compose) — TUI re-imports, tests moved. A 4s watcher (self-gated on `[remote] enabled`, reacts to live config flips) diffs the lane list and broadcasts `event.notification {lane_id, session_id, kind, title, body, prompt}`.

### 3. APNs push (`push.rs`)
Direct daemon→Apple HTTP/2 (a2/ring, no relay). `[push] team_id/key_id/p8_path/bundle_id/sandbox`; `*.p8` gitignored. Actionable category `AGENT_PROMPT` when a needs-you carries the agent's pending question, `AGENT_ALERT` otherwise; dead tokens evicted. New `devices` table (migration 0003) + `push.register`/`push.unregister` RPCs.

### 4. Pairing CLI + docs
`repomon remote enable` (urandom token, Tailscale IP detect, config write) · `remote pair` (terminal QR of `repomon://host:port#token`) · `remote status` (masked) · `remote disable`. protocol.md documents the WS transport, `push.*`, and `event.notification`.

### 5. `agent.transcript` — the conversation for native mobile rendering
A pane capture is rendered at the Mac terminal's width (~250 cols) and wraps to bits on a phone. The transcript has the actual unwrapped text, so serve that: `transcript_tail()` reads the last 512KB of the JSONL into `TranscriptItem` rows (user/assistant messages with full text, tool calls between messages aggregated into "Bash ×2 · Edit", timestamps carried). The iOS app's new Chat tab renders these natively; the raw Screen stays for permission dialogs and non-Claude agents. Verified live against a running session over the Unix socket.

**Verification:** fmt + clippy `-D warnings` clean, **137 tests** (new: WS auth round-trip incl. subscribe delivery and bad/missing-token rejection before upgrade, push registration over the bridge, `slot_by_key`, NotifKind snake_case wire format). Token never crosses the RPC surface; no listener opens unless explicitly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
