### PR TITLE
fix(watcher): drop the file-id cache (NoCache) — it pegged a core on churn

### DIFF
--- a/crates/repomon-core/src/watch.rs
+++ b/crates/repomon-core/src/watch.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use notify::{RecommendedWatcher, RecursiveMode};
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use notify::{Config, RecommendedWatcher, RecursiveMode};
+use notify_debouncer_full::{new_debouncer_opt, DebounceEventResult, Debouncer, NoCache};
 use tokio::sync::broadcast;
 
 use crate::error::{Error, Result};
@@ -35,7 +35,11 @@ pub struct RepoChange {
 
 /// A filesystem watcher over a set of worktree roots.
 pub struct Watcher {
-    debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
+    // `NoCache`, not the default `RecommendedCache` (`FileIdMap` on macOS): the file-id cache
+    // `stat`s + `readdir`s the tree on every event to track renames, which pegs a core when a
+    // watched worktree churns (a dev server / build). repomon only needs "this root changed", not
+    // rename correlation, so the cache is pure overhead.
+    debouncer: Debouncer<RecommendedWatcher, NoCache>,
     tx: broadcast::Sender<RepoChange>,
     roots: Arc<Mutex<Vec<PathBuf>>>,
 }
@@ -48,7 +52,7 @@ impl Watcher {
 
         let tx_cb = tx.clone();
         let roots_cb = roots.clone();
-        let debouncer = new_debouncer(
+        let debouncer = new_debouncer_opt::<_, RecommendedWatcher, NoCache>(
             Duration::from_millis(250),
             None,
             move |res: DebounceEventResult| {
@@ -65,6 +69,8 @@ impl Watcher {
                     }
                 }
             },
+            NoCache::new(),
+            Config::default(),
         )
         .map_err(|e| Error::Other(format!("watcher init: {e}")))?;
 


### PR DESCRIPTION
## Problem
`repomond` was burning **30–150% of a core**. Sampling the live process showed the cost was a
`stat` + `readdir` storm **inside the notify-rs FSEvents callback** — not real work:

```
notify-rs fsevents loop → FSEvents callback → (debouncer cache) → stat (1256) + readdir/getdirentries (654)
```

`notify_debouncer_full`'s default `RecommendedCache` is a **`FileIdMap`** on macOS, which `stat()`s
and `readdir()`s the tree on every filesystem event to track renames. A watched worktree under
heavy churn (here, a **node dev server running in SAAS**) makes that walk run continuously and pegs
the core. The existing noise filter doesn't help — the walk happens *inside notify-rs*, before any
of our code sees the events.

## Fix
repomon only needs "this root changed" to flag a refresh — not rename correlation — so the file-id
cache is pure overhead. Switch the debouncer to **`NoCache`** via `new_debouncer_opt`.

**Measured under the same dev-server churn:** ~33% steady / ~115–150% peak → **~0–1% steady** (one
new daemon at 0.0% while the old FileIdMap one was still pegged mid-restart). Renames now arrive as
remove+create, which the classifier already coalesces by `(root, kind)`.

`cargo build` / `clippy -D warnings` / tests green (106 core tests); daemon installed + restarted
and CPU verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
