### PR TITLE
perf(daemon): frame-rate pane capture while typing so keystroke echo feels instant

### DIFF
--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -69,6 +69,10 @@ pub struct Ctx {
     /// notification engine fires desktop popups itself once this goes stale, so an alert still
     /// reaches you when you're heads-down full-screen in an agent.
     pub local_watcher_seen: Mutex<Option<Instant>>,
+    /// When a key/text/signal was last sent to each lane's agent. The output streamer reads this
+    /// to capture an actively-typed pane at frame-rate (so keystroke echo feels instant), then
+    /// relaxes back to the normal cadence once typing stops.
+    pub input_seen: Mutex<HashMap<LaneId, Instant>>,
     pub shutdown: Notify,
 }
 
@@ -113,6 +117,7 @@ impl Ctx {
             auto_continue_off: Mutex::new(HashSet::new()),
             watcher: Mutex::new(None),
             local_watcher_seen: Mutex::new(None),
+            input_seen: Mutex::new(HashMap::new()),
             shutdown: Notify::new(),
         })
     }
@@ -146,12 +151,12 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
     use std::time::{Duration, Instant};
 
     /// Per-lane streaming state: the last pushed window+content, the current poll interval, and
-    /// when this lane is next due for a capture.
+    /// when this lane was last captured.
     struct St {
         window: String,
         content: String,
         backoff: Duration,
-        next_due: Instant,
+        last_cap: Instant,
     }
     // Activity-driven cadence: a lane is captured at its FLOOR while its pane keeps changing, and
     // its interval doubles toward a CAP once the pane goes quiet (reset to FLOOR on any change).
@@ -162,6 +167,12 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
     const FOCUS_CAP: Duration = Duration::from_millis(600);
     const BG_FLOOR: Duration = Duration::from_millis(700);
     const BG_CAP: Duration = Duration::from_millis(3000);
+    // While a pane is being actively typed into, capture it at ~frame-rate so keystroke echo
+    // feels instant. This regime applies for TYPING_WINDOW after the last key, then relaxes back
+    // to the focused/background cadence above — a brief single-pane burst, only while typing.
+    const TYPING_FLOOR: Duration = Duration::from_millis(30);
+    const TYPING_CAP: Duration = Duration::from_millis(60);
+    const TYPING_WINDOW: Duration = Duration::from_millis(400);
     // Hard ceiling on captures per tick so entering a busy Grid (every pane "fresh" at once) can't
     // burst the whole viewport in one tick — the focused lane always goes first, the rest are
     // serviced round-robin across ticks.
@@ -169,7 +180,11 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
 
     let mut state: HashMap<LaneId, St> = HashMap::new();
     let mut rr: usize = 0; // round-robin offset so background lanes share the per-tick budget fairly
-    let mut tick = tokio::time::interval(FOCUS_FLOOR);
+    // The base tick must be at least as fast as the tightest regime (TYPING_FLOOR); per-lane
+    // gating below keeps non-typing lanes at their slower cadence, so these extra wakeups are
+    // cheap no-ops (no captures) when nothing is being typed.
+    let mut tick = tokio::time::interval(TYPING_FLOOR);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         tick.tick().await;
         let lanes: Vec<LaneId> = ctx.viewport.lock().await.clone();
@@ -181,6 +196,12 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
         let focus_lane = focus.as_ref().map(|(l, _)| *l);
         state.retain(|k, _| lanes.contains(k));
         let now = Instant::now();
+        // Snapshot (and prune) which lanes were typed into recently — they capture at frame-rate.
+        let typing_lanes: HashMap<LaneId, Instant> = {
+            let mut m = ctx.input_seen.lock().await;
+            m.retain(|_, t| now.saturating_duration_since(*t) < TYPING_WINDOW);
+            m.clone()
+        };
 
         // Service the focused lane first (so the per-tick cap never starves what the user is
         // watching), then the rest from a rotating offset so every background pane gets a turn.
@@ -207,11 +228,30 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                 Some((l, w)) if *l == lane => w.clone(),
                 _ => TmuxRuntime::window_name(lane),
             };
