### PR TITLE
docs: sync README + docs/ with multi-agent, CPU, and notification work

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ repomon() {
 
 The Observatory (fleet/lanes/today), the agent multiplexer (spawn, live output, input,
 attach, babysit grid, multi-agent lanes), the history dashboard (timeline/sessions/search),
-per-session notifications (with pane-sniffed permission-dialog detection), and the remote
-access layer (WebSocket bridge + APNs + pairing) are all in; an iOS companion app lives in
-a separate private repo. Deferred follow-ups: a SwiftUI menu-bar companion (much of it now
+per-session notifications (pane-sniffed permission-dialog detection, fired as desktop popups
+even when the TUI is closed or parked full-screen in an agent), and the remote access layer
+(WebSocket bridge + APNs + pairing) are all in; an iOS companion app lives in a separate
+private repo. Deferred follow-ups: a SwiftUI menu-bar companion (much of it now
 exists as the iOS app's shared RepomonKit), an embedded PTY renderer (vs the tmux pivot),
 a web dashboard, and Windows support.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-repomon runs every agent the same way — in a durable tmux window per lane — but it learns
+repomon runs every agent the same way — each in its own durable tmux window — but it learns
 each agent's *status* differently, because each CLI stores its session state differently.
 
 ## How agents run
@@ -15,6 +15,12 @@ tmux new-window -t repomon -n lane-7 -c <worktree> '<agent-binary> [task]'
 The daemon reads output with `capture-pane`, sends input with `send-keys`, and `attach`
 gives you the raw session. Because tmux owns the process, the agent survives the daemon and
 the TUI. The spawned kind is recorded on the lane so repomon can identify it later.
+
+Several agents can run in the **same** worktree at once: a second spawn (or adopting an
+external session into an occupied lane) takes the next slot — `lane-<id>-2`, `lane-<id>-3`,
+… — and they run side by side. Fleet and the sidebar mark such a lane with an `×N` badge,
+and `Tab`/`⇧Tab` cycle the cursor between a lane's agents in Split/Focus; input and attach
+route to the cursored one.
 
 ## Choosing an agent
 
@@ -150,8 +156,10 @@ repomon can't type into a plain terminal process, so to drive an external sessio
 **`o` to adopt** the highlighted one (Fleet/Split/Focus): repomon resumes *that exact* session
 with `claude --resume <id>` (or `--continue` for the most recent) in a managed tmux lane,
 after which it's fully interactive here. The original terminal window is left as-is — close it
-once you've adopted. repomon manages one session per worktree at a time (a single tmux
-window), but you can observe them all and choose which to adopt.
+once you've adopted. repomon can manage several agents in the same worktree, each in its own
+tmux window (`lane-<id>`, `lane-<id>-2`, …), so adopting an external session adds a managed
+agent alongside any already running — and you can observe every external session in the lane
+detail and choose which to adopt.
 
 ## How status is detected
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,8 +31,9 @@ forwards input. That split is what keeps the UI instant and lets agents outlive 
   tmux-backed agent runtime and the agent monitors, the Phase-3 analytics/sessions/indexer,
   launchd service management, and the shared JSON-RPC protocol + framing.
 - **repomon-daemon** (`repomond`) — hosts core behind a length-prefixed JSON-RPC Unix socket.
-  Owns the `Ctx` (store, registry, lanes, tmux runtime, event bus, viewport), the per-
-  connection socket handling, RPC dispatch, the output streamer, and the background indexer.
+  Owns the `Ctx` (store, registry, lanes, tmux runtime, event bus, viewport + focus, and the
+  overlay/status caches), the per-connection socket handling, RPC dispatch, the output streamer,
+  the desktop/remote notification watcher, and the background indexer.
 - **repomon-tui** (`repomon`) — the terminal client and headless CLI. A `DaemonClient` over
   the socket, an async app loop, the four-zoom views, and the `repomon …` subcommands.
 
@@ -43,14 +44,26 @@ computes live state with gix off the runtime, overlays agent sessions (Claude tr
 Aider history → tmux-alive fallback), and returns lanes. The TUI renders cached state
 immediately on every keystroke; git never runs on the UI thread.
 
-**Live agents.** The daemon spawns each agent in a tmux window (`lane-<id>`). The TUI tells
-the daemon which lanes are visible (`viewport.set`); a streamer fast-polls only those panes
-(`capture-pane`) and pushes `event.agent.output`. Input goes back via `agent.send_input`
-(`send-keys`); `agent.target` + a raw `tmux attach` gives the unmediated session.
+**Live agents.** The daemon spawns each agent in its own tmux window — the first at
+`lane-<id>`, additional agents sharing a worktree at `lane-<id>-2`, `lane-<id>-3`, … so
+several run side by side. The TUI tells the daemon which lanes are visible (and which agent
+window the focused lane should stream) via `viewport.set`; a streamer fast-polls only those
+panes (`capture-pane`) and pushes `event.agent.output`. Input goes back via `agent.send_input`
+(`send-keys`), routed to a specific window in a multi-agent lane; `agent.target` + a raw
+`tmux attach` gives the unmediated session.
 
-**Change propagation.** A debounced notify watcher (250 ms, `.git/objects` excluded) plus the
-Claude projects directory feed `event.repo.changed`; the TUI refetches. A 60 s tick is the
-safety net.
+**Change propagation.** A debounced notify watcher (250 ms; `.git/objects` and build/dependency
+churn like `target` and `node_modules` excluded) plus the Claude projects directory feed
+`event.repo.changed`; the TUI refetches. A 60 s tick is the safety net. The watcher is held in
+the daemon's runtime context and watches/unwatches a tree on `repo.add` / `repo.remove`, so a
+removed repo stops churning fsevents instead of being watched until the next restart.
+
+**Desktop notifications.** A `notify_watch` task runs the shared edge-detection over the fleet
+and fires an alert on each meaningful agent transition. Remote clients get an `event.notification`
+broadcast (and APNs push) while `[remote]` is enabled; locally, the daemon fires desktop popups
+itself only once the TUI stops covering them — it watches the TUI's ~1 s `lane.list` heartbeat
+and, after 3 s of silence (the TUI parked in a full-screen attach or closed), takes over so an
+alert still reaches you when you're heads-down in an agent pane.
 
 **History.** On startup and after `repo.add`, the indexer walks HEAD history into SQLite, so
 `timeline`, `sessions`, and `commit.search` work over history rather than just live HEAD.
@@ -59,7 +72,13 @@ safety net.
 
 - All git and tmux work runs in `spawn_blocking`; the reactor never blocks.
 - SQLite writes go through one owned connection on a dedicated thread.
-- The output streamer only fast-polls *visible* lanes; at rest it does nothing.
+- The output streamer fast-polls only *visible* lanes, on an activity-driven backoff (the
+  focused pane stays fast; idle/background panes back off to a cap) with a per-tick capture cap,
+  and each tmux capture is a single fork; at rest it does nothing.
+- Hot reads are cached so rapid client polls don't re-scan: the `lane.list` overlay (lanes +
+  agent sessions) behind a short TTL invalidated only on structural changes, plus per-worktree
+  gix-status, per-repo `git worktree list`, and per-window pending-prompt caches. A transcript
+  write touches no worktree, so it never triggers a status walk.
 - The TUI renders cached state, so first paint doesn't wait on the daemon.
 
 ### Measured (release, macOS, 3 fixture repos × 8 commits)
@@ -68,11 +87,18 @@ safety net.
 |---|---|---|
 | daemon cold start | < 500 ms | ~15 ms |
 | `repomon --print-once` (warm daemon) | < 100 ms | ~38 ms median |
-| idle daemon CPU (no agents) | < 1 % | 0.0 % |
+| daemon CPU, monitoring agents (idle) | < 2 % | ~1.35 % avg · median 0 % |
+| daemon CPU, 8-pane Grid live-streaming | < 6 % | ~5 % avg · 2.5 % median |
 
-(`hyperfine` wasn't available, so these were timed with a `perf_counter` harness over fixture
-repos.) The per-lane Claude status lookup is an O(1) encoded-directory check on the hot path;
-the encoding-drift fallback scan is reserved for explicit use to keep refresh fast.
+(`hyperfine` wasn't available, so the latency rows were timed with a `perf_counter` harness over
+fixture repos; the CPU rows were sampled live via `ps` CPU-time deltas.) The per-lane Claude
+status lookup is an O(1) encoded-directory check on the hot path; the encoding-drift fallback
+scan is reserved for explicit use to keep refresh fast.
+
+The CPU figures are post-optimization. The daemon previously pegged a core (~150 % sustained,
+all fork/exec overhead from a flat-10 Hz multi-fork pane streamer and a per-call worktree-walk
+storm — the tmux server itself idled at 0.3 %); the streamer backoff, single-fork captures, and
+the overlay/status caches above brought it down to the numbers shown.
 
 See [protocol.md](protocol.md) for the wire API and [agents.md](agents.md) for agent
 integration.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -69,20 +69,20 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.remove` | `{ name }` | `null` (drop a custom agent; clears it as default; rejects built-ins) |
 | `agent.set_default` | `{ name? }` | `null` (set/clear the New Lane default; `name` may be a built-in or custom) |
 | `agent.spawn` | `{ lane_id, agent, task? }` | `{ lane_id, window, agent }` |
-| `agent.capture` | `{ lane_id, lines? }` | `{ content }` (ANSI-colored) |
+| `agent.capture` | `{ lane_id, lines?, window? }` | `{ content }` (ANSI-colored; `window` captures one agent in a multi-agent lane) |
 | `agent.transcript` | `{ lane_id, session_id?, limit=50 }` | `[TranscriptItem]` — `{ role, text, at? }` with role `user`/`assistant`/`tools`; full unwrapped message text for clients that lay text out themselves (the mobile chat view). Claude sessions only (empty otherwise). |
-| `agent.send_input` | `{ lane_id, text }` | `null` (types text + Enter) |
-| `agent.key` | `{ lane_id, key, literal=false }` | `null` (one keystroke: literal char or key name) |
-| `agent.signal` | `{ lane_id, key }` | `null` |
-| `agent.stop` | `{ lane_id }` | `null` |
+| `agent.send_input` | `{ lane_id, text, enter=true, window? }` | `null` (types text, then Enter unless `enter=false`; `window` targets one agent in a multi-agent lane) |
+| `agent.key` | `{ lane_id, key, literal=false, window? }` | `null` (one keystroke: literal char or key name; `window` targets one agent in a multi-agent lane) |
+| `agent.signal` | `{ lane_id, key, window? }` | `null` |
+| `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
 | `agent.pin` | `{ lane_id, pinned }` | `null` |
-| `agent.target` | `{ lane_id }` | `{ target, available }` |
+| `agent.target` | `{ lane_id, window? }` | `{ target, available }` |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
 | `terminal.close` | `{ id }` | `null` |
 | `terminal.target` | `{ id }` | `{ target, available }` |
 | `fs.browse` | `{ path? }` | `BrowseResult` (subdirs, repos, added flags) |
-| `viewport.set` | `{ lane_ids }` | `null` |
+| `viewport.set` | `{ lane_ids, focus_lane?, focus_window? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot) |
 | `subscribe` | `{ topics? }` | `null` |
 | `ping` | — | `"pong"` (remote keep-alive / connectivity probe) |
 | `push.register` | `{ device_token }` | `null` (register an APNs device for push; idempotent) |


### PR DESCRIPTION
Documentation was lagging the multi-agent, CPU, watcher-lifecycle, and daemon
desktop-notification work merged this cycle (PRs #4–#7). This corrects the stale
claims against the current code — every change verified against the source, no
behavior changes.

## What changed
- **`docs/agents.md`** — removes the false "repomon manages one session per worktree
  at a time (a single tmux window)" line; documents multiple agents per worktree
  (`lane-<id>`, `lane-<id>-2`, …), the `×N` Fleet/sidebar badge, and `Tab` cycling.
- **`docs/architecture.md`** — multi-window spawn + per-window input routing; the
  filesystem watcher now held in `Ctx` and watched/unwatched on `repo.add`/`repo.remove`;
  the `notify_watch` desktop-notification engine (gated on the TUI's `lane.list`
  heartbeat); the overlay/status caches and activity-driven streamer backoff; and real
  post-optimization CPU numbers (~1.35% avg while monitoring, ~5% avg / 2.5% median on an
  8-pane grid, down from ~150% sustained).
- **`docs/protocol.md`** — the optional params the daemon already accepts: `window?` on
  `agent.capture`/`send_input`/`key`/`signal`/`stop`/`target`, `enter=true` on
  `send_input`, and `focus_lane?`/`focus_window?` on `viewport.set`.
- **`README.md`** — notifications fire as desktop popups even when the TUI is closed or
  parked full-screen in an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
