### PR TITLE
fix(tui): wheel scrolling in Split — drop the pointer-column gate

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1148,6 +1148,9 @@ impl App {
         } else {
             (self.session_idx + n - 1) % n
         };
+        // The scrollback snapshot belonged to the previous agent's window — drop it so the new
+        // agent shows its own live tail instead of stale lines.
+        self.reset_scroll();
     }
 
     async fn on_notification(&mut self, note: Notification) {
@@ -1220,16 +1223,18 @@ impl App {
                             self.settings_click(me.row).await;
                         }
                     }
-                    // Split: the wheel over the agent pane (past the 26-col sidebar + 1-col divider)
-                    // scrolls its output smoothly, line by line; over the sidebar it still moves the
-                    // lane cursor. A left-click focuses the clicked lane (double-click → terminal).
+                    // Split: the wheel scrolls the focused agent pane, smoothly, line by line. No
+                    // column gate — terminals often report wheel events with column 0 / the last
+                    // position, so gating on "is the pointer over the pane" silently breaks it. Use
+                    // the arrow keys to move the lane cursor. A left-click focuses the clicked lane
+                    // (double-click → real terminal).
                     View::Split => match me.kind {
-                        MouseEventKind::ScrollUp if me.column > 26 => self.scroll_up(1).await,
-                        MouseEventKind::ScrollDown if me.column > 26 => self.scroll_down(1),
+                        MouseEventKind::ScrollUp => self.scroll_up(1).await,
+                        MouseEventKind::ScrollDown => self.scroll_down(1),
                         MouseEventKind::Down(MouseButton::Left) => {
                             self.handle_click(me.column, me.row).await
                         }
-                        _ => self.handle_mouse(me),
+                        _ => {}
                     },
                     // Grid/Fleet: a left-click focuses the clicked lane (double-click opens its real
                     // terminal, a click on empty space blurs); the wheel still navigates.


### PR DESCRIPTION
## Problem
After the Split-scroll feature, trackpad/mouse wheel scrolling **didn't work** in the Split view.

Root cause (confirmed by tracing the full mouse path): the Split wheel handler gated on
`me.column > 26` (pointer over the pane vs. the sidebar). But terminals — macOS Terminal.app in
particular — frequently report wheel events with **column 0 / the last cursor position**, because
scroll events carry no inherent position. So the guard failed, the event fell through to
`handle_mouse`, and it **moved the fleet cursor instead of scrolling**. The wheel reached repomon;
it was just misrouted.

## Fix
Drop the column gate — the wheel always scrolls the focused agent pane in Split, matching the Focus
view (no gate, works). Lane navigation is via the arrow keys. Also `reset_scroll()` when
Tab-cycling agents, so switching shows the new agent's live tail rather than the previous agent's
stale scrollback.

TUI-only. `cargo build` / `clippy -D warnings` / tests green; binary reinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
