### PR TITLE
fix(daemon): drop a /exited agent from the ×N count promptly

### DIFF
--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -73,6 +73,11 @@ pub struct Ctx {
     /// to capture an actively-typed pane at frame-rate (so keystroke echo feels instant), then
     /// relaxes back to the normal cadence once typing stops.
     pub input_seen: Mutex<HashMap<LaneId, Instant>>,
+    /// The set of managed (`lane-…`) tmux windows seen on the previous overlay. When one
+    /// disappears (an agent `/exit`ed or was stopped), the overlay refreshes the live-process
+    /// count immediately so the vanished agent drops from the `×N` count without waiting out the
+    /// `live_cwds` cache TTL.
+    pub last_managed_windows: Mutex<HashSet<String>>,
     pub shutdown: Notify,
 }
 
@@ -118,6 +123,7 @@ impl Ctx {
             watcher: Mutex::new(None),
             local_watcher_seen: Mutex::new(None),
             input_seen: Mutex::new(HashMap::new()),
+            last_managed_windows: Mutex::new(HashSet::new()),
             shutdown: Notify::new(),
         })
     }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1097,6 +1097,22 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let windows = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
         .await
         .unwrap_or_default();
+    // If a managed (`lane-…`) window vanished since the last overlay — an agent `/exit`ed or was
+    // stopped — the cached live-process count is now stale-high and would keep the dead session in
+    // the lane's `×N` count for up to the cache TTL. Drop the cache so `live_cwds_cached` recomputes
+    // fresh on the very next line, and the gone agent disappears within one refresh.
+    let managed_now: std::collections::HashSet<String> = windows
+        .iter()
+        .filter(|w| w.starts_with("lane-"))
+        .cloned()
+        .collect();
+    {
+        let mut prev = ctx.last_managed_windows.lock().await;
+        if prev.difference(&managed_now).next().is_some() {
+            *ctx.live_cwds.lock().await = None;
+        }
+        *prev = managed_now;
+    }
     // A `/exit`ed session leaves a recently-modified transcript behind but is no longer
     // running. claude's cwd is the worktree, so the number of live claude processes there
     // bounds how many sessions are actually running — keep that many of the most recent.


### PR DESCRIPTION
## Problem
`/exit`ing a managed agent closes its tmux window immediately, but the lane's `×N` badge could
stay too high. `overlay_agents` keeps a worktree's recent Claude transcripts truncated to
`alive.max(managed_n)`, where `alive` (live `claude` processes) is **cached ~10s**. On `/exit` the
window vanishes (`managed_n` drops) but the stale-high `alive` keeps the just-exited session's
still-recent transcript — shown as an extra `external` session — so the count lingered for up to the
cache TTL (and indefinitely if a real external claude shared the worktree).

Confirmed against the live daemon via `lane.list`: the badge counts managed windows **plus** external
claude transcripts in the worktree.

## Fix
Track the set of managed (`lane-…`) windows across overlays; when one disappears (an agent `/exit`ed
or was stopped), invalidate the `live_cwds` cache so the next overlay recomputes the process count
fresh — the gone agent drops within **one refresh** (~1s) instead of up to ~10s.

- One extra `lsof` only on the rare exit event; steady-state cadence and the cache TTL are untouched,
  so the CPU posture from the perf work is preserved.
- Genuine external sessions (a `claude` in another terminal) are still shown — only the dead managed
  one is removed.

Daemon-only — the TUI/iOS render whatever `agent_sessions` the daemon returns, so they benefit for
free.

## Verification
`cargo build/clippy -D warnings/test` green; daemon reinstalled + restarted; `lane.list` healthy.
Manual: spawn 2 agents in a clean worktree (`×2`), `/exit` one → drops to `×1` within ~1–2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
