### PR TITLE
feat(tui): remove a repo from the Fleet view with X (two-press confirm)

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -14,7 +14,7 @@ use ratatui::text::Line;
 use ratatui::DefaultTerminal;
 use repomon_core::model::{
     AgentChoice, AgentSession, AgentStatus, BrowseEntry, BrowseResult, Commit, Lane, LaneId, Repo,
-    TimelineData, WorkSession,
+    RepoId, TimelineData, WorkSession,
 };
 use repomon_core::notify::{
     diff_session_transitions, session_by_key, session_statuses, slot_by_key, SessKey,
@@ -254,6 +254,9 @@ pub struct App {
     /// Pending bulk repo-discover (root, found paths): armed by a first `d`, committed by a second
     /// — so a recursive scan of a deep folder can't flood the fleet on a single keypress.
     discover_pending: Option<(String, Vec<String>)>,
+    /// Two-press confirm for unregistering a whole repo from the Fleet (`X`): the repo id armed
+    /// by the first press. Cleared by any other action, so navigating away cancels it.
+    repo_remove_armed: Option<RepoId>,
     /// Agent-manager state: the list, the cursor, and the add/edit form.
     pub agents: Vec<AgentChoice>,
     pub agents_selected: usize,
@@ -365,6 +368,7 @@ impl App {
             browse_selected: 0,
             repo_remove_pending: None,
             discover_pending: None,
+            repo_remove_armed: None,
             agents: Vec::new(),
             agents_selected: 0,
             ag_editing: false,
@@ -2765,6 +2769,11 @@ impl App {
     }
 
     async fn apply(&mut self, action: Action) {
+        // Any action other than a second `X` cancels a pending repo-removal confirm, so moving
+        // the cursor (or any other key) safely backs out of it.
+        if !matches!(action, Action::RemoveRepo) {
+            self.repo_remove_armed = None;
+        }
         match action {
             Action::MoveUp => self.selected = self.selected.saturating_sub(1),
             Action::MoveDown => {
@@ -2858,6 +2867,40 @@ impl App {
                         }
                         Err(e) => self.status = format!("delete failed: {e}"),
                     }
+                }
+            }
+            Action::RemoveRepo => {
+                // Unregister the selected lane's whole repo (all its lanes), with a two-press
+                // confirm. Unregister only: the daemon drops the registry row and stops watching
+                // the tree, but worktree files and running agents are left untouched.
+                let Some((repo_id, name)) =
+                    self.selected_lane().map(|l| (l.repo.id, l.repo.name.clone()))
+                else {
+                    return;
+                };
+                let n = self.lanes.iter().filter(|l| l.repo.id == repo_id).count();
+                if self.repo_remove_armed != Some(repo_id) {
+                    self.repo_remove_armed = Some(repo_id);
+                    self.status = format!(
+                        "remove repo {name} ({n} lanes) from repomon? \
+                         files & agents left untouched — press X again to confirm"
+                    );
+                    return;
+                }
+                self.repo_remove_armed = None;
+                match self
+                    .client
+                    .call("repo.remove", Some(json!({ "repo_id": repo_id })))
+                    .await
+                {
+                    Ok(_) => {
+                        self.refresh().await;
+                        self.status = format!(
+                            "removed repo {name} — worktrees & agents left running; \
+                             re-add with `repomon add`"
+                        );
+                    }
+                    Err(e) => self.status = format!("remove failed: {e}"),
                 }
             }
             Action::StartFilter => {

--- a/crates/repomon-tui/src/keybinds.rs
+++ b/crates/repomon-tui/src/keybinds.rs
@@ -45,6 +45,9 @@ pub enum Action {
     Quit,
     NewLane,
     DeleteLane,
+    /// Unregister the selected lane's whole repo from repomon (two-press confirm). Worktree
+    /// files and running agents are left untouched — re-add with `repomon add`.
+    RemoveRepo,
     StartFilter,
     Refresh,
     CdToLane,
@@ -79,6 +82,7 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('q') => Some(Action::Quit),
         KeyCode::Char('n') => Some(Action::NewLane),
         KeyCode::Char('d') | KeyCode::Char('x') => Some(Action::DeleteLane),
+        KeyCode::Char('X') => Some(Action::RemoveRepo),
         KeyCode::Char('/') => Some(Action::StartFilter),
         KeyCode::Char('r') => Some(Action::Refresh),
         KeyCode::Char('c') => Some(Action::CdToLane),
@@ -105,5 +109,25 @@ pub fn nav(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('4') => Some(Action::Goto(View::Search)),
         KeyCode::Char('5') => Some(Action::Goto(View::Notifications)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    fn k(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn capital_x_removes_repo_while_lowercase_deletes_a_lane() {
+        // Capital X is the repo-level scope (unregister the whole project, two-press confirm);
+        // lowercase d/x stay lane-level deletes. Keeping them distinct prevents a fat-fingered
+        // lane delete from nuking a repo.
+        assert_eq!(nav(k('X')), Some(Action::RemoveRepo));
+        assert_eq!(nav(k('d')), Some(Action::DeleteLane));
+        assert_eq!(nav(k('x')), Some(Action::DeleteLane));
     }
 }

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -17,7 +17,7 @@ use crate::notify::NotifKind;
 use crate::theme;
 
 const FLEET_KEYS: &str =
-    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
+    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";


### PR DESCRIPTION
## Problem
Removing a repo you're no longer working on was only possible via the file browser (`a` →
navigate to the repo's parent directory → `x x`) — undiscoverable from the **Fleet**, where
your repos are listed. It felt like repos couldn't be removed at all.

## Fix
A Fleet-level remove action: highlight any lane in the repo, press **`X`**, and a second `X`
confirms (status bar names the repo + its lane count). Mirrors the existing `d d` discover and
`x x` browser two-press patterns.

- **Unregister-only**, reusing the daemon's existing `repo.remove`: drops the registry row and
  stops the file watcher; **worktree files and running agents are left untouched** (re-add with
  `repomon add`). The user explicitly chose this over any destructive cleanup.
- Capital `X` = repo-level scope; lowercase `d`/`x` stay lane-level deletes, so a fat-fingered
  lane delete can't nuke a project.
- The pending confirm is armed per repo id and cleared by any other action — navigating away
  cancels it, and pressing `X` on a different repo just re-arms for that one (never removes the
  wrong repo).
- Footer hint added (`… d del · X rm-repo …`); pure `nav()`-mapping unit test added.

TUI-only — no daemon, protocol, or iOS change.

## Verification
`cargo build/clippy/test -p repomon-tui` all green (13 tests, +1 new). Manual: `X`, `X` on a
repo's lane → the repo and its lanes vanish from the Fleet; the worktree dir and agent tmux
windows remain; `repomon add <path>` re-adds it. `X` then an arrow → confirm cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
