### PR TITLE
feat: add Gemini CLI support (agent + best-effort usage)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -45,9 +45,14 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 - repomon's tmux runs on a **dedicated socket**, isolated from the user's own tmux.
 - **Account-usage corner** (opt-in `usage_probe`) — limit windows (% used) + reset shown
   bottom-right for the focused agent's account, **provider-aware**: Claude `/usage` (5h + weekly,
-  per `~/.claude*` account) and Codex `/status` (5h/weekly or Free monthly). Scraped via a hidden
-  throwaway session per account (`usage_watch.rs` + fixture-tested `agent/usage.rs`), with a
-  rate-limit countdown fallback. See `docs/agents.md`.
+  per `~/.claude*` account), Codex `/status` (5h/weekly or Free monthly), and Gemini `/stats`
+  (daily quota, best-effort — see caveat). Scraped via a hidden throwaway session per account
+  (`usage_watch.rs` + fixture-tested `agent/usage.rs`), with a rate-limit countdown fallback.
+  See `docs/agents.md`.
+- **Gemini** is a first-class spawnable agent (`AgentKind::Gemini`, `gemini` on PATH). Its usage
+  corner is best-effort: Gemini only exposes quota in interactive `/stats` (OAuth Code-Assist) and
+  a probe-spawned `gemini` often can't auth unattended, so usage shows only where it reaches its
+  prompt with cached creds; otherwise the corner falls back.
 
 ## Deferred (explicitly out of scope in the plan)
 

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -23,7 +23,9 @@ use crate::model::{AgentKind, AgentStatus};
 pub use claude::TranscriptSummary;
 pub use limit::{detect_usage_limit, menu_select_keys, LimitMenu, UsageLimit};
 pub use tmux::{shell_quote, TmuxRuntime};
-pub use usage::{parse_codex_status, parse_usage, AccountUsage, UsageReport, UsageWindow};
+pub use usage::{
+    parse_codex_status, parse_gemini_status, parse_usage, AccountUsage, UsageReport, UsageWindow,
+};
 
 /// How recently a file must have changed for its agent to count as "running".
 const ACTIVE_WINDOW: Duration = Duration::from_secs(120);

--- a/crates/repomon-core/src/agent/text.rs
+++ b/crates/repomon-core/src/agent/text.rs
@@ -83,6 +83,59 @@ pub(crate) fn parse_reset_datetime(lower: &str, now: DateTime<Local>) -> Option<
     parse_dated(lower, now).or_else(|| parse_reset_at(lower, now))
 }
 
