### PR TITLE
feat: show the agent's text cursor in the mediated focus/insert view

### DIFF
--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -237,6 +237,28 @@ impl TmuxRuntime {
         self.run_allow_absent(&args)
     }
 
+    /// The agent pane's cursor position `(col, row)`, 0-based from the top-left of the visible
+    /// pane, when the app is actually showing a cursor (`cursor_flag`). `None` if the window is
+    /// gone or the cursor is hidden. Used to draw the cursor in the mediated focus/insert view.
+    pub fn cursor_named(&self, window: &str) -> Option<(u16, u16)> {
+        let target = self.exact_target(window);
+        let out = self
+            .run_allow_absent(&[
+                "display-message",
+                "-p",
+                "-t",
+                &target,
+                "-F",
+                "#{cursor_x} #{cursor_y} #{cursor_flag}",
+            ])
+            .ok()?;
+        let mut it = out.split_whitespace();
+        let x: u16 = it.next()?.parse().ok()?;
+        let y: u16 = it.next()?.parse().ok()?;
+        let visible = it.next() == Some("1");
+        visible.then_some((x, y))
+    }
+
     /// Send a literal string (no trailing Enter) — one keystroke's worth of input.
     pub fn send_literal(&self, lane: LaneId, text: &str) -> Result<()> {
         self.send_literal_named(&Self::window_name(lane), text)

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -157,6 +157,8 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
         content: String,
         backoff: Duration,
         last_cap: Instant,
+        /// The focused pane's last-seen cursor `(col, row)`, so a cursor-only move still re-pushes.
+        cursor: Option<(u16, u16)>,
     }
     // Activity-driven cadence: a lane is captured at its FLOOR while its pane keeps changing, and
     // its interval doubles toward a CAP once the pane goes quiet (reset to FLOOR on any change).
@@ -267,19 +269,43 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                     Ok(Ok(c)) => c,
                     _ => continue,
                 };
