### PR TITLE
feat: account-usage corner from Claude's /usage

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -15,7 +15,7 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 | **3 — Dashboard / history** | M11 history indexer · timeline · jaccard correlations · session detection · markdown export · commit search | ✅ |
 | **4 — Polish (Rust-only)** | M12 accent-color slot + mouse · M13 docs + perf | ✅ |
 
-10 views, 5 CLI subcommands, 38 RPC methods wired.
+10 views, 5 CLI subcommands, 39 RPC methods wired.
 
 ## Quality bar (verified)
 
@@ -43,6 +43,10 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 - **Plain terminals** per worktree (`t`), multiple allowed.
 - Revamped **Grid** (real navigation, Instagram-style position dots, clean exit).
 - repomon's tmux runs on a **dedicated socket**, isolated from the user's own tmux.
+- **Account-usage corner** (opt-in `usage_probe`) — Claude's `/usage` 5h + weekly % and reset,
+  shown bottom-right for the focused agent's account; scraped via a hidden throwaway `claude`
+  session per account (`usage_watch.rs` + fixture-tested `agent/usage.rs`), with a rate-limit
+  countdown fallback. See `docs/agents.md`.
 
 ## Deferred (explicitly out of scope in the plan)
 

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -66,6 +66,7 @@ impl TranscriptSummary {
             tmux_window: None, // overlay pairs managed sessions with their windows
             resume_at: None,
             inferred: false,
+            config_dir: self.config_dir,
         }
     }
 }
@@ -167,6 +168,34 @@ pub fn agent_variants() -> Vec<(String, String)> {
             }
         })
         .collect()
+}
+
+/// A stable key for a Claude account, identifying it by its config dir. The default account
+/// (`~/.claude`, carried as `config_dir: None`) is `"default"`; a variant is its dir path. The
+/// usage probe stores per-account usage under this key and a client matches the focused agent's
+/// `AgentSession::config_dir` to it.
+pub fn account_key(config_dir: Option<&Path>) -> String {
+    config_dir
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "default".to_string())
+}
+
+/// A short human label for a Claude account: `"main"` for the default `~/.claude`, otherwise the
+/// dir's distinguishing suffix (`~/.claude-work` → `"work"`).
+pub fn account_label(config_dir: Option<&Path>) -> String {
+    match config_dir {
+        None => "main".to_string(),
+        Some(p) => p
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|n| {
+                n.trim_start_matches('.')
+                    .trim_start_matches("claude-")
+                    .to_string()
+            })
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "claude".to_string()),
+    }
 }
 
 /// Encode a working directory to Claude Code's project directory name.