+/// Resolve a *relative* reset like `"resets in 3h 24m"` / `"in about 2 hours"` to an absolute time
+/// (`now` + the parsed duration). Sums any `<n><unit>` tokens (d/h/m/s, long or short). `None`
+/// when no duration token is present. Input should be lowercased.
+pub(crate) fn parse_relative_reset(lower: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    let dur = parse_duration_tokens(lower)?;
+    Some((now + dur).with_timezone(&Utc))
+}
+
+fn parse_duration_tokens(s: &str) -> Option<Duration> {
+    let b = s.as_bytes();
+    let mut total = Duration::zero();
+    let mut found = false;
+    let mut i = 0;
+    while i < b.len() {
+        if b[i].is_ascii_digit() && (i == 0 || !b[i - 1].is_ascii_digit()) {
+            let start = i;
+            while i < b.len() && b[i].is_ascii_digit() {
+                i += 1;
+            }
+            let Ok(n) = s[start..i].parse::<i64>() else {
+                continue;
+            };
+            // Optional spaces, then the unit word.
+            let mut k = i;
+            while k < b.len() && b[k] == b' ' {
+                k += 1;
+            }
+            let u0 = k;
+            while k < b.len() && b[k].is_ascii_alphabetic() {
+                k += 1;
+            }
+            if let Some(d) = unit_to_duration(n, &s[u0..k]) {
+                total += d;
+                found = true;
+                i = k;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    found.then_some(total)
+}
+
+fn unit_to_duration(n: i64, unit: &str) -> Option<Duration> {
+    match unit.trim_end_matches('s') {
+        "d" | "day" => Some(Duration::days(n)),
+        "h" | "hr" | "hour" => Some(Duration::hours(n)),
+        "m" | "min" | "minute" => Some(Duration::minutes(n)),
+        "sec" | "second" => Some(Duration::seconds(n)),
+        _ => None,
+    }
+}
+
 const MONTHS: [&str; 12] = [
     "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
 ];
@@ -309,6 +362,21 @@ mod tests {
             .with_timezone(&Local);
         assert_eq!((dt.month(), dt.day()), (7, 19));
         assert_eq!((dt.hour(), dt.minute()), (4, 0));
+    }
+
+    #[test]
+    fn relative_reset_sums_tokens() {
+        let now = Local.with_ymd_and_hms(2026, 6, 19, 10, 0, 0).unwrap();
+        let t = parse_relative_reset("limit resets in 3h 24m", now)
+            .unwrap()
+            .with_timezone(&Local);
+        assert_eq!((t.hour(), t.minute()), (13, 24));
+        // Long unit names and a leading filler word.
+        let t2 = parse_relative_reset("resets in about 2 hours", now)
+            .unwrap()
+            .with_timezone(&Local);
+        assert_eq!(t2.hour(), 12);
+        assert!(parse_relative_reset("no duration here", now).is_none());
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/usage.rs
+++ b/crates/repomon-core/src/agent/usage.rs
@@ -13,7 +13,7 @@
 use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::text::{parse_pct, parse_reset_datetime, strip_ansi};
+use super::text::{parse_pct, parse_relative_reset, parse_reset_datetime, strip_ansi};
 
 /// One usage limit window, normalized across agents. `pct_used` is how much of the window is
 /// consumed (0–100); `label` is a short tag for display (`5h`, `wk`, `mo`, or a model name).
@@ -103,6 +103,33 @@ pub fn parse_codex_status(pane: &str) -> Option<UsageReport> {
         windows.push(window(&codex_label(&low[..lpos]), pct_used, reset));
     }
 
+    (!windows.is_empty()).then_some(UsageReport { windows })
+}
+
+/// Parse Gemini CLI's `/stats` (alias `/usage`) quota line. For OAuth Code-Assist accounts it
+/// renders `"{N}% used (Limit resets in {dur})"`, or `"Limit reached, resets in {dur}"` when
+/// exhausted, with `"Usage limit: {limit}"` / `"… reset daily"` detail rows. The window is the
+/// daily request quota; the reset is a relative duration. (API-key/Vertex accounts show no quota,
+/// so this yields `None` — the corner then falls back.) Normalized to % used (Gemini already is).
+pub fn parse_gemini_status(pane: &str) -> Option<UsageReport> {
+    let now = Local::now();
+    let mut windows = Vec::new();
+    for line in pane.lines() {
+        let clean = strip_ansi(line);
+        let low = clean.to_lowercase();
+        if low.contains("limit reached") && low.contains("resets in") {
+            windows.push(window("day", 100, parse_relative_reset(&low, now)));
+        } else if low.contains("% used") && (low.contains("resets in") || low.contains("limit")) {
+            if let Some(pct) = parse_pct(&clean) {
+                let reset = if low.contains("resets in") {
+                    parse_relative_reset(&low, now)
+                } else {
+                    None
+                };
+                windows.push(window("day", pct, reset));
+            }
+        }
+    }
     (!windows.is_empty()).then_some(UsageReport { windows })
 }
 
@@ -212,10 +239,30 @@ mod tests {
     }
 
     #[test]
+    fn parses_gemini_quota_line() {
+        // Gemini /stats renders this for OAuth Code-Assist accounts. The exact strings are from
+        // gemini-cli's QuotaStatsInfo source; a live capture isn't possible here (a probe-spawned
+        // gemini can't authenticate unattended), so this asserts the documented format.
+        let pane = "Auth Method: oauth-personal\n  37% used (Limit resets in 3h 24m)\n  \
+                    Usage limit: 1000\n  Usage limits span all sessions and reset daily.";
+        let r = parse_gemini_status(pane).expect("gemini quota");
+        let day = win(&r, "day");
+        assert_eq!(day.pct_used, 37);
+        assert!(day.reset_at.is_some());
+    }
+
+    #[test]
+    fn parses_gemini_limit_reached() {
+        let r = parse_gemini_status("Limit reached, resets in 45m").expect("exhausted");
+        assert_eq!(win(&r, "day").pct_used, 100);
+    }
+
+    #[test]
     fn trust_prompt_yields_none() {
         let pane = include_str!("fixtures/trust_prompt.txt");
         assert!(parse_usage(pane).is_none());
         assert!(parse_codex_status(pane).is_none());
+        assert!(parse_gemini_status(pane).is_none());
     }
 
     #[test]
@@ -223,6 +270,8 @@ mod tests {
         assert!(parse_usage("").is_none());
         assert!(parse_usage("running 24 tests\ntest result: ok").is_none());
         assert!(parse_codex_status("just some\noutput lines").is_none());
+        // Gemini's per-session token stats (no account quota) must not parse as usage.
+        assert!(parse_gemini_status("Session Stats\nTokens: 1234 input, 567 output").is_none());
     }
 
     #[test]

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -117,6 +117,7 @@ pub enum AgentKind {
     Cursor,
     Aider,
     Codex,
+    Gemini,
     Other(String),
 }
 
@@ -128,6 +129,7 @@ impl AgentKind {
             AgentKind::Cursor => Cow::Borrowed("cursor"),
             AgentKind::Aider => Cow::Borrowed("aider"),
             AgentKind::Codex => Cow::Borrowed("codex"),
+            AgentKind::Gemini => Cow::Borrowed("gemini"),
             AgentKind::Other(s) => Cow::Owned(s.clone()),
         }
     }
@@ -139,6 +141,7 @@ impl AgentKind {
             AgentKind::Cursor => "cursor",
             AgentKind::Aider => "aider",
             AgentKind::Codex => "codex",
+            AgentKind::Gemini => "gemini",
             AgentKind::Other(s) => s,
         }
     }
@@ -148,6 +151,7 @@ impl AgentKind {
         match self {
             AgentKind::ClaudeCode => "claude",
             AgentKind::Codex => "codex",
+            AgentKind::Gemini => "gemini",
             AgentKind::Aider => "aider",
             AgentKind::Cursor => "cursor-agent",
             AgentKind::Other(s) => s,
@@ -159,6 +163,7 @@ impl AgentKind {
         match s {
             "claude-code" | "claude" => AgentKind::ClaudeCode,
             "codex" => AgentKind::Codex,
+            "gemini" => AgentKind::Gemini,
             "aider" => AgentKind::Aider,
             "cursor" => AgentKind::Cursor,
             other => AgentKind::Other(other.to_string()),
@@ -434,6 +439,7 @@ mod tests {
         for k in [
             AgentKind::ClaudeCode,
             AgentKind::Codex,
+            AgentKind::Gemini,
             AgentKind::Aider,
             AgentKind::Cursor,
             AgentKind::Other("amp".into()),

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -506,7 +506,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                     custom: false,
                 });
             }
-            for kind in [AgentKind::Codex, AgentKind::Aider] {
+            for kind in [AgentKind::Codex, AgentKind::Gemini, AgentKind::Aider] {
                 let command = kind.command().to_string();
                 let name = kind.as_str().into_owned();
                 choices.push(AgentChoice {

--- a/crates/repomon-daemon/src/usage_watch.rs
+++ b/crates/repomon-daemon/src/usage_watch.rs
@@ -18,7 +18,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use repomon_core::agent::{self, parse_codex_status, parse_usage, UsageReport};
+use repomon_core::agent::{
+    self, parse_codex_status, parse_gemini_status, parse_usage, UsageReport,
+};
 use repomon_core::TmuxRuntime;
 
 use crate::Ctx;
@@ -100,13 +102,15 @@ struct Account {
 }
 
 /// How to probe one agent: the launch command, the usage slash-command, the parser, and the pane
-/// markers that say the REPL is ready or sitting on a folder-trust prompt.
+/// markers that say the REPL is ready, sitting on a folder-trust prompt, or hard-blocked (so the
+/// probe gives up fast instead of waiting out the whole ready timeout).
 struct ProbeSpec {
     command: String,
     slash: &'static str,
     parse: fn(&str) -> Option<UsageReport>,
     ready: &'static [&'static str],
     trust: &'static [&'static str],
+    blocked: &'static [&'static str],
 }
 
 fn claude_spec(command: String) -> ProbeSpec {
@@ -125,6 +129,7 @@ fn claude_spec(command: String) -> ProbeSpec {
             "do you trust",
             "project you created or one you trust",
         ],
+        blocked: &[],
     }
 }
 
@@ -137,6 +142,26 @@ fn codex_spec() -> ProbeSpec {
         trust: &[
             "do you trust the contents",
             "trust the contents of this directory",
+        ],
+        blocked: &[],
+    }
+}
+
+/// Best-effort: Gemini's quota appears only in the interactive `/stats` (alias `/usage`) for OAuth
+/// Code-Assist accounts. A probe-spawned `gemini` often can't authenticate unattended (it wants
+/// browser consent) — that's detected as `blocked` so the probe bails fast and the corner falls
+/// back. Where gemini *does* reach its prompt with cached creds, `/stats` is scraped like the rest.
+fn gemini_spec() -> ProbeSpec {
+    ProbeSpec {
+        command: "gemini".to_string(),
+        slash: "/stats",
+        parse: parse_gemini_status,
+        ready: &["type your message", "/help for", "gemini-2", "gemini-3"],
+        trust: &["do you trust", "trust the files in this folder"],
+        blocked: &[
+            "how would you like to authenticate",
+            "authentication consent could not",
+            "opening authentication page",
         ],
     }
 }
@@ -167,6 +192,13 @@ fn accounts() -> Vec<Account> {
             key: "codex".to_string(),
             label: "codex".to_string(),
             spec: codex_spec(),
+        });
+    }
+    if probe_cwd().join(".gemini").is_dir() {
+        out.push(Account {
+            key: "gemini".to_string(),
+            label: "gemini".to_string(),
+            spec: gemini_spec(),
         });
     }
     out
@@ -212,6 +244,7 @@ fn probe_once(tmux: &TmuxRuntime, window: &str, cwd: &Path, spec: &ProbeSpec) ->
             ProbeState::Trust => {
                 let _ = tmux.send_key_named(window, "Enter"); // accept "trust this folder/contents"
             }
+            ProbeState::Blocked => break, // e.g. needs interactive auth — give up this round
             ProbeState::NotYet => {}
         }
     }