+            // Cadence regime: a lane typed into within TYPING_WINDOW captures at frame-rate;
+            // otherwise the focused lane is fast and background/Grid tiles slow.
+            let typing = typing_lanes
+                .get(&lane)
+                .is_some_and(|t| now.saturating_duration_since(*t) < TYPING_WINDOW);
+            let (floor, cap) = if typing {
+                (TYPING_FLOOR, TYPING_CAP)
+            } else if is_focused {
+                (FOCUS_FLOOR, FOCUS_CAP)
+            } else {
+                (BG_FLOOR, BG_CAP)
+            };
+            // The poll interval, re-clamped to the current regime each tick — so the moment a lane
+            // starts being typed into, a stale 150ms wait shrinks to <=60ms and it captures on the
+            // next tick (prompt first-keystroke echo without coupling to the input handler).
+            let interval = state
+                .get(&lane)
+                .map(|s| s.backoff.clamp(floor, cap))
+                .unwrap_or(floor);
             // Not due yet (and window unchanged) → leave it for a later tick; costs nothing. A
             // lane absent from the map (freshly spawned / first frame) or whose window switched
             // (Tab) is always due, so fresh output shows immediately.
             if let Some(s) = state.get(&lane) {
-                if s.window == window && now < s.next_due {
+                if s.window == window && now < s.last_cap + interval {
                     continue;
                 }
             }
@@ -231,30 +271,15 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                 .get(&lane)
                 .map(|s| s.window != window || s.content != content)
                 .unwrap_or(true);
-            let (floor, cap) = if is_focused {
-                (FOCUS_FLOOR, FOCUS_CAP)
-            } else {
-                (BG_FLOOR, BG_CAP)
-            };
-            // Reset to the floor on any change; otherwise double the interval toward the cap.
-            let backoff = if changed {
-                floor
-            } else {
-                state
-                    .get(&lane)
-                    .map(|s| (s.backoff * 2).min(cap))
-                    .unwrap_or(floor)
-            };
+            // Reset to the floor on any change; otherwise double the (clamped) interval toward cap.
+            let backoff = if changed { floor } else { (interval * 2).min(cap) };
             if changed {
                 ctx.broadcast(
                     pubsub::topic::AGENT_OUTPUT,
                     serde_json::json!({ "lane_id": lane, "content": content.clone() }),
                 );
             }
-            state.insert(
-                lane,
-                St { window, content, backoff, next_due: now + backoff },
-            );
+            state.insert(lane, St { window, content, backoff, last_cap: now });
         }
     }
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -775,28 +775,26 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             .await
             .map_err(internal)?
             .map_err(internal)?;
+            ctx.input_seen.lock().await.insert(lane, std::time::Instant::now());
             Ok(Value::Null)
         }
         "agent.signal" => {
             let p: AgentSignal = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let key = p.key;
-            let window = p
-                .window
-                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            let (lane, key) = (p.lane_id, p.key);
+            let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             tokio::task::spawn_blocking(move || tmux.send_key_named(&window, &key))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
+            ctx.input_seen.lock().await.insert(lane, std::time::Instant::now());
             Ok(Value::Null)
         }
         "agent.key" => {
             let p: AgentKey = parse(params)?;
             let tmux = ctx.tmux.clone();
-            let (key, literal) = (p.key, p.literal);
-            let window = p
-                .window
-                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            let (lane, key, literal) = (p.lane_id, p.key, p.literal);
+            let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             tokio::task::spawn_blocking(move || {
                 if literal {
                     tmux.send_literal_named(&window, &key)
@@ -807,6 +805,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             .await
             .map_err(internal)?
             .map_err(internal)?;
+            ctx.input_seen.lock().await.insert(lane, std::time::Instant::now());
             Ok(Value::Null)
         }
         "agent.stop" => {


### PR DESCRIPTION
## Problem
Typing into a focused agent (`i` INSERT mode) felt laggy. The path is daemon-mediated: a
keystroke → `agent.key`/`send_input`/`signal` → `send-keys` (fast), but you only *see* the echo
when `stream_output` next captures the pane and broadcasts `event.agent.output` — at
`FOCUS_FLOOR = 150 ms`, with the input handlers doing nothing to hurry it. So every character had
up to ~150 ms of echo lag.

## Fix
Make the streamer's per-lane cadence **input-aware**:
- The three input handlers stamp `Ctx.input_seen[lane]`.
- `stream_output` captures a lane typed into within the last `TYPING_WINDOW` (400 ms) at
  frame-rate (`TYPING_FLOOR` 30 ms / `TYPING_CAP` 60 ms), then relaxes to the existing focused
  (150/600) and background (700/3000) regimes.
- The base tick drops to 30 ms (`MissedTickBehavior::Skip`); the per-lane timer moves from
  `next_due` to `last_cap` + a **re-clamped** `interval`, so a stale 150 ms wait instantly shrinks
  to ≤60 ms when typing starts — prompt first-keystroke echo, no handler↔streamer coupling.

**Net:** echo drops from ~150 ms to ~30 ms (≤60 ms worst) while typing.

## CPU
A brief **single-pane** ~30 captures/sec, *only while actively typing*; non-typing/idle lanes keep
their cadence. Verified after restart: `sample` shows all tokio workers parked in `kevent` (no
busy-loop / reactor spin); idle/empty-viewport ticks park straight back. The <2% idle and
~5%/8-pane-grid targets are preserved. Daemon-only — TUI/protocol unchanged.

## Verification
`cargo build/clippy -D warnings/test` all green (workspace). Reinstalled `repomond` + restarted.
Manual: `i` then type fast → near-instant echo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