--- a/crates/repomon-core/src/agent/fixtures/trust_prompt.txt
+++ b/crates/repomon-core/src/agent/fixtures/trust_prompt.txt
@@ -1,0 +1,50 @@
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
+
+ /Users/azaleas
+
+ Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this
+ folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/crates/repomon-core/src/agent/fixtures/usage_v2.ansi
+++ b/crates/repomon-core/src/agent/fixtures/usage_v2.ansi
@@ -1,0 +1,50 @@
+
+[91m╭───[39m [91mClaude Code[39m [37mv2.1.181[39m [91m─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+[94m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+[39m   [1m[94mSettings[0m  Status   Config  [1m[30m[104m Usage [0m  Stats
+
+   [1mSession[0m
+
+   [37mTotal cost:            $0.0000[39m
+   [37mTotal duration (API):  0s[39m
+   [37mTotal duration (wall): 2m 8s[39m
+   [37mTotal code changes:    0 lines added, 0 lines removed[39m
+   [37mUsage:                 0 input, 0 output, 0 cache read, 0 cache write[39m
+
+   [1mCurrent session[0m
+   [33m[47m███████▌                                          [39m[49m 15% used
+   [37mResets 11:59pm (Asia/Karachi)[39m
+
+   [1mCurrent week (all models)[0m
+   [33m[47m████████████████████▌                             [39m[49m 41% used
+   [37mResets Jun 21 at 7:59pm (Asia/Karachi)[39m
+
+   [1mCurrent week (Sonnet only)[0m
+   [33m[47m                                                  [39m[49m 0% used
+
+   [1mWhat's contributing to your limits usage?[0m
+   [37mApproximate, based on local sessions on this machine — does not include other devices or claude.ai[39m
+
+   [37mLast 24h · these are independent characteristics of your usage, not a breakdown[39m
+
+   78% of your usage came from sessions active for 8+ hours
+    [37mThese are often background/loop sessions. Continuous usage can add up quickly [39m
+    [37mso make sure it is intentional.[39m
+
+   76% of your usage was at >150k context
+    [37mLonger sessions are more expensive even when cached. /compact mid-task, /clear [39m
+    [37mwhen switching to new tasks.[39m
+
+   63% of your usage came from subagent-heavy sessions
+    [37mEach subagent runs its own requests. Be deliberate about spawning them — and [39m
+    [37mconsider configuring a cheaper model for simpler subagents.[39m
+
+   13% of your usage was while 4+ sessions ran in parallel
+    [37mAll sessions share one limit. If you don't need them all at once, queueing uses[39m
+    [37mit more evenly.[39m
+
+   Skills                  [37m% of usage[39m
+   [37m/superpowers:brainstorming[39m      [37m1%[39m
+   [37m/superpowers:using-git-work…[39m    [37m1%[39m
+   [37m/superpowers:writing-plans[39m      [37m1%[39m
+                                                                                                                                                                                                      [37m↓[39m

--- a/crates/repomon-core/src/agent/limit.rs
+++ b/crates/repomon-core/src/agent/limit.rs
@@ -6,12 +6,9 @@
 //! when it resets. It is deliberately lenient about phrasing and never matches the non-blocking
 //! "approaching usage limit" warning.
 
-use chrono::{DateTime, Duration, Local, NaiveTime, TimeZone, Utc};
+use chrono::{DateTime, Local, Utc};
 
-/// A parsed reset time this far (or less) in the past is treated as "just reset, resume now"
-/// rather than rolled to tomorrow — Claude's resets are always within a few hours, so a time well
-/// beyond this is a genuine next-day (cross-midnight) reset.
-const GRACE_PAST_HOURS: i64 = 6;
+use super::text::{parse_reset_at, strip_ansi};
 
 /// A detected usage-limit pause.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -138,45 +135,6 @@ pub fn menu_select_keys(menu: &LimitMenu) -> Vec<String> {
     }
 }
 
-/// Drop ANSI CSI/OSC escape sequences (pane captures use `-e`, so menu rows carry color and
-/// inverse-video escapes that would break per-line parsing).
-pub(crate) fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\u{1b}' {
-            out.push(c);
-            continue;
-        }
-        match chars.peek() {
-            // CSI: ESC [ … final byte in @-~
-            Some('[') => {
-                chars.next();
-                for n in chars.by_ref() {
-                    if ('\u{40}'..='\u{7e}').contains(&n) {
-                        break;
-                    }
-                }
-            }
-            // OSC: ESC ] … BEL (or ESC \)
-            Some(']') => {
-                chars.next();
-                while let Some(n) = chars.next() {
-                    if n == '\u{07}' {
-                        break;
-                    }
-                    if n == '\u{1b}' && chars.peek() == Some(&'\\') {
-                        chars.next();
-                        break;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    out
-}
-
 /// Whether the pane shows a *blocking* limit. Covers Claude's several phrasings: the classic
 /// "usage limit reached … resets at X", the "You've hit your session limit · resets 3am" notice,
 /// and any screen offering "/upgrade to increase your usage limit". The "approaching … limit"
@@ -198,124 +156,11 @@ fn is_blocked(lower: &str) -> bool {
     reached && reset_cue
 }
 
-/// Claude always states the *next* reset, which is at most a few hours out, formatted in the
-/// machine's local timezone. So today's occurrence is the answer when it's upcoming **or only
-/// recently passed** (within [`GRACE_PAST_HOURS`]) — the latter means the limit just reset and a
-/// stuck agent we notice a moment late should resume now, not wait a day. Only a time that's
-/// *well* in the past (a cross-midnight "resets 3am" seen at night) rolls to tomorrow. Returns
-/// `None` if no clock time is present.
-fn parse_reset_at(lower: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
-    let time = find_reset_time(lower)?;
-    let date = now.date_naive();
-    let naive = date.and_time(time);
-    let mut dt = Local.from_local_datetime(&naive).earliest()?;
-    if now - dt > Duration::hours(GRACE_PAST_HOURS) {
-        let naive2 = (date + Duration::days(1)).and_time(time);
-        dt = Local.from_local_datetime(&naive2).earliest()?;
-    }
-    Some(dt.with_timezone(&Utc))
-}
-
-/// Find the reset clock time — preferring one that appears after a "reset"/"again" cue, falling
-/// back to the first time anywhere in the text.
-fn find_reset_time(lower: &str) -> Option<NaiveTime> {
-    let cue = ["reset", "again"]
-        .iter()
-        .filter_map(|c| lower.find(c))
-        .min();
-    if let Some(idx) = cue {
-        if let Some(t) = parse_first_time(&lower[idx..]) {
-            return Some(t);
-        }
-    }
-    parse_first_time(lower)
-}
-
-/// Scan for the first clock time. A bare integer is **not** a time (so "5-hour limit" and stray
-/// numbers don't match) — a match needs a `:mm` minute or an `am`/`pm` marker.
-fn parse_first_time(s: &str) -> Option<NaiveTime> {
-    let b = s.as_bytes();
-    let mut i = 0;
-    while i < b.len() {
-        let starts_number =
-            b[i].is_ascii_digit() && (i == 0 || !(b[i - 1].is_ascii_digit() || b[i - 1] == b':'));
-        if starts_number {
-            if let Some(t) = try_parse_time_at(b, i) {
-                return Some(t);
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Try to parse `H`, `H:MM`, `H am/pm`, or `H:MM am/pm` (also 24-hour `HH:MM`) starting at `start`.
-fn try_parse_time_at(b: &[u8], start: usize) -> Option<NaiveTime> {
-    let mut i = start;
-    let h0 = i;
-    while i < b.len() && b[i].is_ascii_digit() && i - h0 < 2 {
-        i += 1;
-    }
-    let hour: u32 = std::str::from_utf8(&b[h0..i]).ok()?.parse().ok()?;
-
-    let mut minute: u32 = 0;
-    let mut had_minute = false;
-    if i < b.len() && b[i] == b':' {
-        let m0 = i + 1;
-        let mut j = m0;
-        while j < b.len() && b[j].is_ascii_digit() && j - m0 < 2 {
-            j += 1;
-        }
-        if j - m0 != 2 {
-            return None; // "3:" with no two-digit minute isn't a time
-        }
-        minute = std::str::from_utf8(&b[m0..j]).ok()?.parse().ok()?;
-        had_minute = true;
-        i = j;
-    }
-
-    // Optional spaces, then an am/pm marker — allowing periods (am, a.m., pm, p.m.).
-    let mut k = i;
-    while k < b.len() && b[k] == b' ' {
-        k += 1;
-    }
-    let pm = match b.get(k) {
-        Some(m @ (b'a' | b'p')) => {
-            let mut p = k + 1;
-            if b.get(p) == Some(&b'.') {
-                p += 1; // the '.' in "a.m."
-            }
-            if b.get(p) == Some(&b'm') {
-                Some(*m == b'p')
-            } else {
-                None
-            }
-        }
-        _ => None,
-    };
-
-    // Require a minute or an am/pm marker so bare integers (e.g. "5-hour") don't match.
-    if !had_minute && pm.is_none() {
-        return None;
-    }
-    if minute > 59 {
-        return None;
-    }
-    let hour24 = match pm {
-        Some(true) if hour == 12 => 12,
-        Some(true) if hour <= 11 => hour + 12,
-        Some(false) if hour == 12 => 0,
-        Some(false) if hour <= 11 => hour,
-        None if hour <= 23 => hour,
-        _ => return None,
-    };
-    NaiveTime::from_hms_opt(hour24, minute, 0)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Datelike, Timelike};
+    use crate::agent::text::parse_reset_at;
+    use chrono::{Datelike, Local, TimeZone, Timelike};
 
     #[test]
     fn detects_blocking_message_with_time() {

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -9,7 +9,9 @@
 pub mod claude;
 pub mod limit;
 pub mod prompt;
+pub mod text;
 pub mod tmux;
+pub mod usage;
 
 use std::path::Path;
 use std::time::Duration;
@@ -21,6 +23,7 @@ use crate::model::{AgentKind, AgentStatus};
 pub use claude::TranscriptSummary;
 pub use limit::{detect_usage_limit, menu_select_keys, LimitMenu, UsageLimit};
 pub use tmux::{shell_quote, TmuxRuntime};
+pub use usage::{parse_usage, AccountUsage, UsageReport};
 
 /// How recently a file must have changed for its agent to count as "running".
 const ACTIVE_WINDOW: Duration = Duration::from_secs(120);

--- a/crates/repomon-core/src/agent/prompt.rs
+++ b/crates/repomon-core/src/agent/prompt.rs
@@ -8,7 +8,8 @@
 //! summary (dialog header + question) to use as the notification's "why". The daemon flips
 //! such sessions to `Waiting` during `lane.list`.
 
-use super::limit::{parse_option_line, strip_ansi};
+use super::limit::parse_option_line;
+use super::text::strip_ansi;
 
 /// How far above the option menu the question line may sit.
 const QUESTION_REACH: usize = 5;

--- a/crates/repomon-core/src/agent/text.rs
+++ b/crates/repomon-core/src/agent/text.rs
@@ -1,0 +1,285 @@
+//! Shared pane-text parsing: ANSI stripping, clock/date times, and percentages.
+//!
+//! These primitives are pure and fixture-tested through their callers. [`limit`](super::limit)
+//! reads Claude's usage-limit *pause* from a pane; [`usage`](super::usage) reads the `/usage`
+//! screen. Both need to strip the color escapes a `capture-pane -e` carries and to parse the
+//! clock times Claude prints in the machine's local timezone — so that logic lives here once.
+
+use chrono::{DateTime, Datelike, Duration, Local, NaiveTime, TimeZone, Utc};
+
+/// A parsed reset time this far (or less) in the past is treated as "just reset" rather than
+/// rolled forward — Claude's session resets are always within a few hours, so a time well beyond
+/// this is a genuine next-day (cross-midnight) reset.
+pub(crate) const GRACE_PAST_HOURS: i64 = 6;
+
+/// Drop ANSI CSI/OSC escape sequences (pane captures use `-e`, so lines carry color and
+/// inverse-video escapes that would break per-line parsing).
+pub(crate) fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: ESC [ … final byte in @-~
+            Some('[') => {
+                chars.next();
+                for n in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&n) {
+                        break;
+                    }
+                }
+            }
+            // OSC: ESC ] … BEL (or ESC \)
+            Some(']') => {
+                chars.next();
+                while let Some(n) = chars.next() {
+                    if n == '\u{07}' {
+                        break;
+                    }
+                    if n == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Parse a `NN%` percentage: the integer immediately preceding a `%`. Returns the first such
+/// value (≤ 100; a larger number is treated as a mis-parse and skipped). Lenient about whatever
+/// precedes the digits (bar glyphs, spaces).
+pub(crate) fn parse_pct(s: &str) -> Option<u8> {
+    let b = s.as_bytes();
+    for (i, &c) in b.iter().enumerate() {
+        if c != b'%' {
+            continue;
+        }
+        let mut j = i;
+        while j > 0 && b[j - 1].is_ascii_digit() {
+            j -= 1;
+        }
+        if j < i {
+            if let Ok(n) = s[j..i].parse::<u32>() {
+                if n <= 100 {
+                    return Some(n as u8);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a reset moment from text that may carry a date (`"jun 21 at 7:59pm"`) or just a clock
+/// time (`"resets 11:59pm"`). Date-bearing strings resolve to that calendar day (this year, or
+/// next year if already well past); bare times use [`parse_reset_at`]'s today/tomorrow logic.
+/// Input should be lowercased.
+pub(crate) fn parse_reset_datetime(lower: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    parse_dated(lower, now).or_else(|| parse_reset_at(lower, now))
+}
+
+const MONTHS: [&str; 12] = [
+    "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+];
+
+/// Parse a `"<month> <day> … <time>"` reset, e.g. `"resets jun 21 at 7:59pm"`. Returns `None`
+/// when no month name is present (the bare-time path handles that).
+fn parse_dated(lower: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    for (mi, m) in MONTHS.iter().enumerate() {
+        let Some(pos) = lower.find(m) else { continue };
+        let after = &lower[pos + m.len()..];
+        let day = first_int(after)?;
+        let time = find_reset_time(after)?;
+        let month = mi as u32 + 1;
+        let mut dt = build_local(now.year(), month, day, time)?;
+        // A date well in the past means the printed month/day is next year's occurrence.
+        if now - dt > Duration::hours(GRACE_PAST_HOURS) {
+            dt = build_local(now.year() + 1, month, day, time)?;
+        }
+        return Some(dt.with_timezone(&Utc));
+    }
+    None
+}
+
+/// The first standalone integer in `s` (a day-of-month). Skips digits that are part of a clock
+/// time (`7:59`) by requiring the integer not be immediately followed by `:`.
+fn first_int(s: &str) -> Option<u32> {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i].is_ascii_digit() && (i == 0 || !b[i - 1].is_ascii_digit()) {
+            let start = i;
+            while i < b.len() && b[i].is_ascii_digit() {
+                i += 1;
+            }
+            // Not a clock time's hour, and a plausible day.
+            if b.get(i) != Some(&b':') {
+                if let Ok(n) = s[start..i].parse::<u32>() {
+                    if (1..=31).contains(&n) {
+                        return Some(n);
+                    }
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn build_local(year: i32, month: u32, day: u32, time: NaiveTime) -> Option<DateTime<Local>> {
+    let date = chrono::NaiveDate::from_ymd_opt(year, month, day)?;
+    Local.from_local_datetime(&date.and_time(time)).earliest()
+}
+
+/// Claude states the *next* reset, at most a few hours out, in the machine's local timezone. So
+/// today's occurrence is the answer when it's upcoming **or only recently passed** (within
+/// [`GRACE_PAST_HOURS`]); only a time *well* in the past (a cross-midnight "resets 3am" seen at
+/// night) rolls to tomorrow. Returns `None` if no clock time is present. Input should be lowercased.
+pub(crate) fn parse_reset_at(lower: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    let time = find_reset_time(lower)?;
+    let date = now.date_naive();
+    let naive = date.and_time(time);
+    let mut dt = Local.from_local_datetime(&naive).earliest()?;
+    if now - dt > Duration::hours(GRACE_PAST_HOURS) {
+        let naive2 = (date + Duration::days(1)).and_time(time);
+        dt = Local.from_local_datetime(&naive2).earliest()?;
+    }
+    Some(dt.with_timezone(&Utc))
+}
+
+/// Find the reset clock time — preferring one that appears after a "reset"/"again" cue, falling
+/// back to the first time anywhere in the text.
+pub(crate) fn find_reset_time(lower: &str) -> Option<NaiveTime> {
+    let cue = ["reset", "again"]
+        .iter()
+        .filter_map(|c| lower.find(c))
+        .min();
+    if let Some(idx) = cue {
+        if let Some(t) = parse_first_time(&lower[idx..]) {
+            return Some(t);
+        }
+    }
+    parse_first_time(lower)
+}
+
+/// Scan for the first clock time. A bare integer is **not** a time (so "5-hour limit" and stray
+/// numbers don't match) — a match needs a `:mm` minute or an `am`/`pm` marker.
+pub(crate) fn parse_first_time(s: &str) -> Option<NaiveTime> {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        let starts_number =
+            b[i].is_ascii_digit() && (i == 0 || !(b[i - 1].is_ascii_digit() || b[i - 1] == b':'));
+        if starts_number {
+            if let Some(t) = try_parse_time_at(b, i) {
+                return Some(t);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Try to parse `H`, `H:MM`, `H am/pm`, or `H:MM am/pm` (also 24-hour `HH:MM`) starting at `start`.
+pub(crate) fn try_parse_time_at(b: &[u8], start: usize) -> Option<NaiveTime> {
+    let mut i = start;
+    let h0 = i;
+    while i < b.len() && b[i].is_ascii_digit() && i - h0 < 2 {
+        i += 1;
+    }
+    let hour: u32 = std::str::from_utf8(&b[h0..i]).ok()?.parse().ok()?;
+
+    let mut minute: u32 = 0;
+    let mut had_minute = false;
+    if i < b.len() && b[i] == b':' {
+        let m0 = i + 1;
+        let mut j = m0;
+        while j < b.len() && b[j].is_ascii_digit() && j - m0 < 2 {
+            j += 1;
+        }
+        if j - m0 != 2 {
+            return None; // "3:" with no two-digit minute isn't a time
+        }
+        minute = std::str::from_utf8(&b[m0..j]).ok()?.parse().ok()?;
+        had_minute = true;
+        i = j;
+    }
+
+    // Optional spaces, then an am/pm marker — allowing periods (am, a.m., pm, p.m.).
+    let mut k = i;
+    while k < b.len() && b[k] == b' ' {
+        k += 1;
+    }
+    let pm = match b.get(k) {
+        Some(m @ (b'a' | b'p')) => {
+            let mut p = k + 1;
+            if b.get(p) == Some(&b'.') {
+                p += 1; // the '.' in "a.m."
+            }
+            if b.get(p) == Some(&b'm') {
+                Some(*m == b'p')
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    // Require a minute or an am/pm marker so bare integers (e.g. "5-hour") don't match.
+    if !had_minute && pm.is_none() {
+        return None;
+    }
+    if minute > 59 {
+        return None;
+    }
+    let hour24 = match pm {
+        Some(true) if hour == 12 => 12,
+        Some(true) if hour <= 11 => hour + 12,
+        Some(false) if hour == 12 => 0,
+        Some(false) if hour <= 11 => hour,
+        None if hour <= 23 => hour,
+        _ => return None,
+    };
+    NaiveTime::from_hms_opt(hour24, minute, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    #[test]
+    fn parse_pct_basic() {
+        assert_eq!(parse_pct("███▌   15% used"), Some(15));
+        assert_eq!(parse_pct("   0% used"), Some(0));
+        assert_eq!(parse_pct("100% used"), Some(100));
+        assert_eq!(parse_pct("no percent here"), None);
+        assert_eq!(parse_pct("999% bogus"), None); // >100 → mis-parse, skipped
+    }
+
+    #[test]
+    fn dated_reset_resolves_to_that_day() {
+        let now = Local.with_ymd_and_hms(2026, 6, 18, 20, 0, 0).unwrap();
+        let dt = parse_reset_datetime("resets jun 21 at 7:59pm (asia/karachi)", now)
+            .unwrap()
+            .with_timezone(&Local);
+        assert_eq!((dt.month(), dt.day()), (6, 21));
+        assert_eq!((dt.hour(), dt.minute()), (19, 59));
+    }
+
+    #[test]
+    fn bare_time_falls_back_to_today() {
+        let now = Local.with_ymd_and_hms(2026, 6, 18, 20, 0, 0).unwrap();
+        let dt = parse_reset_datetime("resets 11:59pm (asia/karachi)", now)
+            .unwrap()
+            .with_timezone(&Local);
+        assert_eq!(dt.day(), 18);
+        assert_eq!((dt.hour(), dt.minute()), (23, 59));
+    }
+}

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -416,6 +416,44 @@ impl TmuxRuntime {
         Ok(self.target_named(name))
     }
 
+    /// Launch `command` in `cwd` as an arbitrary named window — like [`spawn`](Self::spawn) but
+    /// with a caller-chosen window name instead of a lane slot. Used for the hidden `/usage`
+    /// probe (`usage-probe-…`), whose non-`lane-` name keeps it out of the lane-window scans.
+    /// Returns the window's exact target.
+    pub fn spawn_named(&self, name: &str, cwd: &Path, command: &str) -> Result<String> {
+        let cwd = cwd.to_string_lossy();
+        if self.session_exists() {
+            self.run(&[
+                "new-window",
+                "-t",
+                &self.session,
+                "-n",
+                name,
+                "-c",
+                &cwd,
+                command,
+            ])?;
+        } else {
+            self.run(&[
+                "new-session",
+                "-d",
+                "-x",
+                "220",
+                "-y",
+                "50",
+                "-s",
+                &self.session,
+                "-n",
+                name,
+                "-c",
+                &cwd,
+                command,
+            ])?;
+        }
+        self.configure();
+        Ok(self.exact_target(name))
+    }
+
     /// Terminate a named window (an agent slot or a terminal). Exact-match target, so killing
     /// `lane-1` can't take out `lane-1-2`.
     pub fn kill_named(&self, name: &str) -> Result<()> {

--- a/crates/repomon-core/src/agent/usage.rs
+++ b/crates/repomon-core/src/agent/usage.rs
@@ -1,0 +1,163 @@
+//! Parsing Claude Code's interactive `/usage` screen into structured limit numbers.
+//!
+//! Claude exposes subscription usage *only* through the interactive `/usage` command — there's no
+//! CLI flag, local file, or supported endpoint. So the daemon's usage probe runs `/usage` in a
+//! throwaway session, captures the pane (`capture-pane -e`), and hands the text here. This module
+//! is the pure, fixture-tested heart: it strips ANSI, anchors on the section labels Claude prints
+//! ("Current session", "Current week (all models)"), and reads each section's percentage and
+//! reset time. It is deliberately lenient about layout — the `/usage` screen is undocumented and
+//! changes between versions, so it anchors on labels rather than line positions and returns
+//! `None` (never fabricated zeros) when nothing recognizable is on screen.
+
+use chrono::{DateTime, Local, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::text::{parse_pct, parse_reset_datetime, strip_ansi};
+
+/// Claude account usage, parsed from `/usage`. Every field is optional so a partial screen still
+/// yields what was readable. Percentages are "% used" of each window.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsageReport {
+    /// The 5-hour ("Current session") window, % used.
+    pub session_pct: Option<u8>,
+    /// When the 5-hour window resets.
+    pub session_reset_at: Option<DateTime<Utc>>,
+    /// The weekly ("Current week (all models)") window, % used.
+    pub week_pct: Option<u8>,
+    /// When the weekly window resets (a dated time, days out).
+    pub week_reset_at: Option<DateTime<Utc>>,
+    /// The model-specific weekly window, % used (e.g. "Current week (Opus)" / "(Sonnet only)").
+    pub week_model_pct: Option<u8>,
+}
+
+impl UsageReport {
+    /// Whether anything usable was parsed (at least one percentage).
+    pub fn is_empty(&self) -> bool {
+        self.session_pct.is_none() && self.week_pct.is_none() && self.week_model_pct.is_none()
+    }
+}
+
+/// One Claude account's usage, as carried over RPC to clients. `key` matches
+/// [`super::claude::account_key`] so a client can pick the account of the focused agent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountUsage {
+    /// Stable account key (the canonical config dir, or "default").
+    pub key: String,
+    /// Short human label ("main", "work", …).
+    pub label: String,
+    pub report: UsageReport,
+    /// How long ago the probe captured this, in seconds.
+    pub age_secs: u64,
+}
+
+/// Parse the `/usage` screen. Returns `None` when no percentage is found anywhere — a blank,
+/// loading, or trust/onboarding screen yields nothing rather than fake numbers.
+pub fn parse_usage(pane: &str) -> Option<UsageReport> {
+    let lines: Vec<String> = pane.lines().map(strip_ansi).collect();
+    let now = Local::now();
+    let mut r = UsageReport::default();
+
+    for (i, line) in lines.iter().enumerate() {
+        let low = line.to_lowercase();
+        if low.contains("current session") {
+            let (pct, reset) = section_after(&lines, i, now);
+            r.session_pct = pct;
+            r.session_reset_at = reset;
+        } else if low.contains("current week") {
+            if low.contains("all models") {
+                let (pct, reset) = section_after(&lines, i, now);
+                r.week_pct = pct;
+                r.week_reset_at = reset;
+            } else {
+                // A model-specific weekly window: "(Opus)", "(Sonnet only)", etc.
+                let (pct, _) = section_after(&lines, i, now);
+                r.week_model_pct = pct;
+            }
+        }
+    }
+
+    (!r.is_empty()).then_some(r)
+}
+
+/// Read a section's `NN% used` and `Resets …` from the few lines following its header. Stops at
+/// the next section header so one section never borrows another's numbers.
+fn section_after(
+    lines: &[String],
+    header: usize,
+    now: DateTime<Local>,
+) -> (Option<u8>, Option<DateTime<Utc>>) {
+    let mut pct = None;
+    let mut reset = None;
+    for line in lines.iter().skip(header + 1).take(4) {
+        let low = line.to_lowercase();
+        if low.contains("current session") || low.contains("current week") {
+            break;
+        }
+        if pct.is_none() {
+            pct = parse_pct(line);
+        }
+        if reset.is_none() && low.contains("reset") {
+            reset = parse_reset_datetime(&low, now);
+        }
+    }
+    (pct, reset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, Timelike};
+
+    #[test]
+    fn parses_real_usage_capture() {
+        // The real `/usage` screen from Claude Code v2.1.181, captured via `capture-pane -e`
+        // (so it carries ANSI color escapes — this also exercises strip_ansi).
+        let pane = include_str!("fixtures/usage_v2.ansi");
+        let r = parse_usage(pane).expect("should parse the /usage screen");
+        assert_eq!(r.session_pct, Some(15));
+        assert_eq!(r.week_pct, Some(41));
+        assert_eq!(r.week_model_pct, Some(0));
+
+        let session = r
+            .session_reset_at
+            .expect("session reset")
+            .with_timezone(&Local);
+        assert_eq!((session.hour(), session.minute()), (23, 59)); // "Resets 11:59pm"
+
+        let week = r.week_reset_at.expect("week reset").with_timezone(&Local);
+        assert_eq!((week.month(), week.day()), (6, 21)); // "Resets Jun 21 at 7:59pm"
+        assert_eq!((week.hour(), week.minute()), (19, 59));
+    }
+
+    #[test]
+    fn trust_prompt_yields_none() {
+        // The folder-trust prompt has no usage numbers — must not parse as zeros.
+        let pane = include_str!("fixtures/trust_prompt.txt");
+        assert!(parse_usage(pane).is_none());
+    }
+
+    #[test]
+    fn blank_and_ordinary_output_yield_none() {
+        assert!(parse_usage("").is_none());
+        assert!(parse_usage("running 24 tests\ntest result: ok. 24 passed").is_none());
+    }
+
+    #[test]
+    fn partial_screen_session_only() {
+        let pane = "Current session\n  ████ 22% used\n  Resets 3:00pm\n";
+        let r = parse_usage(pane).expect("partial parse");
+        assert_eq!(r.session_pct, Some(22));
+        assert_eq!(r.week_pct, None);
+        assert_eq!(r.week_model_pct, None);
+        assert!(r.session_reset_at.is_some());
+    }
+
+    #[test]
+    fn sections_do_not_borrow_each_others_numbers() {
+        // No percentage under "Current session" → it must stay None, not grab the week's 88%.
+        let pane = "Current session\n  Resets 3:00pm\n\nCurrent week (all models)\n  88% used\n";
+        let r = parse_usage(pane).expect("week parsed");
+        assert_eq!(r.session_pct, None);
+        assert_eq!(r.week_pct, Some(88));
+    }
+}

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -79,6 +79,11 @@ pub struct Config {
     pub remote: RemoteConfig,
     /// APNs push for the iOS companion: alerts reach the phone even with the app closed.
     pub push: PushConfig,
+    /// Show Claude account usage (the `/usage` 5-hour + weekly windows) in the TUI's bottom-right
+    /// corner. Off by default: subscription usage has no CLI/file/endpoint, so this works by
+    /// running `/usage` in a hidden throwaway `claude` session per account every few minutes —
+    /// which spawns a background process and writes a tiny transcript. See `docs/agents.md`.
+    pub usage_probe: bool,
 }
 
 impl Default for Config {
@@ -106,6 +111,7 @@ impl Default for Config {
             repos: HashMap::new(),
             remote: RemoteConfig::default(),
             push: PushConfig::default(),
+            usage_probe: false,
         }
     }
 }

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -264,6 +264,11 @@ pub struct AgentSession {
     /// exactly when this is present — a plain end-of-turn `Waiting` has none.
     #[serde(default)]
     pub pending_prompt: Option<String>,
+    /// The Claude account (config dir) this agent runs under, overlaid at list time from the
+    /// transcript. `None` = the default `~/.claude`; `Some` = a variant (`~/.claude-work`). Lets a
+    /// client attribute account-level usage (the `/usage` probe) to the focused agent. Not persisted.
+    #[serde(default)]
+    pub config_dir: Option<PathBuf>,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -425,6 +425,7 @@ mod tests {
             tmux_window: None,
             last_message: None,
             pending_prompt: None,
+            config_dir: None,
         }
     }
 

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -646,6 +646,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         tmux_window: None,
         last_message: None,
         pending_prompt: None,
+        config_dir: None,
     })
 }
 
@@ -873,6 +874,7 @@ mod tests {
             tmux_window: None,
             last_message: None,
             pending_prompt: None,
+            config_dir: None,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -11,6 +11,7 @@ pub mod push;
 pub mod remote;
 pub mod rpc;
 pub mod socket;
+pub mod usage_watch;
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -58,6 +59,9 @@ pub struct Ctx {
     /// Lanes currently paused on a usage limit, with their reset time — written by the
     /// auto-continue watcher and read by `overlay_agents` to surface the `RateLimited` status.
     pub rate_limits: Mutex<HashMap<LaneId, auto_continue::RateLimit>>,
+    /// Per Claude account (config-dir key) usage from the `/usage` probe — written by the usage
+    /// watcher, read by `usage.get`. Empty unless `[usage_probe]` is enabled and a TUI is attached.
+    pub usage: Mutex<HashMap<String, usage_watch::UsageEntry>>,
     /// Lanes where the user disabled auto-continue this session (the `C` key).
     pub auto_continue_off: Mutex<HashSet<LaneId>>,
     /// The filesystem watcher (set once the background task brings it up). Held here so `repo.add`
@@ -119,6 +123,7 @@ impl Ctx {
             overlay_cache: Mutex::new(None),
             prompt_cache: Mutex::new(HashMap::new()),
             rate_limits: Mutex::new(HashMap::new()),
+            usage: Mutex::new(HashMap::new()),
             auto_continue_off: Mutex::new(HashSet::new()),
             watcher: Mutex::new(None),
             local_watcher_seen: Mutex::new(None),

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -138,6 +138,10 @@ async fn main() {
     // live (config.set) starts/stops it without a restart.
     tokio::spawn(repomon_daemon::notify_watch::notify_watch(ctx.clone()));
 
+    // Probe Claude's `/usage` for the TUI's account-usage corner. Self-gates per tick on
+    // `[usage_probe]` and a TUI being attached, so it costs nothing until enabled and watched.
+    tokio::spawn(repomon_daemon::usage_watch::usage_watcher(ctx.clone()));
+
     // Index commit history in the background (timeline / sessions / search).
     {
         let indexer = repomon_core::Indexer::new(ctx.store.clone(), ctx.registry.clone());

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -48,6 +48,7 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "notify_show_why": cfg.notify_show_why,
         "notify_coalesce": cfg.notify_coalesce,
         "notify_click_focus": cfg.notify_click_focus,
+        "usage_probe": cfg.usage_probe,
     })
 }
 
@@ -215,6 +216,8 @@ struct ConfigSet {
     notify_coalesce: Option<bool>,
     #[serde(default)]
     notify_click_focus: Option<bool>,
+    #[serde(default)]
+    usage_probe: Option<bool>,
 }
 #[derive(Deserialize)]
 struct PushDevice {
@@ -665,6 +668,9 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 if let Some(b) = p.notify_click_focus {
                     cfg.notify_click_focus = b;
                 }
+                if let Some(b) = p.usage_probe {
+                    cfg.usage_probe = b;
+                }
                 if let Err(e) = cfg.save_to(&ctx.config_path) {
                     *cfg = prev;
                     return Err(internal(e));
@@ -1093,6 +1099,24 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             Ok(Value::Null)
         }
 
+        // ---- usage ----
+        // Per-account Claude usage scraped from `/usage` (empty unless [usage_probe] is on and a
+        // TUI is attached). The TUI matches an entry's `key` to the focused agent's `config_dir`.
+        "usage.get" => {
+            let usage = ctx.usage.lock().await;
+            let mut out: Vec<agent::AccountUsage> = usage
+                .iter()
+                .map(|(key, e)| agent::AccountUsage {
+                    key: key.clone(),
+                    label: e.label.clone(),
+                    report: e.report.clone(),
+                    age_secs: e.fetched_at.elapsed().as_secs(),
+                })
+                .collect();
+            out.sort_by(|a, b| a.key.cmp(&b.key));
+            to_value(out)
+        }
+
         other => Err(RpcError::method_not_found(other)),
     }
 }
@@ -1277,6 +1301,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     tmux_window: None,
                     last_message: None,
                     pending_prompt: None,
+                    config_dir: None,
                 });
             }
         }
@@ -1525,6 +1550,7 @@ fn window_placeholder_session(lane: &Lane, kind: AgentKind, window: String) -> A
         tmux_window: Some(window),
         last_message: None,
         pending_prompt: None,
+        config_dir: None,
     }
 }
 

--- a/crates/repomon-daemon/src/usage_watch.rs
+++ b/crates/repomon-daemon/src/usage_watch.rs
@@ -1,0 +1,273 @@
+//! Probing Claude's `/usage` screen for account-level usage, for the TUI's corner indicator.
+//!
+//! Subscription usage (the 5-hour and weekly windows) has no CLI flag, local file, or supported
+//! endpoint — the only source is the interactive `/usage` command. So, per Claude account, this
+//! watcher spawns a hidden throwaway `claude` window, drives it to the prompt (accepting the
+//! one-time folder-trust prompt), sends `/usage`, captures the pane, parses it
+//! ([`repomon_core::agent::parse_usage`]), dismisses, and kills the window. The result lands in
+//! [`Ctx::usage`] for the `usage.get` RPC.
+//!
+//! It is deliberately frugal and opt-in: it does nothing unless `[usage_probe]` is enabled AND a
+//! local TUI is attached, re-probes only every few minutes, and never sends a model prompt (just
+//! `/usage` + Esc). The probe window is named `usage-probe-…` (not `lane-…`) and runs in a neutral
+//! cwd, so it never pollutes repomon's own lane/agent detection. The parsing it relies on is the
+//! pure, fixture-tested part; this module is the IO around it. See `docs/agents.md`.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use repomon_core::agent::{self, parse_usage, UsageReport};
+use repomon_core::TmuxRuntime;
+
+use crate::Ctx;
+
+/// How often the watcher wakes to consider a probe. Cheap (just flag checks) unless a probe is
+/// actually due, so this is short enough to start probing soon after a TUI attaches.
+const TICK: Duration = Duration::from_secs(20);
+/// How long a usage reading stays fresh before the next probe round. Usage moves slowly and each
+/// round spawns a hidden `claude` per account, so this is generous.
+const REFRESH: Duration = Duration::from_secs(300);
+/// How long since the local TUI's last request before we treat it as gone and stop probing (we
+/// keep the last reading so reopening shows it instantly). The TUI polls ~1s; minutes of silence
+/// means nobody's looking, so there's no point spawning hidden sessions.
+const LOCAL_TTL: Duration = Duration::from_secs(60);
+
+/// One account's last usage reading, with its display label and when it was captured (for an
+/// "age" the client can show).
+#[derive(Debug, Clone)]
+pub struct UsageEntry {
+    pub report: UsageReport,
+    pub label: String,
+    pub fetched_at: Instant,
+}
+
+pub async fn usage_watcher(ctx: Arc<Ctx>) {
+    let mut tick = tokio::time::interval(TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_round: Option<Instant> = None;
+
+    loop {
+        tick.tick().await;
+
+        if !ctx.config.read().await.usage_probe {
+            // Disabled: forget any readings and re-arm so re-enabling probes promptly.
+            ctx.usage.lock().await.clear();
+            last_round = None;
+            continue;
+        }
+        // Only probe while a TUI is watching — keep the last reading otherwise (don't wipe it),
+        // so reopening the TUI shows data at once without spawning sessions in the meantime.
+        let tui_active =
+            (*ctx.local_watcher_seen.lock().await).is_some_and(|t| t.elapsed() < LOCAL_TTL);
+        if !tui_active {
+            continue;
+        }
+        if last_round.is_some_and(|t| t.elapsed() < REFRESH) {
+            continue;
+        }
+
+        let accounts = accounts();
+        let live: HashSet<String> = accounts.iter().map(|a| a.key.clone()).collect();
+        for acct in accounts {
+            let tmux = ctx.tmux.clone();
+            let window = probe_window(&acct.label);
+            let cwd = probe_cwd();
+            let command = acct.command.clone();
+            let report =
+                tokio::task::spawn_blocking(move || probe_once(&tmux, &window, &cwd, &command))
+                    .await
+                    .ok()
+                    .flatten();
+            if let Some(report) = report {
+                ctx.usage.lock().await.insert(
+                    acct.key,
+                    UsageEntry {
+                        report,
+                        label: acct.label,
+                        fetched_at: Instant::now(),
+                    },
+                );
+            }
+        }
+        // Drop readings for accounts that no longer exist.
+        ctx.usage.lock().await.retain(|k, _| live.contains(k));
+        last_round = Some(Instant::now());
+    }
+}
+
+/// A Claude account to probe: its stable key (matches `AgentSession::config_dir`), a short label
+/// (for the probe window name + display), and the launch command (carrying `CLAUDE_CONFIG_DIR`).
+struct Account {
+    key: String,
+    label: String,
+    command: String,
+}
+
+/// Enumerate the Claude accounts worth probing — those whose config dir has actually been used
+/// (`projects/` exists), so a never-run account doesn't trap the probe on first-run onboarding.
+fn accounts() -> Vec<Account> {
+    let default = agent::claude::default_config_base();
+    agent::claude::config_bases()
+        .into_iter()
+        .filter(|base| base.join("projects").is_dir())
+        .map(|base| {
+            let cfg_dir = (base != default).then(|| base.clone());
+            let command = match &cfg_dir {
+                None => "claude".to_string(),
+                Some(p) => format!("CLAUDE_CONFIG_DIR={} claude", p.display()),
+            };
+            Account {
+                key: agent::claude::account_key(cfg_dir.as_deref()),
+                label: agent::claude::account_label(cfg_dir.as_deref()),
+                command,
+            }
+        })
+        .collect()
+}
+
+/// The probe's working dir: the home directory (the parent of `~/.claude`). Neutral and outside
+/// any registered repo, so the probe never inflates a lane's agent count; typically already
+/// trusted, and the trust prompt is accepted once on first run anyway.
+fn probe_cwd() -> PathBuf {
+    agent::claude::default_config_base()
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// The hidden probe window name for an account. Non-`lane-`/`term-` so the lane scans skip it.
+fn probe_window(label: &str) -> String {
+    let safe: String = label
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    format!("usage-probe-{safe}")
+}
+
+/// Spawn a hidden `claude`, drive it to a ready prompt, run `/usage`, parse the pane, then dismiss
+/// and kill the window. Blocking (tmux IO + waits) — call from `spawn_blocking`. Returns `None` on
+/// any failure (the caller keeps the previous reading).
+fn probe_once(tmux: &TmuxRuntime, window: &str, cwd: &Path, command: &str) -> Option<UsageReport> {
+    use std::thread::sleep;
+
+    // Clear a window left over from a crashed previous round, then launch our own (detached, so an
+    // attached client never gets yanked to it).
+    let _ = tmux.kill_named(window);
+    tmux.spawn_named(window, cwd, command).ok()?;
+
+    // Drive to a ready REPL, accepting the one-time folder-trust prompt if it appears.
+    let mut ready = false;
+    for _ in 0..40 {
+        sleep(Duration::from_millis(500));
+        let pane = tmux.capture_named(window, None).unwrap_or_default();
+        match probe_state(&pane) {
+            ProbeState::Ready => {
+                ready = true;
+                break;
+            }
+            ProbeState::Trust => {
+                let _ = tmux.send_key_named(window, "Enter"); // "Yes, I trust this folder"
+            }
+            ProbeState::NotYet => {}
+        }
+    }
+
+    let mut report = None;
+    if ready {
+        // Type `/usage`, give the slash palette a beat to register, then Enter to run it.
+        let _ = tmux.send_literal_named(window, "/usage");
+        sleep(Duration::from_millis(600));
+        let _ = tmux.send_key_named(window, "Enter");
+        for _ in 0..12 {
+            sleep(Duration::from_millis(400));
+            let pane = tmux.capture_named(window, None).unwrap_or_default();
+            if let Some(r) = parse_usage(&pane) {
+                report = Some(r);
+                break;
+            }
+        }
+        let _ = tmux.send_key_named(window, "Escape"); // close the usage view
+    }
+
+    let _ = tmux.kill_named(window);
+    report
+}
+
+/// What the probe pane is showing, so the driver knows whether to wait, accept trust, or proceed.
+#[derive(Debug, PartialEq, Eq)]
+enum ProbeState {
+    /// The REPL is up and ready for `/usage`.
+    Ready,
+    /// The one-time "trust this folder?" prompt — accept it and keep waiting.
+    Trust,
+    /// Still starting up (or a screen we don't recognize) — keep waiting.
+    NotYet,
+}
+
+fn probe_state(pane: &str) -> ProbeState {
+    let low = pane.to_lowercase();
+    if low.contains("trust this folder")
+        || low.contains("do you trust")
+        || low.contains("project you created or one you trust")
+    {
+        return ProbeState::Trust;
+    }
+    if low.contains("? for shortcuts")
+        || low.contains("welcome back")
+        || low.contains("welcome to claude")
+        || low.contains("/help for help")
+    {
+        return ProbeState::Ready;
+    }
+    ProbeState::NotYet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_window_is_sanitized_and_non_lane() {
+        let w = probe_window("work");
+        assert_eq!(w, "usage-probe-work");
+        assert!(!w.starts_with("lane-"));
+        // Odd labels can't break the tmux target.
+        assert_eq!(probe_window("a.b/c"), "usage-probe-a-b-c");
+    }
+
+    #[test]
+    fn probe_state_classifies_screens() {
+        assert_eq!(
+            probe_state("Quick safety check: Is this a project you created or one you trust?"),
+            ProbeState::Trust
+        );
+        assert_eq!(
+            probe_state("Welcome back Star Solutions!\n ? for shortcuts"),
+            ProbeState::Ready
+        );
+        assert_eq!(probe_state("\n\n   loading…"), ProbeState::NotYet);
+    }
+
+    /// Full end-to-end probe against a real `claude` on the default account, in an isolated tmux
+    /// server (never the user's `repomon` session). Ignored by default — it spawns a real session
+    /// (a little quota + a tiny transcript) and takes ~10–20s. Run manually:
+    ///   cargo test -p repomon-daemon probe_once_reads_real_usage -- --ignored --nocapture
+    #[test]
+    #[ignore = "spawns a real `claude` and runs /usage; run manually with --ignored"]
+    fn probe_once_reads_real_usage() {
+        let tmux = TmuxRuntime::new("repomon-usagetest-probe");
+        let report = probe_once(&tmux, "usage-probe-test", &probe_cwd(), "claude");
+        // Tear down the isolated tmux server regardless of outcome.
+        let _ = std::process::Command::new("tmux")
+            .args(["-L", "repomon-usagetest-probe", "kill-server"])
+            .output();
+        let r = report.expect("probe should scrape and parse /usage");
+        eprintln!("scraped usage: {r:?}");
+        assert!(
+            r.session_pct.is_some() || r.week_pct.is_some(),
+            "expected at least one usage percentage"
+        );
+    }
+}

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -121,6 +121,7 @@ pub struct Settings {
     pub notify_show_why: bool,
     pub notify_coalesce: bool,
     pub notify_click_focus: bool,
+    pub usage_probe: bool,
 }
 
 /// Accent choices the Settings view cycles through (`mono` = no color).
@@ -129,7 +130,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 15;
+const SETTINGS_COUNT: usize = 16;
 
 pub struct App {
     pub client: DaemonClient,
@@ -293,6 +294,11 @@ pub struct App {
     attach_target: Option<String>,
     /// When set, the stdin-reader thread pauses (so tmux owns the terminal during an attach).
     input_suspended: Arc<AtomicBool>,
+    /// Per-account Claude usage (from the daemon's `/usage` probe), shown in the bottom-right
+    /// corner for the focused agent's account. Empty unless `usage_probe` is enabled.
+    pub usage: Vec<repomon_core::agent::AccountUsage>,
+    /// When `usage.get` was last fetched, to throttle the refresh well below the 1s tick.
+    last_usage_fetch: Option<std::time::Instant>,
 }
 
 impl App {
@@ -402,6 +408,8 @@ impl App {
             attach_request: None,
             attach_target: None,
             input_suspended: Arc::new(AtomicBool::new(false)),
+            usage: Vec::new(),
+            last_usage_fetch: None,
         }
     }
 
@@ -419,6 +427,24 @@ impl App {
         }
         if let Ok(r) = self.client.call_typed::<Vec<Repo>>("repo.list", None).await {
             self.repos = r;
+        }
+    }
+
+    /// Pull per-account `/usage` from the daemon, throttled well below the 1s tick — usage moves
+    /// slowly and the daemon only re-probes every few minutes. Leaves the previous value on error
+    /// (and stays empty when `usage_probe` is off, so the corner falls back / hides).
+    async fn sync_usage(&mut self) {
+        const EVERY: std::time::Duration = std::time::Duration::from_secs(20);
+        if self.last_usage_fetch.is_some_and(|t| t.elapsed() < EVERY) {
+            return;
+        }
+        self.last_usage_fetch = Some(std::time::Instant::now());
+        if let Ok(u) = self
+            .client
+            .call_typed::<Vec<repomon_core::agent::AccountUsage>>("usage.get", None)
+            .await
+        {
+            self.usage = u;
         }
     }
 
@@ -1139,6 +1165,20 @@ impl App {
             .and_then(|s| s.tmux_window.clone())
     }
 
+    /// The Claude account (config-dir key) of the agent the user is looking at — the selected
+    /// lane's selected session — for attributing the usage corner. `None` when no agent is in
+    /// focus. The key matches `AccountUsage::key` from the daemon's `/usage` probe.
+    pub fn focused_account_key(&self) -> Option<String> {
+        let lane = self.selected_lane()?;
+        let sess = lane
+            .agent_sessions
+            .get(self.session_idx)
+            .or_else(|| lane.agent_sessions.first())?;
+        Some(repomon_core::agent::claude::account_key(
+            sess.config_dir.as_deref(),
+        ))
+    }
+
     /// Move the session cursor among the selected lane's agents.
     fn cycle_session(&mut self, forward: bool) {
         let n = self
@@ -1607,6 +1647,9 @@ impl App {
         if let Some(x) = b("notify_click_focus") {
             self.settings.notify_click_focus = x;
         }
+        if let Some(x) = b("usage_probe") {
+            self.settings.usage_probe = x;
+        }
     }
 
     /// Persist the current settings to the daemon config and apply the accent live.
@@ -1632,6 +1675,7 @@ impl App {
             "notify_show_why": self.settings.notify_show_why,
             "notify_coalesce": self.settings.notify_coalesce,
             "notify_click_focus": self.settings.notify_click_focus,
+            "usage_probe": self.settings.usage_probe,
         });
         match self.client.call("config.set", Some(params)).await {
             Ok(v) => self.apply_settings_value(&v),
@@ -1766,13 +1810,17 @@ impl App {
                 self.settings.notify_click_focus = !self.settings.notify_click_focus;
                 self.save_settings().await;
             }
+            15 => {
+                self.settings.usage_probe = !self.settings.usage_probe;
+                self.save_settings().await;
+            }
             _ => {}
         }
     }
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 | 5..=14 => self.adjust_setting(true).await,
+            0..=2 | 5..=15 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
             _ => {}
         }
@@ -3353,6 +3401,8 @@ async fn event_loop(
                 // user is looking at Fleet or another view. lane.list is cheap (~55ms) at 1Hz and
                 // only runs while the TUI is open; commits/repos still refresh on git events.
                 app.refresh_lanes().await;
+                // Account-usage corner: a slow, self-throttled poll (no-op most ticks).
+                app.sync_usage().await;
             }
         }
     }
@@ -3612,6 +3662,7 @@ mod tests {
             tmux_window: None,
             last_message: None,
             pending_prompt: None,
+            config_dir: None,
         }
     }
 

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -60,6 +60,8 @@ pub fn render(f: &mut Frame, app: &App) {
         View::SpawnPick => render_spawn_pick(f, app),
         View::LaneJump => render_lane_jump(f, app),
     }
+    // Drawn last, over the free right end of the bottom row, so it overlays every view.
+    corner(f, app);
 }
 
 const AGENTS_KEYS: &str = "↑↓ select  ·  n new · e edit · d delete · * default  ·  esc back";
@@ -189,7 +191,7 @@ fn render_settings(f: &mut Frame, app: &App) {
         s.default_agent.clone()
     };
     let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
-    let items: [(&str, String, &str); 15] = [
+    let items: [(&str, String, &str); 16] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
         ("auto-continue", onoff(s.auto_continue), "space toggles"),
@@ -233,6 +235,11 @@ fn render_settings(f: &mut Frame, app: &App) {
             "  · click focuses terminal",
             onoff(s.notify_click_focus),
             "needs terminal-notifier",
+        ),
+        (
+            "usage corner (spawns claude)",
+            onoff(s.usage_probe),
+            "/usage probe · space toggles",
         ),
     ];
     // Size the columns to the content so values and hints line up no matter how long a label is:
@@ -1221,6 +1228,89 @@ fn fmt_resume(resume_at: Option<DateTime<Utc>>) -> String {
         Some(t) => format!("resume {}", t.with_timezone(&Local).format("%-I:%M %p")),
         None => "retrying".to_string(),
     }
+}
+
+/// The bottom-right corner: Claude usage for the focused agent's account — `5h NN% · wk NN% ·
+/// <reset>`, drawn over the free right end of the last row of *every* view. Falls back to the
+/// focused lane's rate-limit countdown when there's no scraped usage for that account, and draws
+/// nothing when there's nothing to show (probe off and no limit hit) — never fabricated numbers.
+fn corner(f: &mut Frame, app: &App) {
+    let Some((text, style)) = corner_text(app) else {
+        return;
+    };
+    let area = f.area();
+    if area.height == 0 || area.width == 0 || text.is_empty() {
+        return;
+    }
+    let w = (text.chars().count() as u16).min(area.width);
+    let rect = Rect {
+        x: area.x + area.width.saturating_sub(w),
+        y: area.y + area.height - 1,
+        width: w,
+        height: 1,
+    };
+    f.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), rect);
+}
+
+/// What the corner should show, if anything: scraped usage for the focused agent's account, else
+/// that lane's rate-limit countdown, else nothing.
+fn corner_text(app: &App) -> Option<(String, Style)> {
+    if !app.usage.is_empty() {
+        let acct = app.focused_account_key();
+        let entry = acct
+            .as_ref()
+            .and_then(|k| app.usage.iter().find(|u| &u.key == k))
+            // When the focused agent can't be attributed but there's a single account, use it.
+            .or_else(|| (app.usage.len() == 1).then(|| &app.usage[0]));
+        if let Some(found) = entry.and_then(|u| format_usage(app, u)) {
+            return Some(found);
+        }
+    }
+    corner_fallback(app)
+}
+
+/// Format one account's usage as `[label · ]5h NN% · wk NN% · <reset>`. The label is shown only
+/// when more than one account is in play. `None` when there's no usable percentage to show.
+fn format_usage(app: &App, u: &repomon_core::agent::AccountUsage) -> Option<(String, Style)> {
+    let r = &u.report;
+    if r.session_pct.is_none() && r.week_pct.is_none() {
+        return None;
+    }
+    let mut parts: Vec<String> = Vec::new();
+    if app.usage.len() > 1 {
+        parts.push(u.label.clone());
+    }
+    if let Some(p) = r.session_pct {
+        parts.push(format!("5h {p}%"));
+    }
+    if let Some(p) = r.week_pct {
+        parts.push(format!("wk {p}%"));
+    }
+    if let Some(t) = r.session_reset_at {
+        parts.push(t.with_timezone(&Local).format("%-I:%M %p").to_string());
+    }
+    // Cyan warning once the 5-hour window is getting tight; muted otherwise.
+    let style = if r.session_pct.is_some_and(|p| p >= 80) {
+        app.theme.rate_limited()
+    } else {
+        app.theme.muted()
+    };
+    Some((parts.join(" · "), style))
+}
+
+/// The focused lane's rate-limit countdown, when usage numbers aren't available — so the corner
+/// stays useful even if the probe is off or failed.
+fn corner_fallback(app: &App) -> Option<(String, Style)> {
+    use repomon_core::model::AgentStatus;
+    let lane = app.selected_lane()?;
+    let rl = lane
+        .agent_sessions
+        .iter()
+        .find(|s| s.status == AgentStatus::RateLimited)?;
+    Some((
+        format!("⏳ {}", fmt_resume(rl.resume_at)),
+        app.theme.rate_limited(),
+    ))
 }
 
 /// A compact "time since" label for a session's last activity.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -142,6 +142,28 @@ resumed on their own.
   type into. The detection/parse and the state machine are pure and unit-tested
   (`agent/limit.rs`, `auto_continue.rs`).
 
+## Usage corner (`/usage` probe)
+
+With `usage_probe = true` (a Settings toggle, **off by default**), the TUI shows Claude's account
+usage in the **bottom-right corner** — `5h 38% · wk 12% · 3:00 PM` (5-hour window %, weekly %, and
+the 5-hour reset time) — for the **account the focused agent runs under** (e.g. `~/.claude` vs
+`~/.claude-work`); switch focus to an agent on another account and the corner follows.
+
+Subscription usage has no CLI flag, file, or supported endpoint — the only source is the
+interactive `/usage` command. So a daemon watcher (`usage_watch.rs`), **only while a TUI is
+attached**, spawns a hidden throwaway `claude` window per account every ~5 minutes, sends `/usage`,
+captures and parses the pane (`agent/usage.rs`, fixture-tested), then dismisses (`Esc`) and kills
+the window. It never sends a model prompt. Caveats, by design:
+
+- It **spawns a background `claude` process** briefly per probe (hence opt-in). The probe window is
+  named `usage-probe-…` (not `lane-…`) and runs in your home dir, so it never inflates a lane's
+  `×N` agent count. The first run accepts the one-time folder-trust prompt for that dir; each probe
+  leaves a tiny (promptless) transcript behind.
+- The `/usage` layout is undocumented and changes between Claude versions. The parser anchors on
+  labels (not positions) and returns nothing rather than wrong numbers; when it can't read usage,
+  the corner **falls back** to the focused lane's rate-limit countdown (`⏳ resume 3:00 PM`), or
+  shows nothing. If Claude restyles `/usage`, recapture the fixture and adjust the parser.
+
 ## External sessions (running in another terminal)
 
 Because status comes from the transcript, a `claude` you start in any other terminal inside a

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -91,8 +91,15 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `push.unregister` | `{ device_token }` | `null` |
 | `daemon.status` | — | `{ uptime_secs, repos, lanes, db_size_bytes, version }` |
 | `daemon.shutdown` | — | `null` |
+| `usage.get` | — | `[AccountUsage]` (per Claude account, scraped from `/usage`; empty unless `usage_probe` is enabled and a TUI is attached) |
 
 `CreateLaneParams`: `{ repo_id, branch, source_branch?, path?, copy_files? }`.
+
+`AccountUsage`: `{ key, label, report: UsageReport, age_secs }` — `key` matches a session's
+`config_dir` (the account; `"default"` for `~/.claude`) so a client attributes usage to the
+focused agent's account. `UsageReport`: `{ session_pct?, session_reset_at?, week_pct?,
+week_reset_at?, week_model_pct? }` — percentages of the 5-hour and weekly windows; every field
+optional (a partial `/usage` parse still returns what was readable).
 
 ## Events
 


### PR DESCRIPTION
## What

Shows Claude **account usage** in the TUI's bottom-right corner, in every view:

```
work · 5h 38% · wk 12% · 3:00 PM
```

(5-hour window %, weekly %, 5-hour reset time) — attributed to the **account the focused agent runs under** (`~/.claude` vs `~/.claude-work`). Switch focus to an agent on another account and the corner follows. **Off by default** behind a `usage_probe` Settings toggle.

## Why it's built this way

Subscription usage has **no CLI flag, local file, or supported endpoint** — the only source is the interactive `/usage` command. So a daemon watcher (`usage_watch.rs`), **only while a TUI is attached**, spawns a hidden throwaway `claude` window per account every ~5 min, sends `/usage`, captures + parses the pane, then dismisses (`Esc`) and kills the window. It never sends a model prompt. The probe window is named `usage-probe-…` (not `lane-…`) and runs in a neutral cwd, so it never pollutes repomon's own lane/agent detection.

## Changes

- **core**: `agent/usage.rs` parses the `/usage` screen (fixture-tested against a real v2.1.181 capture); `agent/text.rs` holds the ANSI/clock/percent helpers refactored out of `agent/limit.rs`, plus date-aware reset parsing for the weekly window. `AgentSession.config_dir` added so the account reaches clients.
- **daemon**: `usage_watch.rs` spawn-capture-kill probe + `Ctx.usage` map + `usage.get` RPC; gated on `usage_probe` **and** a TUI being attached.
- **tui**: a `corner()` drawn once over every view's bottom row, account-attributed via the focused agent, with a **rate-limit-countdown fallback** when usage isn't available; Settings toggle.
- **config**: `usage_probe` (default `false`), wired through `config.get`/`config.set`.
- **docs**: `protocol.md` (`usage.get` + `UsageReport`), `agents.md` (probe + caveats), `STATUS.md`.

## Verification

- `cargo test --workspace` green; clippy clean. New unit tests: 8 parser/text (against the **real** `/usage` capture), 2 probe-classifier.
- **Live end-to-end** (isolated tmux server, real `claude` v2.1.181, ignored test `probe_once_reads_real_usage`): `session_pct 25, week_pct 42, session_reset 19:00Z, week_reset Jun 21 15:00Z` — full pipeline confirmed.

## Caveats (by design)

- Spawns a background `claude` per probe (hence opt-in); leaves a tiny promptless transcript; accepts the one-time folder-trust prompt for the probe cwd.
- The `/usage` layout is undocumented and shifts between Claude versions — the parser anchors on labels and returns nothing rather than wrong numbers (the corner then falls back to the rate-limit countdown). If Claude restyles `/usage`, recapture the fixture (`crates/repomon-core/src/agent/fixtures/usage_v2.ansi`) and adjust `agent/usage.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)