### PR TITLE
feat: smooth scrolling in the Split agent pane + fit the agent terminal to the view

### DIFF
--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -259,6 +259,24 @@ impl TmuxRuntime {
         visible.then_some((x, y))
     }
 
+    /// Resize a window to `cols × rows` so the mediated view's pane reflows to exactly the visible
+    /// width (no right-edge clipping). `resize-window` sets the window's `window-size` to `manual`;
+    /// [`follow_client_named`](Self::follow_client_named) restores client-follow before an attach.
+    pub fn resize_named(&self, window: &str, cols: u16, rows: u16) -> Result<()> {
+        let target = self.exact_target(window);
+        let (cols, rows) = (cols.to_string(), rows.to_string());
+        self.run_allow_absent(&["resize-window", "-t", &target, "-x", &cols, "-y", &rows])?;
+        Ok(())
+    }
+
+    /// Let `window` follow the attaching client's size again (undoing `resize_named`'s manual
+    /// size), so `tmux attach` renders the agent at the real terminal's full size.
+    pub fn follow_client_named(&self, window: &str) -> Result<()> {
+        let target = self.exact_target(window);
+        self.run_allow_absent(&["set-window-option", "-t", &target, "window-size", "latest"])?;
+        Ok(())
+    }
+
     /// Send a literal string (no trailing Enter) — one keystroke's worth of input.
     pub fn send_literal(&self, lane: LaneId, text: &str) -> Result<()> {
         self.send_literal_named(&Self::window_name(lane), text)

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -144,6 +144,14 @@ struct AgentTarget {
     window: Option<String>,
 }
 #[derive(Deserialize)]
+struct AgentResize {
+    lane_id: repomon_core::model::LaneId,
+    cols: u16,
+    rows: u16,
+    #[serde(default)]
+    window: Option<String>,
+}
+#[derive(Deserialize)]
 struct AgentAutoContinue {
     lane_id: repomon_core::model::LaneId,
     enabled: bool,
@@ -843,12 +851,33 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            // This is the pre-attach hook (the TUI calls it right before `tmux attach`). The
+            // mediated view sizes the window to its pane with `agent.resize` (which sets
+            // window-size manual); restore client-follow so the attaching real terminal renders the
+            // agent at full size. The TUI re-fits it on return.
             let w = window.clone();
-            let available = tokio::task::spawn_blocking(move || tmux.has_named(&w))
-                .await
-                .map_err(internal)?;
+            let available = tokio::task::spawn_blocking(move || {
+                let _ = tmux.follow_client_named(&w);
+                tmux.has_named(&w)
+            })
+            .await
+            .map_err(internal)?;
             let target = format!("{}:={}", ctx.tmux.session(), window);
             Ok(json!({ "target": target, "available": available }))
+        }
+        "agent.resize" => {
+            let p: AgentResize = parse(params)?;
+            let tmux = ctx.tmux.clone();
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            // Clamp to a sane floor so a momentary tiny layout can't shrink the agent to nothing.
+            let (cols, rows) = (p.cols.max(20), p.rows.max(4));
+            tokio::task::spawn_blocking(move || tmux.resize_named(&window, cols, rows))
+                .await
+                .map_err(internal)?
+                .map_err(internal)?;
+            Ok(Value::Null)
         }
         // Arm/disarm auto-continue (resume on usage limit) for one lane, this session.
         "agent.auto_continue" => {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -171,6 +171,13 @@ pub struct App {
     pub sel_anchor: Option<usize>,
     pub sel_head: Option<usize>,
     pub focus_geom: std::cell::Cell<(u16, usize, usize)>,
+    /// The focused agent pane's content size `(cols, rows)`, recorded during render of the Split /
+    /// Focus view. The event loop resizes the agent's tmux window to match so it reflows to the
+    /// visible width (no right-edge clipping) instead of staying at a stale `attach` width.
+    pub focus_pane_dims: std::cell::Cell<Option<(u16, u16)>>,
+    /// The `(lane, window, cols, rows)` of the last `agent.resize` sent, so it fires only on a real
+    /// size/focus change rather than every tick.
+    last_resize: Option<(LaneId, String, u16, u16)>,
     /// Clickable lane regions for the current frame, recorded during render and read by the mouse
     /// handler. Cleared and repopulated every render.
     pub click_zones: RefCell<Vec<ClickZone>>,
@@ -315,6 +322,8 @@ impl App {
             sel_anchor: None,
             sel_head: None,
             focus_geom: std::cell::Cell::new((0, 0, 0)),
+            focus_pane_dims: std::cell::Cell::new(None),
+            last_resize: None,
             click_zones: RefCell::new(Vec::new()),
             last_click: None,
             hover_lane: None,
@@ -867,6 +876,37 @@ impl App {
         }
     }
 
+    /// Resize the focused agent's tmux window to match the mediated view's pane, so it reflows to
+    /// the visible width (no right-edge clipping). Only fires on a real size/focus change — view
+    /// switch, terminal resize, or return-from-attach — not every tick.
+    async fn sync_pane_size(&mut self) {
+        if !matches!(self.view, View::Split | View::Focus) {
+            return;
+        }
+        let (Some((cols, rows)), Some(lane), Some(window)) = (
+            self.focus_pane_dims.get(),
+            self.selected_lane().map(|l| l.id),
+            self.selected_window(), // a managed window; `None` for external/no-window sessions
+        ) else {
+            return;
+        };
+        if cols < 4 || rows < 2 {
+            return;
+        }
+        let key = (lane, window.clone(), cols, rows);
+        if self.last_resize.as_ref() == Some(&key) {
+            return;
+        }
+        let _ = self
+            .client
+            .call(
+                "agent.resize",
+                Some(json!({ "lane_id": lane, "cols": cols, "rows": rows, "window": window })),
+            )
+            .await;
+        self.last_resize = Some(key);
+    }
+
     /// Load the selected lane's recent commits (its branch history) when the selection
     /// changes. `recent_commits_lane == None` forces a refetch (e.g. after a repo event).
     pub async fn sync_recent_commits(&mut self) {
@@ -1180,8 +1220,19 @@ impl App {
                             self.settings_click(me.row).await;
                         }
                     }
-                    // Grid/Fleet/Split: a left-click focuses the clicked lane (double-click opens
-                    // its real terminal, a click on empty space blurs); the wheel still navigates.
+                    // Split: the wheel over the agent pane (past the 26-col sidebar + 1-col divider)
+                    // scrolls its output smoothly, line by line; over the sidebar it still moves the
+                    // lane cursor. A left-click focuses the clicked lane (double-click → terminal).
+                    View::Split => match me.kind {
+                        MouseEventKind::ScrollUp if me.column > 26 => self.scroll_up(1).await,
+                        MouseEventKind::ScrollDown if me.column > 26 => self.scroll_down(1),
+                        MouseEventKind::Down(MouseButton::Left) => {
+                            self.handle_click(me.column, me.row).await
+                        }
+                        _ => self.handle_mouse(me),
+                    },
+                    // Grid/Fleet: a left-click focuses the clicked lane (double-click opens its real
+                    // terminal, a click on empty space blurs); the wheel still navigates.
                     _ => match me.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
                             self.handle_click(me.column, me.row).await
@@ -2208,6 +2259,16 @@ impl App {
                 self.focus_insert = false;
                 return;
             }
+            // PgUp/PgDn scroll the captured output even while typing (always reach repomon); any
+            // other key returns to the live tail and goes to the agent.
+            match key.code {
+                KeyCode::PageUp => return self.scroll_up(10).await,
+                KeyCode::PageDown => return self.scroll_down(10),
+                _ => {}
+            }
+            if self.scroll > 0 {
+                self.reset_scroll();
+            }
             self.send_agent_key(key).await;
             return;
         }
@@ -2215,19 +2276,29 @@ impl App {
             self.filter_key(key);
             return;
         }
+        // esc returns to the live tail before it would zoom out.
+        if key.code == KeyCode::Esc && self.scroll > 0 {
+            self.reset_scroll();
+            return;
+        }
         // ↵ opens the selected agent in its real tmux pane (a native terminal); → zooms to the
         // Focus monitor; `i` is a quick mediated type without leaving repomon.
         if key.code == KeyCode::Enter {
+            self.reset_scroll();
             self.attach_request = self.selected_lane().map(|l| l.id);
             return;
         }
         if key.code == KeyCode::Char('i') {
+            self.reset_scroll();
             self.focus_insert = true;
             return;
         }
         match key.code {
             KeyCode::Tab => return self.cycle_session(true),
             KeyCode::BackTab => return self.cycle_session(false),
+            // PgUp/PgDn scroll the pane; arrows still navigate the fleet.
+            KeyCode::PageUp => return self.scroll_up(10).await,
+            KeyCode::PageDown => return self.scroll_down(10),
             _ => {}
         }
         if let Some(action) = keybinds::nav(key) {
@@ -3135,6 +3206,7 @@ async fn event_loop(
     let mut tick = tokio::time::interval(Duration::from_secs(1));
     loop {
         app.sync_viewport().await;
+        app.sync_pane_size().await;
         app.sync_recent_commits().await;
         app.sync_terminals().await;
         app.sync_session_cursor();

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -19,8 +19,9 @@ use crate::theme;
 const FLEET_KEYS: &str =
     "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
-    "↑↓ lane · tab session  ·  click focus · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
-const SPLIT_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O / click-out blur";
+    "↑↓ lane · tab session  ·  click focus · wheel/PgUp scroll · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
+const SPLIT_INSERT_KEYS: &str =
+    "keys → agent (esc · ⇧⇥ · ^C sent) · PgUp/PgDn scroll  ·  ^O / click-out blur";
 const FOCUS_CMD_KEYS: &str =
     "↵/→ open (real terminal) · i quick-type · tab agent · PgUp scroll  ·  e spawn · o adopt · t term · s stop  ·  g/G next · f find  ·  ←/esc back";
 const FOCUS_INSERT_KEYS: &str = "keys → agent (esc · ⇧⇥ · ^C sent)  ·  ^O command-mode";
@@ -857,14 +858,27 @@ fn render_split(f: &mut Frame, app: &App) {
         .map(|_| Line::from(Span::styled(theme::VLIGHT.to_string(), app.theme.muted())))
         .collect();
     f.render_widget(Paragraph::new(divider), body[1]);
-    // Live agent output if there is any, otherwise the lane's git detail.
+    // Record the pane size so the event loop resizes the agent's tmux window to match (reflow to
+    // the visible width — no right-edge clipping).
+    app.focus_pane_dims
+        .set(Some((body[2].width, body[2].height)));
+    // Live agent output if there is any, otherwise the lane's git detail. Shows the scrollback
+    // window when scrolled (`scroll > 0`), else the live tail — both via `output_window`.
     let id = app.selected_lane().map(|l| l.id);
     let has_output = id
         .and_then(|i| app.output.get(&i))
         .map(|p| !p.raw.trim().is_empty())
         .unwrap_or(false);
     let right = if has_output {
-        output_tail(app, id, body[2].height as usize)
+        let h = (body[2].height as usize).max(1);
+        let lines: &[Line<'static>] = if app.scroll > 0 {
+            app.scroll_lines.as_deref().unwrap_or(&[])
+        } else {
+            id.and_then(|i| app.output.get(&i))
+                .map_or(&[][..], |p| p.lines.as_slice())
+        };
+        let (start, end) = output_window(lines.len(), h, app.scroll);
+        lines[start..end].to_vec()
     } else {
         detail_lines(app)
     };
@@ -939,6 +953,9 @@ fn render_focus(f: &mut Frame, app: &App) {
     }
     let out_y0 = rows[1].y + body.len() as u16;
     let avail = (rows[1].height as usize).saturating_sub(body.len());
+    // Record the pane size so the event loop fits the agent's tmux window to the full-screen view.
+    app.focus_pane_dims
+        .set(Some((rows[1].width, avail as u16)));
     body.extend(focus_output(app, lane.map(|l| l.id), avail, out_y0));
     f.render_widget(Paragraph::new(body), rows[1]);
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -76,7 +76,8 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.signal` | `{ lane_id, key, window? }` | `null` |
 | `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
 | `agent.pin` | `{ lane_id, pinned }` | `null` |
-| `agent.target` | `{ lane_id, window? }` | `{ target, available }` |
+| `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
+| `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
 | `terminal.close` | `{ id }` | `null` |


### PR DESCRIPTION
Two fixes for the mediated **Split** view (sidebar + focused agent pane).

## Smooth scrolling
Split had **no** agent-pane scrolling — the wheel moved the fleet cursor and the pane was a fixed
live tail with no scrollback. Now:
- Wheel **over the pane** scrolls its output smoothly, line-by-line; over the sidebar it still moves
  the lane cursor.
- `PgUp`/`PgDn` page (even while typing in INSERT); typing / `esc` returns to the live tail.
- The pane renders the scrollback window when scrolled, else the live tail (shared `output_window`).
- Footer hints updated.

## Fit the agent terminal to the view width
The agent's tmux pane was often **254** cols (a prior `attach` resized it to the full terminal)
while Split's pane is only ~227 — clipping the right edge. The TUI now records the focused pane's
content size each render and resizes the agent's window to match via a new **`agent.resize`** RPC,
so it **reflows to exactly the visible width**. Fires only on a real size/focus change.

`resize-window` sets `window-size manual`; `agent.target` (the pre-attach hook) resets it to
`latest` so **`↵` attach still opens a full-size real terminal**, and returning to the mediated view
re-fits within a tick. (Verified the tmux mechanics + the RPC live: a window went `220x50` →
`111x29` and reset cleanly.)

## Verification
`cargo build` / `clippy -D warnings` / full test suite green. Both binaries reinstalled, daemon
restarted. `agent.resize` exercised end-to-end over the socket. `docs/protocol.md` documents the
new method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