@@ -243,16 +276,21 @@ fn probe_once(tmux: &TmuxRuntime, window: &str, cwd: &Path, spec: &ProbeSpec) ->
     report
 }
 
-/// What the probe pane is showing, so the driver knows whether to wait, accept trust, or proceed.
+/// What the probe pane is showing, so the driver knows whether to wait, accept trust, proceed, or
+/// give up (a hard block like an unattended-auth demand).
 #[derive(Debug, PartialEq, Eq)]
 enum ProbeState {
     Ready,
     Trust,
+    Blocked,
     NotYet,
 }
 
 fn probe_state(pane: &str, spec: &ProbeSpec) -> ProbeState {
     let low = pane.to_lowercase();
+    if spec.blocked.iter().any(|m| low.contains(m)) {
+        return ProbeState::Blocked;
+    }
     if spec.trust.iter().any(|m| low.contains(m)) {
         return ProbeState::Trust;
     }
@@ -294,6 +332,17 @@ mod tests {
         );
         assert_eq!(
             probe_state(">_ OpenAI Codex (v0.141.0)", &codex),
+            ProbeState::Ready
+        );
+
+        let gemini = gemini_spec();
+        // An unattended-auth demand is a hard block (bail fast, don't wait out the timeout).
+        assert_eq!(
+            probe_state("How would you like to authenticate for this project?", &gemini),
+            ProbeState::Blocked
+        );
+        assert_eq!(
+            probe_state("Type your message or @path/to/file", &gemini),
             ProbeState::Ready
         );
     }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -37,7 +37,7 @@ const NOTIF_DEBOUNCE: Duration = Duration::from_secs(30);
 const NOTIF_HISTORY_CAP: usize = 200;
 
 /// Agent kinds offered when creating a lane (cycled with Tab).
