### PR TITLE
Fire desktop notifications from the daemon when the TUI is parked or closed

### DIFF
--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -3,8 +3,10 @@
 //! Both the TUI (local popups) and the daemon (remote `event.notification` broadcasts + push)
 //! watch per-session agent statuses across refreshes and alert on meaningful transitions.
 //! Everything shared lives here: session keying, the status diff, transition classification,
-//! and the `(title, body)` text composition. Delivery (osascript, APNs, banners) stays with
-//! each client.
+//! and the `(title, body)` text composition, plus the local desktop delivery
+//! ([`send_native`]) shared by the TUI and the daemon — the daemon fires it as a fallback when
+//! the local TUI is parked (attached to a pane) or closed. Remote delivery (APNs) and the TUI's
+//! in-app banner stay with their clients.
 
 use std::collections::{HashMap, HashSet};
 
@@ -276,6 +278,123 @@ fn truncate(s: &str, max: usize) -> String {
     let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
     out.push('…');
     out
+}
+
+// ---- local desktop delivery (shared by the TUI and the daemon) ----
+
+/// Play the notification chime once, off-thread — a preview used when enabling sound in Settings.
+pub fn play_chime() {
+    #[cfg(target_os = "macos")]
+    std::thread::spawn(|| {
+        let _ = std::process::Command::new("afplay")
+            .arg(NOTIFY_SOUND_FILE)
+            .output();
+    });
+}
+
+/// Fire a native desktop notification, best-effort and without blocking the caller (the actual
+/// `osascript`/`notify-send` invocation runs on a detached thread). `click_focus` makes the popup
+/// click-to-focus the terminal when `terminal-notifier` is installed (plain popup otherwise).
+pub fn send_native(title: &str, body: &str, sound: bool, click_focus: bool) {
+    let (title, body) = (title.to_string(), body.to_string());
+    std::thread::spawn(move || {
+        run_native(&title, &body, sound, click_focus);
+    });
+}
+
+/// A system sound file played for an audible notification (see [`run_native`]).
+#[cfg(target_os = "macos")]
+const NOTIFY_SOUND_FILE: &str = "/System/Library/Sounds/Glass.aiff";
+
+#[cfg(target_os = "macos")]
+fn run_native(title: &str, body: &str, sound: bool, click_focus: bool) {
+    // Prefer the clickable popup; fall back to osascript when terminal-notifier isn't installed
+    // (or click-to-focus is off). We deliberately do NOT use osascript's own `sound name`: on
+    // recent macOS the notification is attributed to "Script Editor", whose notification sound is
+    // usually off, so the chime is silently dropped. Play it with `afplay` instead.
+    let clickable = click_focus && notify_clickable(title, body);
+    if !clickable {
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            escape(body),
+            escape(title),
+        );
+        let _ = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .output();
+    }
+    if sound {
+        let _ = std::process::Command::new("afplay")
+            .arg(NOTIFY_SOUND_FILE)
+            .output();
+    }
+}
+
+/// Post a click-to-focus popup via `terminal-notifier`. Returns false when it isn't installed, so
+/// the caller can fall back to a plain popup.
+#[cfg(target_os = "macos")]
+fn notify_clickable(title: &str, body: &str) -> bool {
+    let Some(bin) = terminal_notifier() else {
+        return false;
+    };
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["-title", title, "-message", body]);
+    if let Some(bundle) = std::env::var("TERM_PROGRAM")
+        .ok()
+        .as_deref()
+        .and_then(terminal_bundle_id)
+    {
+        cmd.args(["-activate", bundle]);
+    }
+    cmd.output().is_ok()
+}
+
+/// The installed `terminal-notifier` binary, located once per process. `None` = not installed.
+#[cfg(target_os = "macos")]
+fn terminal_notifier() -> Option<&'static str> {
+    fn locate() -> Option<String> {
+        let out = std::process::Command::new("which")
+            .arg("terminal-notifier")
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        (!p.is_empty()).then_some(p)
+    }
+    static FOUND: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    FOUND.get_or_init(locate).as_deref()
+}
+
+/// The macOS bundle id behind a `$TERM_PROGRAM` value — what a clicked notification focuses.
+/// Unknown terminals (including `tmux`, which masks the real one) get no `-activate`.
+#[cfg(target_os = "macos")]
+fn terminal_bundle_id(term_program: &str) -> Option<&'static str> {
+    match term_program {
+        "iTerm.app" => Some("com.googlecode.iterm2"),
+        "Apple_Terminal" => Some("com.apple.Terminal"),
+        "WezTerm" => Some("com.github.wez.wezterm"),
+        "ghostty" => Some("com.mitchellh.ghostty"),
+        "vscode" => Some("com.microsoft.VSCode"),
+        "kitty" => Some("net.kovidgoyal.kitty"),
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_native(title: &str, body: &str, _sound: bool, _click_focus: bool) {
+    let _ = std::process::Command::new("notify-send")
+        .arg(title)
+        .arg(body)
+        .output();
+}
+
+/// Escape a string for embedding in an AppleScript double-quoted literal.
+#[cfg(target_os = "macos")]
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]
@@ -573,5 +692,27 @@ mod tests {
             serde_json::to_string(&NotifKind::RateLimited).unwrap(),
             "\"rate_limited\""
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bundle_ids_cover_known_terminals_only() {
+        assert_eq!(
+            terminal_bundle_id("iTerm.app"),
+            Some("com.googlecode.iterm2")
+        );
+        assert_eq!(
+            terminal_bundle_id("Apple_Terminal"),
+            Some("com.apple.Terminal")
+        );
+        // tmux masks the real terminal; unknowns get no -activate.
+        assert_eq!(terminal_bundle_id("tmux"), None);
+        assert_eq!(terminal_bundle_id(""), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn escape_neutralizes_applescript_quotes() {
+        assert_eq!(escape(r#"say "hi" \ now"#), r#"say \"hi\" \\ now"#);
     }
 }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -64,6 +64,11 @@ pub struct Ctx {
     /// / `repo.remove` can watch / unwatch a tree at runtime — otherwise the watcher only ever
     /// reflects the repos present at startup, and a removed repo keeps churning fsevents.
     pub watcher: Mutex<Option<Watcher>>,
+    /// When a *local* client (the TUI) was last seen making a request — its 1s `lane.list` refresh
+    /// is a built-in heartbeat that stops the moment the TUI parks in an attach or closes. The
+    /// notification engine fires desktop popups itself once this goes stale, so an alert still
+    /// reaches you when you're heads-down full-screen in an agent.
+    pub local_watcher_seen: Mutex<Option<Instant>>,
     pub shutdown: Notify,
 }
 
@@ -107,6 +112,7 @@ impl Ctx {
             rate_limits: Mutex::new(HashMap::new()),
             auto_continue_off: Mutex::new(HashSet::new()),
             watcher: Mutex::new(None),
+            local_watcher_seen: Mutex::new(None),
             shutdown: Notify::new(),
         })
     }

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -28,6 +28,10 @@ use crate::{push, rpc, Ctx};
 const TICK: Duration = Duration::from_secs(8);
 /// Don't re-fire the same session's notification within this window (status flapping).
 const DEBOUNCE: Duration = Duration::from_secs(30);
+/// How long since the local TUI's last request before we treat it as parked (attached) or closed
+/// and let the daemon fire desktop popups itself. The TUI refreshes ~1s, so a few seconds of
+/// silence means it isn't watching.
+const LOCAL_TTL: Duration = Duration::from_secs(3);
 
 pub async fn notify_watch(ctx: Arc<Ctx>) {
     let mut tick = tokio::time::interval(TICK);
@@ -40,13 +44,18 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
     loop {
         tick.tick().await;
         let cfg = ctx.config.read().await.clone();
-        if !cfg.remote.enabled || !cfg.notify_enabled {
+        if !cfg.notify_enabled {
             // Drop state while disabled so re-enabling re-seeds instead of firing a backlog.
             prev.clear();
             seeded = false;
             debounce.clear();
             continue;
         }
+        // The TUI fires its own desktop popups while it's actively watching; the daemon takes over
+        // local desktop delivery only when the TUI has parked in an attach or closed — i.e. its
+        // ~1s lane.list heartbeat has gone stale. Remote delivery is gated separately below.
+        let tui_active =
+            (*ctx.local_watcher_seen.lock().await).is_some_and(|t| t.elapsed() < LOCAL_TTL);
 
         // Always recompute (bypass the lane.list cache): edge detection must never reuse a stale
         // snapshot, and in a headless setup nothing else populates the cache.
@@ -114,18 +123,32 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
                 "body": body,
                 "prompt": prompt,
             });
-            ctx.broadcast("event.notification", payload.clone());
+            // Remote clients (the iOS companion): event.notification + APNs — only when the bridge
+            // is enabled.
+            if cfg.remote.enabled {
+                ctx.broadcast("event.notification", payload.clone());
+                // Lock-screen push: a NeedsYou with a pending question gets the actionable
+                // category (Approve / Open); everything else is a plain alert. Approve-from-lock
+                // only when an actual dialog is up — a plain "finished its turn" Enter would be a
+                // no-op (or worse, submit an empty reply).
+                let category = if kind == NotifKind::NeedsYou && dialog.is_some() {
+                    push::CATEGORY_PROMPT
+                } else {
+                    push::CATEGORY_ALERT
+                };
+                push::send_all(&ctx, &title, &body, category, &payload).await;
+            }
 
-            // Lock-screen push: a NeedsYou with a pending question gets the actionable
-            // category (Approve / Open); everything else is a plain alert.
-            // Approve-from-lock-screen only when an actual dialog is up — a plain "finished
-            // its turn" Enter would be a no-op (or worse, submit an empty reply).
-            let category = if kind == NotifKind::NeedsYou && dialog.is_some() {
-                push::CATEGORY_PROMPT
-            } else {
-                push::CATEGORY_ALERT
-            };
-            push::send_all(&ctx, &title, &body, category, &payload).await;
+            // Local desktop popup — fired by the daemon only when the TUI isn't already covering it
+            // (it's parked in an attach or closed), so we never double-notify with the TUI's own.
+            if !tui_active {
+                repomon_core::notify::send_native(
+                    &title,
+                    &body,
+                    cfg.notify_sound,
+                    cfg.notify_click_focus,
+                );
+            }
         }
     }
 }

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -77,6 +77,10 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
                         continue;
                     }
                 };