-            let changed = state
+            // Only the focused pane carries a cursor (the TUI renders it where you're typing) — one
+            // extra tmux fork on a single pane, never on background/Grid tiles.
+            let cursor = if is_focused {
+                let tmux = ctx.tmux.clone();
+                let cw = window.clone();
+                tokio::task::spawn_blocking(move || tmux.cursor_named(&cw))
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+            let content_changed = state
                 .get(&lane)
                 .map(|s| s.window != window || s.content != content)
                 .unwrap_or(true);
+            // The focused pane also re-pushes on a cursor-only move (arrowing within the input box)
+            // so the rendered cursor tracks even when the text itself is unchanged.
+            let cursor_changed =
+                is_focused && state.get(&lane).map(|s| s.cursor != cursor).unwrap_or(true);
+            let changed = content_changed || cursor_changed;
             // Reset to the floor on any change; otherwise double the (clamped) interval toward cap.
             let backoff = if changed { floor } else { (interval * 2).min(cap) };
             if changed {
                 ctx.broadcast(
                     pubsub::topic::AGENT_OUTPUT,
-                    serde_json::json!({ "lane_id": lane, "content": content.clone() }),
+                    serde_json::json!({
+                        "lane_id": lane,
+                        "content": content.clone(),
+                        "cursor": cursor.map(|(x, y)| [x, y]),
+                    }),
                 );
             }
-            state.insert(lane, St { window, content, backoff, last_cap: now });
+            state.insert(
+                lane,
+                St { window, content, backoff, last_cap: now, cursor },
+            );
         }
     }
 }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -73,6 +73,10 @@ impl Zoom {
 pub struct Pane {
     pub raw: String,
     pub lines: Vec<Line<'static>>,
+    /// The agent pane's cursor `(col, row)` (0-based, from the top-left of the captured pane),
+    /// when the daemon reported one for this (focused) lane. The render places the terminal cursor
+    /// here while you're typing into the agent. `None` for background panes / hidden cursors.
+    pub cursor: Option<(u16, u16)>,
 }
 
 /// A clickable lane region recorded during render (in `view.rs`) and hit-tested by the mouse
@@ -1115,7 +1119,13 @@ impl App {
                 // Parse the ANSI once, here, instead of on every render of this pane.
                 let raw = content.to_string();
                 let lines = view::parse_pane(&raw);
-                self.output.insert(id, Pane { raw, lines });
+                // The daemon attaches the agent pane's cursor for the focused lane (`[col, row]`).
+                let cursor = note
+                    .params
+                    .get("cursor")
+                    .and_then(|v| v.as_array())
+                    .and_then(|a| Some((a.first()?.as_u64()? as u16, a.get(1)?.as_u64()? as u16)));
+                self.output.insert(id, Pane { raw, lines, cursor });
             }
         } else {
             // Don't refresh inline — the event loop coalesces a burst of notifications into a

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -873,6 +873,17 @@ fn render_split(f: &mut Frame, app: &App) {
     if let Some(id) = id {
         click_zone(app, body[2], id, true);
     }
+    // Show the agent's text cursor where you're typing — INSERT mode at the live tail only.
+    if app.focus_insert && app.scroll == 0 && has_output {
+        if let Some(p) = id.and_then(|i| app.output.get(&i)) {
+            if let Some((cx, cy)) = p.cursor {
+                let h = (body[2].height as usize).max(1);
+                let start = p.lines.len().saturating_sub(h);
+                let count = p.lines.len() - start;
+                place_pane_cursor(f, body[2], start, count, (cx, cy));
+            }
+        }
+    }
 
     // INSERT here forwards keystrokes straight to the selected agent (no need to zoom).
     let mode = if app.focus_insert {
@@ -930,6 +941,15 @@ fn render_focus(f: &mut Frame, app: &App) {
     let avail = (rows[1].height as usize).saturating_sub(body.len());
     body.extend(focus_output(app, lane.map(|l| l.id), avail, out_y0));
     f.render_widget(Paragraph::new(body), rows[1]);
+
+    // Show the agent's text cursor where you're typing — INSERT mode at the live tail only.
+    if app.focus_insert && app.scroll == 0 {
+        if let Some((cx, cy)) = lane.and_then(|l| app.output.get(&l.id)).and_then(|p| p.cursor) {
+            let (cur_y0, start, count) = app.focus_geom.get();
+            let pane = Rect { x: rows[1].x, y: cur_y0, width: rows[1].width, height: count as u16 };
+            place_pane_cursor(f, pane, start, count, (cx, cy));
+        }
+    }
 
     // Mode indicator: SCROLL while paging back, else reverse-video INSERT vs dim COMMAND.
     let mode = if app.scroll > 0 {
@@ -1241,6 +1261,23 @@ fn output_window(total: usize, height: usize, scroll: usize) -> (usize, usize) {
     let s = scroll.min(total - h);
     let end = total - s;
     (end - h, end)
+}
+
+/// Place the real terminal cursor at the agent pane's cursor, when it falls inside the visible
+/// window of the rendered pane. `area` is the pane's screen rect; `start` is the index of the first
+/// visible captured line and `count` how many are shown; `(cx, cy)` is the agent cursor in
+/// captured-pane coordinates (col, row). No-op when the cursor row is scrolled out of view or the
+/// column runs past the pane width.
+fn place_pane_cursor(f: &mut Frame, area: Rect, start: usize, count: usize, (cx, cy): (u16, u16)) {
+    let cy = cy as usize;
+    if cy < start || cy >= start + count {
+        return;
+    }
+    let row = (cy - start) as u16;
+    if row >= area.height || cx >= area.width {
+        return;
+    }
+    f.set_cursor_position((area.x + cx, area.y + row));
 }
 
 /// The Focus pane's visible lines: the live tail (or the scrollback window), ANSI-colored,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -102,7 +102,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `event.lane.created` | `{ lane }` |
 | `event.lane.deleted` | `{ lane_id }` |
 | `event.agent.status` | `{ lane_id, status }` |
-| `event.agent.output` | `{ lane_id, content }` |
+| `event.agent.output` | `{ lane_id, content, cursor? }` (`cursor` is `[col, row]` — the pane's text-cursor position, 0-based from the pane's top-left — sent only for the focused lane when its cursor is visible; `null`/absent otherwise) |
 | `event.agent.changed` | `{ name }` or `{ default }` (a custom agent was added/removed, or the default changed) |
 | `event.notification` | `{ lane_id, session_id?, kind, title, body, prompt? }` — daemon-side agent alert (kinds: `needs_you`, `rate_limited`, `resumed`, `idle`; `prompt` is the agent's pending question verbatim). Emitted only while `[remote]` is enabled; the same alert goes to APNs devices with category `AGENT_PROMPT` (actionable) or `AGENT_ALERT`. |
 


### PR DESCRIPTION
## Problem
In the mediated focus/insert view the agent pane is a `capture-pane` text snapshot, which carries
**no cursor** — so while typing (INSERT mode) you couldn't see where the agent's cursor was. Only
the real `attach` terminal (`↵`) showed one.

## Fix
- **Daemon** reads the focused pane's cursor from tmux (`display-message
  '#{cursor_x} #{cursor_y} #{cursor_flag}'`, new `cursor_named`) and ships it on
  `event.agent.output` as `cursor: [col, row]` — **focused lane only**. A cursor-only move (arrowing
  within the input box) re-pushes so it tracks even without a text change; background/Grid panes
  fetch no cursor and pay nothing.
- **TUI** stores it on `Pane` and, while in **INSERT mode at the live tail**, places the real
  terminal cursor (`set_cursor_position`) at the mapped screen cell in both **Split** and **Focus**
  (shared `place_pane_cursor` helper bounds-guards and skips when the cursor row is scrolled out of
  view). It rides the input-aware streamer, so it tracks at ~30 ms while typing.
- `docs/protocol.md` documents the new optional field.

## Verification
`cargo build` / `clippy -D warnings` / full test suite green. Verified the tmux source live
(`display-message` → `20 65 1`). Both binaries reinstalled + daemon restarted.

Manual: `i` then type → a cursor sits where you're typing and tracks edits; `esc`/`PgUp` hide it;
`Tab` moves it to the newly-selected agent's pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
