### PR TITLE
feat: forward wheel/PgUp scroll to full-screen agents (+ panic logger)

### DIFF
--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -277,6 +277,29 @@ impl TmuxRuntime {
         Ok(())
     }
 
+    /// Whether `window`'s app is on the *alternate screen* — i.e. a full-screen TUI (Claude, vim, …)
+    /// that owns its own scrollback. `false` for a plain shell (whose scrollback lives in tmux).
+    pub fn alternate_on_named(&self, window: &str) -> bool {
+        let target = self.exact_target(window);
+        self.run_allow_absent(&["display-message", "-p", "-t", &target, "-F", "#{alternate_on}"])
+            .map(|s| s.trim() == "1")
+            .unwrap_or(false)
+    }
+
+    /// Forward `ticks` mouse-wheel scroll events to `window`'s app, so a full-screen agent scrolls
+    /// its own history (the mediated pane can't otherwise — alternate-screen apps keep no tmux
+    /// scrollback). Sends SGR wheel sequences (button 64 = up, 65 = down) at the pane's top-left.
+    pub fn scroll_wheel_named(&self, window: &str, up: bool, ticks: u32) -> Result<()> {
+        if ticks == 0 {
+            return Ok(());
+        }
+        let button = if up { 64 } else { 65 };
+        let seq = format!("\x1b[<{button};1;1M").repeat(ticks as usize);
+        let target = self.exact_target(window);
+        self.run_allow_absent(&["send-keys", "-t", &target, "-l", &seq])?;
+        Ok(())
+    }
+
     /// Send a literal string (no trailing Enter) — one keystroke's worth of input.
     pub fn send_literal(&self, lane: LaneId, text: &str) -> Result<()> {
         self.send_literal_named(&Self::window_name(lane), text)

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -152,6 +152,18 @@ struct AgentResize {
     window: Option<String>,
 }
 #[derive(Deserialize)]
+struct AgentScroll {
+    lane_id: repomon_core::model::LaneId,
+    up: bool,
+    #[serde(default = "default_scroll_ticks")]
+    ticks: u32,
+    #[serde(default)]
+    window: Option<String>,
+}
+fn default_scroll_ticks() -> u32 {
+    1
+}
+#[derive(Deserialize)]
 struct AgentAutoContinue {
     lane_id: repomon_core::model::LaneId,
     enabled: bool,
@@ -878,6 +890,35 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 .map_err(internal)?
                 .map_err(internal)?;
             Ok(Value::Null)
+        }
+        "agent.scroll" => {
+            let p: AgentScroll = parse(params)?;
+            let tmux = ctx.tmux.clone();
+            let lane = p.lane_id;
+            let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
+            let (up, ticks) = (p.up, p.ticks.min(40));
+            // Only forward to a full-screen agent (alternate screen) — it owns its scrollback, so
+            // it can scroll itself. A plain shell would just get junk on its command line; the
+            // caller falls back to the capture-based scroll when `forwarded` is false.
+            let forwarded = tokio::task::spawn_blocking(move || {
+                if tmux.alternate_on_named(&window) {
+                    let _ = tmux.scroll_wheel_named(&window, up, ticks);
+                    true
+                } else {
+                    false
+                }
+            })
+            .await
+            .map_err(internal)?;
+            if forwarded {
+                // Fast-poll the pane so the scrolled view shows immediately (reuses the typing
+                // cadence path).
+                ctx.input_seen
+                    .lock()
+                    .await
+                    .insert(lane, std::time::Instant::now());
+            }
+            Ok(json!({ "forwarded": forwarded }))
         }
         // Arm/disarm auto-continue (resume on usage limit) for one lane, this session.
         "agent.auto_continue" => {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1213,8 +1213,8 @@ impl App {
                 // to the clipboard on release); elsewhere the wheel moves the cursor.
                 match self.view {
                     View::Focus => match me.kind {
-                        MouseEventKind::ScrollUp => self.scroll_up(3).await,
-                        MouseEventKind::ScrollDown => self.scroll_down(3),
+                        MouseEventKind::ScrollUp => self.pane_scroll(true, 1).await,
+                        MouseEventKind::ScrollDown => self.pane_scroll(false, 1).await,
                         MouseEventKind::Down(MouseButton::Left) => {
                             self.sel_anchor = self.focus_line_at(me.row);
                             self.sel_head = self.sel_anchor;
@@ -1241,8 +1241,10 @@ impl App {
                         let col = if me.column > 0 { me.column } else { self.last_mouse_col };
                         let over_pane = col > 26;
                         match me.kind {
-                            MouseEventKind::ScrollUp if over_pane => self.scroll_up(1).await,
-                            MouseEventKind::ScrollDown if over_pane => self.scroll_down(1),
+                            MouseEventKind::ScrollUp if over_pane => self.pane_scroll(true, 1).await,
+                            MouseEventKind::ScrollDown if over_pane => {
+                                self.pane_scroll(false, 1).await
+                            }
                             MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
                                 self.handle_mouse(me)
                             }
@@ -2283,8 +2285,8 @@ impl App {
             // PgUp/PgDn scroll the captured output even while typing (always reach repomon); any
             // other key returns to the live tail and goes to the agent.
             match key.code {
-                KeyCode::PageUp => return self.scroll_up(10).await,
-                KeyCode::PageDown => return self.scroll_down(10),
+                KeyCode::PageUp => return self.pane_scroll(true, 8).await,
+                KeyCode::PageDown => return self.pane_scroll(false, 8).await,
                 _ => {}
             }
             if self.scroll > 0 {
@@ -2318,8 +2320,8 @@ impl App {
             KeyCode::Tab => return self.cycle_session(true),
             KeyCode::BackTab => return self.cycle_session(false),
             // PgUp/PgDn scroll the pane; arrows still navigate the fleet.
-            KeyCode::PageUp => return self.scroll_up(10).await,
-            KeyCode::PageDown => return self.scroll_down(10),
+            KeyCode::PageUp => return self.pane_scroll(true, 8).await,
+            KeyCode::PageDown => return self.pane_scroll(false, 8).await,
             _ => {}
         }
         if let Some(action) = keybinds::nav(key) {
@@ -2338,8 +2340,8 @@ impl App {
             // tmux/terminals; these keys always reach repomon). Other keys go to the agent, and
             // typing returns to the live tail.
             match key.code {
-                KeyCode::PageUp => return self.scroll_up(10).await,
-                KeyCode::PageDown => return self.scroll_down(10),
+                KeyCode::PageUp => return self.pane_scroll(true, 8).await,
+                KeyCode::PageDown => return self.pane_scroll(false, 8).await,
                 _ => {}
             }
             if self.scroll > 0 {
@@ -2362,8 +2364,8 @@ impl App {
                 self.focus_insert = true;
             }
             // Scroll back through the agent's output (e.g. to read a long plan).
-            KeyCode::PageUp | KeyCode::Up => self.scroll_up(10).await,
-            KeyCode::PageDown | KeyCode::Down => self.scroll_down(10),
+            KeyCode::PageUp | KeyCode::Up => self.pane_scroll(true, 8).await,
+            KeyCode::PageDown | KeyCode::Down => self.pane_scroll(false, 8).await,
             KeyCode::Tab => self.cycle_session(true),
             KeyCode::BackTab => self.cycle_session(false),
             KeyCode::Char('e') => self.spawn_agent().await,
@@ -2686,6 +2688,34 @@ impl App {
         } else {
             disable_mouse();
             self.status = "mouse released — drag to select & copy · y for wheel-scroll".into();
+        }
+    }
+
+    /// Scroll the focused agent's pane. Full-screen agents (Claude, …) run on the alternate screen
+    /// and keep their own scrollback that tmux's capture can't reach, so forward the wheel to the
+    /// agent and let it scroll itself (the streamer mirrors the result). Plain-shell agents have
+    /// real tmux scrollback, so fall back to the local capture-based scroll.
+    async fn pane_scroll(&mut self, up: bool, ticks: usize) {
+        let Some(lane) = self.selected_lane().map(|l| l.id) else {
+            return;
+        };
+        let window = self.selected_window();
+        let forwarded = self
+            .client
+            .call(
+                "agent.scroll",
+                Some(json!({ "lane_id": lane, "up": up, "ticks": ticks, "window": window })),
+            )
+            .await
+            .ok()
+            .and_then(|v| v.get("forwarded").and_then(|f| f.as_bool()))
+            .unwrap_or(false);
+        if !forwarded {
+            if up {
+                self.scroll_up(ticks).await;
+            } else {
+                self.scroll_down(ticks);
+            }
         }
     }
 
@@ -3071,6 +3101,23 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     app.load_settings().await;
 
     let mut terminal = ratatui::init();
+    // Log panics to a file before the terminal is restored (which would otherwise scroll the
+    // message off-screen, leaving a crash undiagnosable). Chains to ratatui's restore hook.
+    {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let loc = info
+                .location()
+                .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_default();
+            let bt = std::backtrace::Backtrace::force_capture();
+            let _ = std::fs::write(
+                "/tmp/repomon-panic.log",
+                format!("repomon panic at {loc}\n{info}\n\nbacktrace:\n{bt}\n"),
+            );
+            prev(info);
+        }));
+    }
     if app.mouse_on {
         enable_mouse();
     }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -78,6 +78,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.pin` | `{ lane_id, pinned }` | `null` |
 | `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
 | `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
+| `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
 | `terminal.close` | `{ id }` | `null` |


### PR DESCRIPTION
## Scroll the agent's own history from the mediated pane

The mediated Split/Focus pane couldn't meaningfully scroll a full-screen agent: Claude runs on the
terminal's **alternate screen**, which keeps **no tmux scrollback**, so `capture-pane` only ever
has the live screen (verified: `capture -S -2000` returns just the visible rows). The agent owns
its history.

So forward the scroll to the agent instead:

- **`agent.scroll { lane_id, up, ticks=1, window? } → { forwarded }`** (daemon) sends SGR
  mouse-wheel events (`<64`/`<65`) to the pane so the agent scrolls itself — but **only when it's on
  the alternate screen** (`alternate_on`); a plain shell would just get junk on its command line, so
  it returns `forwarded:false` and the TUI falls back to the existing capture-based scroll.
- **TUI**: the wheel over the pane and `PgUp`/`PgDn` in Split/Focus now route through `pane_scroll →
  agent.scroll`. Forwarding stamps `input_seen` so the scrolled view streams back at frame-rate.
- Verified live end-to-end: `agent.scroll` forwards to a real Claude window, it scrolls, and
  scrolls back (Claude clamps at the bottom).

### Also: a panic logger
The TUI now writes any panic (message + location + backtrace) to `/tmp/repomon-panic.log` before
ratatui restores the terminal — so a crash is diagnosable instead of scrolling off-screen. (Added
while chasing an unreproducible `X`-remove crash; keeps it catchable if it recurs.)

`docs/protocol.md` documents `agent.scroll`. `cargo build` / `clippy -D warnings` green; both
binaries installed + daemon restarted for live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