+                // A local request means the TUI is actively watching; its 1s lane.list refresh
+                // keeps this fresh and stops the instant the TUI parks in an attach or closes —
+                // which is how the notification engine knows to take over desktop popups.
+                *ctx.local_watcher_seen.lock().await = Some(std::time::Instant::now());
                 if req.method == "subscribe" {
                     forwarding = true;
                 }

--- a/crates/repomon-tui/src/notify.rs
+++ b/crates/repomon-tui/src/notify.rs
@@ -1,19 +1,19 @@
-//! Desktop + in-app notification *delivery* for agent state changes.
+//! In-app notification feed (the scrollable history) for agent state changes.
 //!
-//! The TUI watches each agent session's status across refreshes (see
-//! `App::detect_notifications`) and, on a meaningful transition, delivers a notification here:
-//! a native macOS popup (terminal-notifier/`osascript`, fired on a short-lived thread so it
-//! never blocks the event loop) plus an in-app banner and a scrollable history feed. The pure
-//! parts — kinds, edge detection, text composition — live in `repomon_core::notify`, shared
-//! with the daemon's remote engine; the config toggles live in `app`.
+//! The TUI watches each agent session's status across refreshes (see `App::detect_notifications`)
+//! and, on a meaningful transition, fires a native desktop popup plus an in-app banner and this
+//! history feed. The pure parts — kinds, edge detection, text composition — AND the desktop popup
+//! delivery ([`send_native`]) live in `repomon_core::notify`, shared with the daemon (which fires
+//! the same popup when this TUI is parked in an attach or closed). The config toggles live in `app`.
 
 use chrono::{DateTime, Local};
 
 use repomon_core::model::LaneId;
 