-pub const AGENT_KINDS: &[&str] = &["claude-code", "codex", "aider"];
+pub const AGENT_KINDS: &[&str] = &["claude-code", "codex", "gemini", "aider"];
 
 /// Timeline zoom levels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1187,6 +1187,7 @@ impl App {
             .or_else(|| lane.agent_sessions.first())?;
         match &sess.agent {
             AgentKind::Codex => Some("codex".to_string()),
+            AgentKind::Gemini => Some("gemini".to_string()),
             AgentKind::ClaudeCode => Some(repomon_core::agent::claude::account_key(
                 sess.config_dir.as_deref(),
             )),

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -151,12 +151,20 @@ agent shows its account's `/usage` (`~/.claude` vs `~/.claude-work`), a Codex ag
 `/status`; switch focus and the corner follows.
 
 Subscription usage has no CLI flag, file, or supported endpoint — the only source is an interactive
-command (Claude `/usage`, Codex `/status`). So a daemon watcher (`usage_watch.rs`), **only while a
-TUI is attached**, spawns a hidden throwaway session per account every ~5 minutes, sends the usage
-command, captures and parses the pane (`agent/usage.rs`, fixture-tested), then dismisses (`Esc`) and
-kills the window. It never sends a model prompt. Numbers are normalized to **% used** across agents
-(Codex reports "% left"); windows shown are whatever the tool reports — Claude's 5-hour + weekly,
-Codex's 5-hour/weekly or (Free plan) monthly. Caveats, by design:
+command (Claude `/usage`, Codex `/status`, Gemini `/stats`). So a daemon watcher (`usage_watch.rs`),
+**only while a TUI is attached**, spawns a hidden throwaway session per account every ~5 minutes,
+sends the usage command, captures and parses the pane (`agent/usage.rs`, fixture-tested), then
+dismisses (`Esc`) and kills the window. It never sends a model prompt. Numbers are normalized to
+**% used** across agents (Codex reports "% left"); windows shown are whatever the tool reports —
+Claude's 5-hour + weekly, Codex's 5-hour/weekly or (Free) monthly, Gemini's daily request quota.
+Caveats, by design:
+
+- **Gemini is best-effort.** Its quota appears only in the interactive `/stats` and only for OAuth
+  Code-Assist accounts; there is no local file or headless command. A probe-spawned `gemini` often
+  can't authenticate unattended (it demands browser consent), in which case the probe detects the
+  auth screen, gives up fast, and the corner falls back — so Gemini usage shows only where `gemini`
+  reaches its prompt with cached credentials. The parser is unit-tested against Gemini's documented
+  `/stats` format. (Gemini is still a first-class spawnable agent regardless of usage.)
 
 - It **spawns a background agent process** briefly per probe (hence opt-in). The probe window is
   named `usage-probe-…` (not `lane-…`) and runs in your home dir, so it never inflates a lane's

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -91,7 +91,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `push.unregister` | `{ device_token }` | `null` |
 | `daemon.status` | — | `{ uptime_secs, repos, lanes, db_size_bytes, version }` |
 | `daemon.shutdown` | — | `null` |
-| `usage.get` | — | `[AccountUsage]` (per agent account, scraped from Claude `/usage` and Codex `/status`; empty unless `usage_probe` is enabled and a TUI is attached) |
+| `usage.get` | — | `[AccountUsage]` (per agent account, scraped from Claude `/usage`, Codex `/status`, Gemini `/stats`; empty unless `usage_probe` is enabled and a TUI is attached) |
 
 `CreateLaneParams`: `{ repo_id, branch, source_branch?, path?, copy_files? }`.
 


### PR DESCRIPTION
## What

Makes **Gemini a first-class agent** and extends the usage corner to it (provider-aware, after Claude + Codex).

- **Spawnable agent**: `AgentKind::Gemini` (binary `gemini`) wired through `as_str`/`short`/`command`/`from_kind_str`; added to the New Lane picker (`AGENT_KINDS`) and `agent.detect` (PATH-checked built-in).
- **Usage**: `parse_gemini_status` parses Gemini's interactive `/stats` (alias `/usage`) quota line — `"{N}% used (Limit resets in {dur})"` / `"Limit reached, resets in {dur}"` — into a daily window. New `text::parse_relative_reset` handles the relative duration ("resets in 3h 24m"). Already "% used", so no conversion (Codex's "% left" → used stays Codex-only).
- **Probe**: `gemini_spec()` + a `"gemini"` account gated on `~/.gemini`. `ProbeSpec` gains a `blocked` marker set + `ProbeState::Blocked` so the probe bails fast on Gemini's unattended-auth screen instead of waiting out the ready timeout.
- **TUI**: `focused_account_key` returns `"gemini"` for Gemini agents; the corner renders its windows generically (no view change).
- Docs: `agents.md`, `protocol.md`, `STATUS.md`.

## Verification

- 112 core tests pass (+3: gemini quota parse, limit-reached, relative-reset), clippy clean. The parser is unit-tested against gemini-cli's **documented** `/stats` strings.

## Best-effort caveat (important)

Gemini exposes quota **only** in the interactive `/stats` and **only** for OAuth Code-Assist accounts — there's no local file or headless command. A probe-spawned `gemini` often can't authenticate unattended (it demands browser consent; verified here that both interactive-spawn and headless `gemini -p` fail/hang on auth), so on those setups the corner **falls back** (the `Blocked` state makes it give up in ~1s). Gemini usage shows only where `gemini` reaches its prompt with cached creds. The live Gemini probe therefore **could not be verified on this machine**; if a real `/stats` capture differs from the documented format, the parser (and the best-guess `ready` markers) may need a small tweak. The spawnable-agent half is fully functional regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)