-// The pure heart (kinds, edge detection, text composition) lives in core, shared with the
-// daemon's remote notification engine; this module keeps the local delivery.
-pub use repomon_core::notify::{compose, compose_burst, NotifKind};
+// Everything reusable — kinds, edge detection, text composition, and the local desktop delivery —
+// lives in core, shared with the daemon's notification engine; this module keeps only the in-app
+// feed event below.
+pub use repomon_core::notify::{compose, compose_burst, play_chime, send_native, NotifKind};
 
 /// A fired notification, kept in the in-app history feed.
 #[derive(Debug, Clone)]
@@ -29,151 +29,4 @@ pub struct NotifEvent {
     pub read: bool,
     pub title: String,
     pub body: String,
-}
-
-/// Play the notification chime once, off-thread — a preview used when the user enables sound in
-/// Settings so they can confirm it's audible without waiting for an agent to change state.
-pub fn play_chime() {
-    #[cfg(target_os = "macos")]
-    std::thread::spawn(|| {
-        let _ = std::process::Command::new("afplay")
-            .arg(NOTIFY_SOUND_FILE)
-            .output();
-    });
-}
-
-/// Fire a native desktop notification, best-effort and without blocking the caller: the actual
-/// `osascript`/`notify-send` invocation runs (and is reaped) on a detached thread.
-/// `click_focus` makes the popup click-to-focus the terminal when `terminal-notifier` is
-/// installed (plain popup otherwise).
-pub fn send_native(title: &str, body: &str, sound: bool, click_focus: bool) {
-    let (title, body) = (title.to_string(), body.to_string());
-    std::thread::spawn(move || {
-        run_native(&title, &body, sound, click_focus);
-    });
-}
-
-/// A system sound file played for an audible notification (see [`run_native`]).
-#[cfg(target_os = "macos")]
-const NOTIFY_SOUND_FILE: &str = "/System/Library/Sounds/Glass.aiff";
-
-#[cfg(target_os = "macos")]
-fn run_native(title: &str, body: &str, sound: bool, click_focus: bool) {
-    // Prefer the clickable popup; fall back to osascript when terminal-notifier isn't
-    // installed (or click-to-focus is off). We deliberately do NOT use osascript's own
-    // `sound name`: on recent macOS the notification is attributed to "Script Editor", whose
-    // notification sound is usually off, so the chime is silently dropped even though the
-    // call succeeds.
-    let clickable = click_focus && notify_clickable(title, body);
-    if !clickable {
-        let script = format!(
-            "display notification \"{}\" with title \"{}\"",
-            escape(body),
-            escape(title),
-        );
-        let _ = std::process::Command::new("osascript")
-            .arg("-e")
-            .arg(script)
-            .output();
-    }
-    // Play the sound directly instead — `afplay` is audible regardless of notification settings.
-    if sound {
-        let _ = std::process::Command::new("afplay")
-            .arg(NOTIFY_SOUND_FILE)
-            .output();
-    }
-}
-
-/// Post a click-to-focus popup via `terminal-notifier`: clicking it activates the terminal
-/// the TUI runs in (resolved from `$TERM_PROGRAM`). Returns false when terminal-notifier
-/// isn't installed, so the caller can fall back to a plain popup.
-#[cfg(target_os = "macos")]
-fn notify_clickable(title: &str, body: &str) -> bool {
-    let Some(bin) = terminal_notifier() else {
-        return false;
-    };
-    let mut cmd = std::process::Command::new(bin);
-    cmd.args(["-title", title, "-message", body]);
-    if let Some(bundle) = std::env::var("TERM_PROGRAM")
-        .ok()
-        .as_deref()
-        .and_then(terminal_bundle_id)
-    {
-        cmd.args(["-activate", bundle]);
-    }
-    cmd.output().is_ok()
-}
-
-/// The installed `terminal-notifier` binary, located once per process. `None` = not installed.
-#[cfg(target_os = "macos")]
-fn terminal_notifier() -> Option<&'static str> {
-    fn locate() -> Option<String> {
-        let out = std::process::Command::new("which")
-            .arg("terminal-notifier")
-            .output()
-            .ok()?;
-        if !out.status.success() {
-            return None;
-        }
-        let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        (!p.is_empty()).then_some(p)
-    }
-    static FOUND: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    FOUND.get_or_init(locate).as_deref()
-}
-
-/// The macOS bundle id behind a `$TERM_PROGRAM` value — what a clicked notification focuses.
-/// Unknown terminals (including `tmux`, which masks the real one) get no `-activate`.
-#[cfg(target_os = "macos")]
-fn terminal_bundle_id(term_program: &str) -> Option<&'static str> {
-    match term_program {
-        "iTerm.app" => Some("com.googlecode.iterm2"),
-        "Apple_Terminal" => Some("com.apple.Terminal"),
-        "WezTerm" => Some("com.github.wez.wezterm"),
-        "ghostty" => Some("com.mitchellh.ghostty"),
-        "vscode" => Some("com.microsoft.VSCode"),
-        "kitty" => Some("net.kovidgoyal.kitty"),
-        _ => None,
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn run_native(title: &str, body: &str, _sound: bool, _click_focus: bool) {
-    let _ = std::process::Command::new("notify-send")
-        .arg(title)
-        .arg(body)
-        .output();
-}
-
-/// Escape a string for embedding in an AppleScript double-quoted literal.
-#[cfg(target_os = "macos")]
-fn escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn bundle_ids_cover_known_terminals_only() {
-        assert_eq!(
-            terminal_bundle_id("iTerm.app"),
-            Some("com.googlecode.iterm2")
-        );
-        assert_eq!(
-            terminal_bundle_id("Apple_Terminal"),
-            Some("com.apple.Terminal")
-        );
-        // tmux masks the real terminal; unknowns get no -activate.
-        assert_eq!(terminal_bundle_id("tmux"), None);
-        assert_eq!(terminal_bundle_id(""), None);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn escape_neutralizes_applescript_quotes() {
-        assert_eq!(escape(r#"say "hi" \ now"#), r#"say \"hi\" \\ now"#);
-    }
 }


### PR DESCRIPTION
## Problem

Desktop popups were fired **only by the TUI** (`detect_notifications` → `send_native`), which runs inside the TUI's event loop. When you "go all the way in" (attach to an agent's tmux pane), that loop parks on the blocking `tmux attach` (`do_attach(...).await`), so there's **no edge detection and no popups — for any agent — until you detach**. Same when the TUI is closed entirely. (The daemon's `notify_watch` only did remote `event.notification` + APNs, and APNs is disabled on a free Apple team.)

## Fix

Make the always-running daemon cover the gap, without double-notifying when the TUI *is* watching:

- **Shared delivery** — lifted `send_native` + the osascript/terminal-notifier helpers into `repomon_core::notify`, so both the TUI and daemon fire the same popup.
- **Heartbeat** — the local socket stamps a "TUI seen" time on every request. The TUI's existing **~1s `lane.list` refresh is a built-in heartbeat** that stops the instant it parks (attach) or closes. Remote/WS requests deliberately don't stamp it, so iOS polling can't mask a parked *local* TUI.
- **Daemon delivery** — `notify_watch` now runs whenever `notify_enabled` (not only with the remote bridge), and fires `send_native` for each transition **only when the TUI heartbeat is stale** — never while the TUI is actively watching. Remote `event.notification` + APNs stay gated on the bridge.

## Result

An agent going "needs you" reaches you on the **desktop** whether the TUI is open, attached full-screen, or closed.

- `cargo test` green (98 core / 18 daemon / tui), incl. the relocated delivery tests; `clippy --all-targets -D warnings` clean.
- Reinstalled + restarted: idle CPU unchanged at **~0.4%** (running `notify_watch` for local adds no measurable cost — the overlay is cached).

Note: during an attach, the daemon's tick drives latency (~≤8s) vs the TUI's ~1s when active — easy to tune if you want it snappier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)