### PR TITLE
feat: expand multi-agent lanes into per-agent sidebar rows + rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 # repomon
 
-**Mission control for parallel AI coding agents — across many repos, branches, and
-worktrees, from one terminal.**
+**Run a fleet of AI coding agents across all your repos — from one terminal.**
+
+Many repos × many worktrees × many agents on one screen — durable in tmux, the ones waiting
+on you float to the top, and you can approve a prompt from your phone.
+
+<p>
+  <a href="https://github.com/AliHamzaAzam/repomon/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/AliHamzaAzam/repomon?color=00b3b3&label=release"></a>
+  <img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue">
+  <img alt="Platforms: macOS · Linux" src="https://img.shields.io/badge/macOS%20%C2%B7%20Linux-555">
+  <img alt="Built with Rust" src="https://img.shields.io/badge/built%20with-Rust-orange">
+  <img alt="For Claude Code · Codex · Aider" src="https://img.shields.io/badge/for-Claude%20Code%20%C2%B7%20Codex%20%C2%B7%20Aider-8A2BE2">
+</p>
+
+<!-- Hero demo GIF: docs/demo.gif -->
+<p align="center">
+  <img src="docs/demo.gif" alt="repomon — triaging a fleet of AI coding agents across repos" width="900">
+</p>
 
 Other tools run parallel agents in *one repo, many worktrees* (Claude Squad, Conductor,
-Crystal, ccmanager, …). repomon is built for the developer with 5–15 active projects and a
-fleet of agents running at once: **many repos × many worktrees × many agents**, on one
-screen, spawned and steered from one place.
+Crystal, ccmanager). repomon is built for the developer juggling **5–15 active projects** with
+a fleet of agents running at once: **many repos × many worktrees × many agents**, spawned and
+steered from one place.
 
 ```
 REPOMON                                              14:02 fri 29 may 2026
@@ -52,6 +67,20 @@ changes — including interactive permission dialogs read from the pane — broa
 iOS companion app, which renders the fleet, the agents' conversations, and an Approve
 button for pending dialogs.
 
+## How it compares
+
+|  | **repomon** | Claude Squad / ccmanager | GUI apps (Conductor, Crystal) | built-in `claude agents` |
+|---|---|---|---|---|
+| **Scope** | many repos × worktrees × agents | one repo, many worktrees | one repo, many worktrees | one tool, flat list |
+| **Runtime** | durable tmux — survives close, reattach | tmux | app process | inside the CLI |
+| **Triage** | needs-you float to top, `g` to jump | flat list | varies | grouped by state |
+| **Usage limits** | live usage corner + auto-continue | — | — | — |
+| **Remote** | approve from your phone (iOS over Tailscale) | — | — | — |
+| **Lives in the terminal** | ✅ (4-zoom TUI) | ✅ | ❌ (GUI) | ✅ |
+
+Honest take: if you work in **one** repo, Claude Squad/ccmanager or a GUI may be simpler.
+repomon earns its keep once you're running agents across **several** projects at once.
+
 ## Architecture
 
 A background daemon (`repomond`) owns SQLite, file watchers, the git layer, and the
@@ -64,17 +93,17 @@ is a thin client. Three crates:
 
 ## Install
 
+**One line, no deps** (prebuilt binaries — no Rust or Xcode):
+
+```sh
+curl -fsSL https://github.com/AliHamzaAzam/repomon/releases/latest/download/install.sh | sh
+```
+
 **Homebrew** (macOS):
 
 ```sh
 brew install AliHamzaAzam/tap/repomon      # or: brew tap AliHamzaAzam/tap && brew install repomon
 brew services start repomon                # optional: run the daemon at login
-```
-
-**Without Homebrew** — prebuilt binaries, no Rust or Xcode needed:
-
-```sh
-curl -fsSL https://github.com/AliHamzaAzam/repomon/releases/latest/download/install.sh | sh
 ```
 
 Or grab a tarball from the [latest release](https://github.com/AliHamzaAzam/repomon/releases/latest) —

--- a/STATUS.md
+++ b/STATUS.md
@@ -43,6 +43,10 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 - **Plain terminals** per worktree (`t`), multiple allowed.
 - Revamped **Grid** (real navigation, Instagram-style position dots, clean exit).
 - repomon's tmux runs on a **dedicated socket**, isolated from the user's own tmux.
+- **Notifications hardened** — desktop popups land faster (daemon edge-detector tick 8s→2s),
+  attach-return no longer replays a duplicate backlog (re-seed instead of re-diff), and a new
+  `notify_subagents` toggle (default off) suppresses alerts when worktree-isolated *subagents*
+  finish — you're alerted only when the *main* agent finishes.
 - **Expand agent rows** (opt-in `expand_agents`) — a lane running several agents can render as a
   tree in the sidebar (header + one row per agent, each with a 1-4 word summary + status) instead
   of an `×N` badge; sub-rows are individually selectable. Press `R` to rename an agent; the label

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 _Snapshot: 2026-05-30 · branch `main` · 44 commits · github.com/AliHamzaAzam/repomon (private)_
 
-repomon is a Rust TUI "mission control" for parallel AI coding agents across many repos,
+repomon is a Rust TUI for running a fleet of AI coding agents across many repos,
 branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned milestones
 (M0–M13) are complete and the quality/perf gates pass — ready for hands-on testing.**
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,7 +15,7 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 | **3 — Dashboard / history** | M11 history indexer · timeline · jaccard correlations · session detection · markdown export · commit search | ✅ |
 | **4 — Polish (Rust-only)** | M12 accent-color slot + mouse · M13 docs + perf | ✅ |
 
-10 views, 5 CLI subcommands, 39 RPC methods wired.
+10 views, 5 CLI subcommands, 40 RPC methods wired.
 
 ## Quality bar (verified)
 
@@ -43,6 +43,10 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 - **Plain terminals** per worktree (`t`), multiple allowed.
 - Revamped **Grid** (real navigation, Instagram-style position dots, clean exit).
 - repomon's tmux runs on a **dedicated socket**, isolated from the user's own tmux.
+- **Expand agent rows** (opt-in `expand_agents`) — a lane running several agents can render as a
+  tree in the sidebar (header + one row per agent, each with a 1-4 word summary + status) instead
+  of an `×N` badge; sub-rows are individually selectable. Press `R` to rename an agent; the label
+  persists in the daemon keyed by transcript id (`session.rename` RPC, `session_labels` table).
 - **Account-usage corner** (opt-in `usage_probe`) — limit windows (% used) + reset shown
   bottom-right for the focused agent's account, **provider-aware**: Claude `/usage` (5h + weekly,
   per `~/.claude*` account) and Codex `/status` (5h/weekly or Free monthly). Scraped via a hidden

--- a/crates/repomon-core/migrations/0004_session_labels.sql
+++ b/crates/repomon-core/migrations/0004_session_labels.sql
@@ -1,0 +1,8 @@
+-- User-set short labels for agent sessions, keyed by the durable Claude transcript session id
+-- (stable across refreshes and daemon restarts; a new agent in a reused slot gets a new id, so a
+-- label never bleeds onto an unrelated successor). Overlaid onto AgentSession at lane.list time.
+CREATE TABLE IF NOT EXISTS session_labels (
+    session_id TEXT PRIMARY KEY,
+    label      TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -67,6 +67,7 @@ impl TranscriptSummary {
             resume_at: None,
             inferred: false,
             config_dir: self.config_dir,
+            custom_label: None, // overlay sets this from the session_labels store
         }
     }
 }

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -327,8 +327,16 @@ fn parse_transcript_inner(path: &Path) -> Option<TranscriptSummary> {
             }
             Some("user") => {
                 last_type = Some("user");
+                // Title from the first *real* prompt — skip Claude Code's injected scaffolding
+                // (the local-command caveat, slash-command invocations, local-command stdout),
+                // which would otherwise show up as "<local-command-caveat>Caveat: …".
                 if title.is_none() {
-                    title = user_text(&v).map(|t| truncate(&t, 60));
+                    if let Some(t) = user_text(&v) {
+                        let t = t.trim();
+                        if !t.is_empty() && !is_synthetic_user_text(t) {
+                            title = Some(truncate(t, 60));
+                        }
+                    }
                 }
             }
             Some("summary") => {
@@ -509,6 +517,19 @@ pub fn config_base_for_session(cwd: &Path, session_id: &str) -> Option<Option<Pa
 
 fn canonical(p: &Path) -> PathBuf {
     p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Whether a user message is Claude Code's injected scaffolding rather than a real prompt — the
+/// local-command caveat, a slash-command invocation, or local-command stdout. Such messages must
+/// not become the session title/summary.
+fn is_synthetic_user_text(t: &str) -> bool {
+    let t = t.trim_start();
+    t.starts_with("Caveat:")
+        || t.starts_with("<local-command-caveat>")
+        || t.starts_with("<command-name>")
+        || t.starts_with("<command-message>")
+        || t.starts_with("<command-args>")
+        || t.starts_with("<local-command-stdout>")
 }
 
 fn user_text(v: &Value) -> Option<String> {
@@ -760,6 +781,31 @@ mod tests {
             parse_transcript(&path).unwrap().status,
             AgentStatus::Idle,
             "a frozen transcript still decays to Idle on a cache hit"
+        );
+    }
+
+    #[test]
+    fn synthetic_user_text_detected() {
+        assert!(is_synthetic_user_text(
+            "Caveat: The messages below were generated while running local commands"
+        ));
+        assert!(is_synthetic_user_text("<local-command-caveat>Caveat: …"));
+        assert!(is_synthetic_user_text("<command-name>/foo</command-name>"));
+        assert!(is_synthetic_user_text("  <local-command-stdout>out"));
+        assert!(!is_synthetic_user_text("Refactor the parser to stream"));
+    }
+
+    #[test]
+    fn title_skips_local_command_scaffolding() {
+        // The first user message is Claude Code's injected caveat; the title must be the next,
+        // real prompt — not "<local-command-caveat>Caveat: …".
+        let root = tempfile::tempdir().unwrap();
+        let caveat = r#"{"type":"user","message":{"content":"<local-command-caveat>Caveat: generated while running local commands"}}"#;
+        let real = r#"{"type":"user","message":{"content":"Refactor the parser to stream"}}"#;
+        let path = write_transcript(root.path(), "caveat.jsonl", &[caveat, real]);
+        assert_eq!(
+            parse_transcript(&path).unwrap().title.as_deref(),
+            Some("Refactor the parser to stream")
         );
     }
 

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -84,6 +84,9 @@ pub struct Config {
     /// running `/usage` in a hidden throwaway `claude` session per account every few minutes —
     /// which spawns a background process and writes a tiny transcript. See `docs/agents.md`.
     pub usage_probe: bool,
+    /// In the sidebars, expand a lane running several agents into one row per agent (a tree under
+    /// the lane) instead of a single row with an `×N` badge. Off by default.
+    pub expand_agents: bool,
 }
 
 impl Default for Config {
@@ -112,6 +115,7 @@ impl Default for Config {
             remote: RemoteConfig::default(),
             push: PushConfig::default(),
             usage_probe: false,
+            expand_agents: false,
         }
     }
 }

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -72,6 +72,11 @@ pub struct Config {
     /// Make desktop popups click-to-focus the terminal (uses `terminal-notifier` when
     /// installed; falls back to plain popups otherwise).
     pub notify_click_focus: bool,
+    /// Notify when a worktree-isolated *subagent* finishes (an inferred file-activity session,
+    /// e.g. a Claude Code subagent that leaves no transcript or process of its own). Off by
+    /// default: you're alerted only when the *main* agent finishes, not each subagent it spawns.
+    /// Turn on to get a popup for every subagent too.
+    pub notify_subagents: bool,
     /// Per-repo overrides, keyed by repo display name.
     pub repos: HashMap<String, RepoConfig>,
     /// Remote access: the WebSocket JSON-RPC bridge that companion apps (iOS) connect
@@ -111,6 +116,7 @@ impl Default for Config {
             notify_show_why: true,
             notify_coalesce: true,
             notify_click_focus: true,
+            notify_subagents: false,
             repos: HashMap::new(),
             remote: RemoteConfig::default(),
             push: PushConfig::default(),

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -269,6 +269,12 @@ pub struct AgentSession {
     /// client attribute account-level usage (the `/usage` probe) to the focused agent. Not persisted.
     #[serde(default)]
     pub config_dir: Option<PathBuf>,
+    /// A user-set short label for this session, overlaid at list time from the persisted
+    /// `session_labels` store (keyed by `session_id`). When set, clients show it instead of the
+    /// auto-derived summary. `None` when unset or when the session has no durable id. Not persisted
+    /// on the session row itself.
+    #[serde(default)]
+    pub custom_label: Option<String>,
 }
 
 /// The materialized `(repo, worktree, agent?)` join — the UI's primary unit.

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use chrono::Local;
+use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::model::{AgentSession, AgentStatus, Lane, LaneId};
@@ -36,6 +36,16 @@ impl NotifKind {
             NotifKind::RateLimited => "⏳",
             NotifKind::Resumed => "▶",
             NotifKind::Idle => "○",
+        }
+    }
+    /// The stable snake_case token for this kind (matches the serde wire name). Used to build a
+    /// notification's dedup id so a flapped re-send carries the same id and clients can drop it.
+    pub fn slug(self) -> &'static str {
+        match self {
+            NotifKind::NeedsYou => "needs_you",
+            NotifKind::RateLimited => "rate_limited",
+            NotifKind::Resumed => "resumed",
+            NotifKind::Idle => "idle",
         }
     }
     fn verb(self) -> &'static str {
@@ -196,6 +206,35 @@ pub fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> O
         // Was active, now quiet (idle / ended / the session went away).
         (Some(Running) | Some(Waiting), Some(Idle) | Some(Ended) | None) => Some(NotifKind::Idle),
         _ => None,
+    }
+}
+
+/// Whether an alert for a session may fire again, anchored on the session's transcript activity
+/// rather than on elapsed time.
+///
+/// The status signal a notification is derived from flaps: a frozen-but-waiting transcript decays
+/// `Waiting → Idle` at the 10-minute mark and flips back on the next byte; the `lsof` live-process
+/// probe undercounts and drops then re-includes a session; the pane sniff (and usage-limit sniff)
+/// are screen-scrapes that read `Some → None → Some`. Every such round-trip re-detects a transition
+/// and, since the only other guard is a 30s time-debounce, re-fires the *same* alert minutes or
+/// hours later. [`AgentSession::last_activity_at`](crate::model::AgentSession::last_activity_at) —
+/// the transcript mtime — advances **only on real agent output**, never on any of those flaps, so
+/// it is the right thing to gate a repeat on: re-fire only when the agent has actually done new
+/// work since it last alerted (the user replied and it ran, then waited again), not when detection
+/// merely wobbled. Caller keeps a per-`(lane, session, kind)` record of the activity timestamp at
+/// the last fire and passes it as `prev_fired_at`.
+///
+/// Used for `NeedsYou` / `RateLimited` / `Resumed`, whose session is present in the snapshot when
+/// they fire (so `current_activity` is `Some`). `Idle` fires on disappearance — no activity anchor
+/// — and stays on the time-debounce.
+pub fn activity_allows_refire(
+    prev_fired_at: Option<DateTime<Utc>>,
+    current_activity: Option<DateTime<Utc>>,
+) -> bool {
+    match (prev_fired_at, current_activity) {
+        (None, _) => true,           // never fired this (lane, session, kind) — let it through
+        (Some(_), None) => false,    // fired before and no fresh anchor to justify a repeat
+        (Some(p), Some(c)) => c > p, // only when the transcript advanced since the last fire
     }
 }
 
@@ -693,6 +732,28 @@ mod tests {
     }
 
     #[test]
+    fn activity_latch_gates_repeats_on_real_work() {
+        let t0 = Utc::now();
+        let t1 = t0 + chrono::Duration::minutes(5);
+
+        // First time this (lane, session, kind) is seen: always fires.
+        assert!(activity_allows_refire(None, Some(t0)));
+
+        // Already fired and the transcript hasn't advanced — the flap cases the latch exists to
+        // kill: an idle-decayed Waiting returning to Waiting, an lsof undercount dropping then
+        // re-adding the session, a sniff reading Some→None→Some. All share the same last_activity.
+        assert!(!activity_allows_refire(Some(t0), Some(t0)));
+
+        // Fired before, but the session vanished (no current anchor): suppress the repeat rather
+        // than re-firing off a presence flap.
+        assert!(!activity_allows_refire(Some(t0), None));
+
+        // Genuine new work since the last alert (user replied, the agent ran and waited again):
+        // the transcript advanced, so re-fire.
+        assert!(activity_allows_refire(Some(t0), Some(t1)));
+    }
+
+    #[test]
     fn compose_shows_the_why_and_the_slot() {
         let mut s = sess(Some("abc"), AgentStatus::Waiting, false);
         s.title = Some("build the parser".into());
@@ -779,6 +840,15 @@ mod tests {
             serde_json::to_string(&NotifKind::RateLimited).unwrap(),
             "\"rate_limited\""
         );
+        // slug() must stay in lock-step with the serde wire name (it keys the dedup id).
+        for k in [
+            NotifKind::NeedsYou,
+            NotifKind::RateLimited,
+            NotifKind::Resumed,
+            NotifKind::Idle,
+        ] {
+            assert_eq!(serde_json::to_string(&k).unwrap(), format!("\"{}\"", k.slug()));
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -426,6 +426,7 @@ mod tests {
             last_message: None,
             pending_prompt: None,
             config_dir: None,
+            custom_label: None,
         }
     }
 

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -70,15 +70,21 @@ pub enum SessKey {
     Fallback,
 }
 
-/// Key/status pairs for one lane's *real* agent sessions. Inferred "file activity" placeholders
-/// are dropped so they never drive named alerts. On a (theoretically impossible) duplicate key,
-/// the higher-priority status wins — the same order the old per-lane rollup used.
+/// Key/status pairs for one lane's *real* agent sessions, used to drive notifications.
+///
+/// `inferred` "file-activity" sessions are worktree-isolated subagents (a Claude Code subagent
+/// runs inside its parent's process and leaves no transcript or process of its own). They are
+/// dropped unless `include_subagents` is set — the `notify_subagents` toggle, off by default, so
+/// the user is alerted only when the *main* agent finishes, not each subagent it spawns. On a
+/// (theoretically impossible) duplicate key, the higher-priority status wins — the same order the
+/// old per-lane rollup used.
 pub fn session_statuses(
     lane_id: LaneId,
     sessions: &[AgentSession],
+    include_subagents: bool,
 ) -> Vec<((LaneId, SessKey), AgentStatus)> {
     let mut out: Vec<((LaneId, SessKey), AgentStatus)> = Vec::new();
-    for s in sessions.iter().filter(|s| !s.inferred) {
+    for s in sessions.iter().filter(|s| include_subagents || !s.inferred) {
         let key = (
             lane_id,
             s.session_id
@@ -143,11 +149,16 @@ pub fn diff_session_transitions(
 }
 
 /// Resolve a session key back to the lane's session, for composing the notification text.
-/// `None` when the session vanished (i.e. its disappearance was the trigger).
-pub fn session_by_key<'a>(lane: &'a Lane, key: &SessKey) -> Option<&'a AgentSession> {
+/// `None` when the session vanished (i.e. its disappearance was the trigger). `include_subagents`
+/// must match the value passed to [`session_statuses`] so an inferred-subagent key resolves.
+pub fn session_by_key<'a>(
+    lane: &'a Lane,
+    key: &SessKey,
+    include_subagents: bool,
+) -> Option<&'a AgentSession> {
     lane.agent_sessions
         .iter()
-        .filter(|s| !s.inferred)
+        .filter(|s| include_subagents || !s.inferred)
         .find(|s| match key {
             SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
             SessKey::Fallback => s.session_id.is_none(),
@@ -155,9 +166,14 @@ pub fn session_by_key<'a>(lane: &'a Lane, key: &SessKey) -> Option<&'a AgentSess
 }
 
 /// Which of the lane's real sessions `key` resolves to: `(index, count)`, for the
-/// "agent 2/3" tag in multi-agent lanes. `None` when the session vanished.
-pub fn slot_by_key(lane: &Lane, key: &SessKey) -> Option<(usize, usize)> {
-    let real: Vec<&AgentSession> = lane.agent_sessions.iter().filter(|s| !s.inferred).collect();
+/// "agent 2/3" tag in multi-agent lanes. `None` when the session vanished. `include_subagents`
+/// must match the value passed to [`session_statuses`].
+pub fn slot_by_key(lane: &Lane, key: &SessKey, include_subagents: bool) -> Option<(usize, usize)> {
+    let real: Vec<&AgentSession> = lane
+        .agent_sessions
+        .iter()
+        .filter(|s| include_subagents || !s.inferred)
+        .collect();
     let i = real.iter().position(|s| match key {
         SessKey::Transcript(id) => s.session_id.as_deref() == Some(id.as_str()),
         SessKey::Fallback => s.session_id.is_none(),
@@ -516,7 +532,7 @@ mod tests {
             sess(None, Running, true), // inferred file-activity placeholder — excluded
             sess(None, Running, false),
         ];
-        let got = session_statuses(7, &sessions);
+        let got = session_statuses(7, &sessions, false);
         assert_eq!(got.len(), 3);
         assert!(got.contains(&((7, SessKey::Transcript("a".into())), Waiting)));
         assert!(got.contains(&((7, SessKey::Transcript("b".into())), RateLimited)));
@@ -525,9 +541,34 @@ mod tests {
         // Defensive: a duplicate key keeps the higher-priority status.
         let dup = vec![sess(None, Idle, false), sess(None, Waiting, false)];
         assert_eq!(
-            session_statuses(7, &dup),
+            session_statuses(7, &dup, false),
             vec![((7, SessKey::Fallback), Waiting)]
         );
+    }
+
+    #[test]
+    fn subagents_excluded_by_default_included_when_opted_in() {
+        use AgentStatus::*;
+        // A lane with only an inferred worktree-isolated subagent (no transcript/process), the
+        // shape `overlay_agents` produces for a Claude Code subagent.
+        let sessions = vec![sess(None, Running, true)];
+
+        // Default: subagents never drive notifications — the inferred session is dropped, so it
+        // can't fire an Idle when it finishes.
+        assert!(session_statuses(7, &sessions, false).is_empty());
+
+        // Opted in (`notify_subagents = true`): the subagent surfaces as a Fallback session so
+        // its finish (→ disappearance) can alert.
+        assert_eq!(
+            session_statuses(7, &sessions, true),
+            vec![((7, SessKey::Fallback), Running)]
+        );
+
+        // A main (transcript-backed) agent alongside a subagent: the main always counts; the
+        // subagent only when opted in.
+        let mixed = vec![sess(Some("main"), Waiting, false), sess(None, Running, true)];
+        assert_eq!(session_statuses(7, &mixed, false).len(), 1);
+        assert_eq!(session_statuses(7, &mixed, true).len(), 2);
     }
 
     #[test]
@@ -613,6 +654,45 @@ mod tests {
     }
 
     #[test]
+    fn subagent_finishing_fires_idle_only_when_included() {
+        use AgentStatus::*;
+        let live: HashSet<LaneId> = [7].into();
+        let managed = HashSet::new();
+
+        // A lane whose only agent is an inferred worktree-isolated subagent, running then gone.
+        let running = vec![sess(None, Running, true)];
+        let gone: Vec<AgentSession> = vec![];
+
+        // Default (subagents excluded): the subagent never enters the tracked set, so its finish
+        // is invisible — no Idle.
+        let prev: HashMap<_, _> = session_statuses(7, &running, false).into_iter().collect();
+        let now: HashMap<_, _> = session_statuses(7, &gone, false).into_iter().collect();
+        assert!(prev.is_empty());
+        assert!(diff_session_transitions(&prev, &now, &live, &managed).is_empty());
+
+        // Opted in: the subagent is tracked, so its disappearance fires Idle (it was active).
+        let prev: HashMap<_, _> = session_statuses(7, &running, true).into_iter().collect();
+        let now: HashMap<_, _> = session_statuses(7, &gone, true).into_iter().collect();
+        assert_eq!(
+            diff_session_transitions(&prev, &now, &live, &managed),
+            vec![((7, SessKey::Fallback), NotifKind::Idle)]
+        );
+    }
+
+    #[test]
+    fn reseed_snapshot_fires_nothing() {
+        use AgentStatus::*;
+        // Re-seeding (what the TUI does on attach-return / toggle flip, and the daemon on
+        // re-enable) sets prev = now; diffing an unchanged snapshot must produce no alerts, which
+        // is what stops the daemon-covered backlog from double-firing.
+        let live: HashSet<LaneId> = [1].into();
+        let managed = HashSet::new();
+        let k = |id: &str| (1, SessKey::Transcript(id.into()));
+        let snap: HashMap<_, _> = [(k("a"), Waiting), (k("b"), RateLimited)].into();
+        assert!(diff_session_transitions(&snap, &snap, &live, &managed).is_empty());
+    }
+
+    #[test]
     fn compose_shows_the_why_and_the_slot() {
         let mut s = sess(Some("abc"), AgentStatus::Waiting, false);
         s.title = Some("build the parser".into());
@@ -650,10 +730,15 @@ mod tests {
             sess(Some("b"), AgentStatus::Waiting, false),
         ];
         assert_eq!(
-            slot_by_key(&l, &SessKey::Transcript("b".into())),
+            slot_by_key(&l, &SessKey::Transcript("b".into()), false),
             Some((1, 2))
         );
-        assert_eq!(slot_by_key(&l, &SessKey::Transcript("zz".into())), None);
+        assert_eq!(slot_by_key(&l, &SessKey::Transcript("zz".into()), false), None);
+        // With subagents included, the inferred session occupies a slot too (now 3 real).
+        assert_eq!(
+            slot_by_key(&l, &SessKey::Transcript("b".into()), true),
+            Some((2, 3))
+        );
     }
 
     #[test]

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -203,8 +203,14 @@ pub fn transition_kind(prev: Option<AgentStatus>, now: Option<AgentStatus>) -> O
         (Some(RateLimited), Some(Running)) => Some(NotifKind::Resumed),
         // Finished its turn / needs you.
         (p, Some(Waiting)) if p != Some(Waiting) => Some(NotifKind::NeedsYou),
-        // Was active, now quiet (idle / ended / the session went away).
-        (Some(Running) | Some(Waiting), Some(Idle) | Some(Ended) | None) => Some(NotifKind::Idle),
+        // The session actually ended — its tmux window/process is gone (`None`) or the transcript
+        // closed (`Ended`). Fires regardless of the status it last held (it may have decayed to
+        // Idle first), so a real stop is reported promptly. A still-present session merely *decaying*
+        // to `Idle` after IDLE_AFTER is intentionally NOT alerted: that popup is ~10 minutes stale by
+        // construction (the decay is a 10-min-old event), which produced bursts of stale "went idle"
+        // alerts. The status still decays for the UI; only the notification is suppressed.
+        (Some(_), None) => Some(NotifKind::Idle),
+        (Some(p), Some(Ended)) if p != Ended => Some(NotifKind::Idle),
         _ => None,
     }
 }
@@ -549,12 +555,15 @@ mod tests {
             transition_kind(Some(RateLimited), Some(Waiting)),
             Some(NotifKind::NeedsYou)
         );
-        // Went quiet (idle / ended / the agent went away).
-        assert_eq!(
-            transition_kind(Some(Running), Some(Idle)),
-            Some(NotifKind::Idle)
-        );
+        // Ended: the session went away (window/process gone) — a real stop, alerted promptly,
+        // whatever it was doing just before (including after it had decayed to Idle).
         assert_eq!(transition_kind(Some(Waiting), None), Some(NotifKind::Idle));
+        assert_eq!(transition_kind(Some(Running), None), Some(NotifKind::Idle));
+        assert_eq!(transition_kind(Some(Idle), None), Some(NotifKind::Idle));
+        // The bare 10-minute inactivity decay (still present, just `Idle` now) is NOT an alert —
+        // it would be ~10 min stale. This is the fix for the bursts of old "went idle" popups.
+        assert_eq!(transition_kind(Some(Running), Some(Idle)), None);
+        assert_eq!(transition_kind(Some(Waiting), Some(Idle)), None);
         // Non-events: you replied, work simply started, or nothing changed.
         assert_eq!(transition_kind(Some(Waiting), Some(Running)), None);
         assert_eq!(transition_kind(None, Some(Running)), None);

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -21,6 +21,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0001_init.sql"),
     include_str!("../../migrations/0002_agent_kind.sql"),
     include_str!("../../migrations/0003_devices.sql"),
+    include_str!("../../migrations/0004_session_labels.sql"),
 ];
 
 type Job = Box<dyn FnOnce(&mut Connection) + Send + 'static>;
@@ -363,6 +364,45 @@ impl Store {
         .await
     }
 
+    // ---- session labels ------------------------------------------------------
+
+    /// Set (or clear, when `label` is `None`) a user-defined label for a session, keyed by its
+    /// durable transcript `session_id`. Survives daemon restarts; overlaid onto `AgentSession`.
+    pub async fn set_session_label(&self, session_id: String, label: Option<String>) -> Result<()> {
+        self.call(move |c| {
+            match label {
+                Some(l) => c.execute(
+                    "INSERT INTO session_labels(session_id, label, updated_at) VALUES(?1, ?2, ?3)
+                     ON CONFLICT(session_id) DO UPDATE SET label = ?2, updated_at = ?3",
+                    params![session_id, l, to_iso(&Utc::now())],
+                )?,
+                None => c.execute(
+                    "DELETE FROM session_labels WHERE session_id = ?1",
+                    params![session_id],
+                )?,
+            };
+            Ok(())
+        })
+        .await
+    }
+
+    /// All session labels, as `session_id -> label`.
+    pub async fn list_session_labels(&self) -> Result<std::collections::HashMap<String, String>> {
+        self.call(|c| {
+            let mut stmt = c.prepare("SELECT session_id, label FROM session_labels")?;
+            let rows = stmt.query_map([], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })?;
+            let mut out = std::collections::HashMap::new();
+            for row in rows {
+                let (k, v) = row?;
+                out.insert(k, v);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
     // ---- commits -------------------------------------------------------------
 
     /// Insert commits, ignoring ones already present. Returns the number newly added.
@@ -647,6 +687,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         last_message: None,
         pending_prompt: None,
         config_dir: None,
+        custom_label: None,
     })
 }
 
@@ -875,6 +916,7 @@ mod tests {
             last_message: None,
             pending_prompt: None,
             config_dir: None,
+            custom_label: None,
         };
         let id = s.upsert_session(sess.clone()).await.unwrap();
         // Upsert again (same manifest) updates rather than duplicates.

--- a/crates/repomon-daemon/src/auto_continue.rs
+++ b/crates/repomon-daemon/src/auto_continue.rs
@@ -27,6 +27,13 @@ const UNKNOWN_RETRY_MIN: i64 = 20; // coarse retry when no reset time is known (
 const GIVE_UP_AFTER_HOURS: i64 = 6; // stop this long after first detecting the pause (>5h window)
 const SEND_COOLDOWN_SECS: i64 = 90; // suppress re-detect of the stale on-screen message
 const RESET_BUFFER_SECS: i64 = 60; // resume a little after the stated reset, never before
+// Consecutive ticks with no limit message before we believe the pause is really gone. The
+// detection is a pane screen-scrape (`detect_usage_limit`) that misfires for a tick when the
+// menu redraws or scrolls; clearing on a single miss flips the public status RateLimited→running
+// and back, re-firing the rate-limit / resumed notifications repeatedly across the multi-hour
+// pause. Requiring two consecutive misses (~40s at the 20s TICK) rides out a single flaky capture;
+// a genuine resume keeps the menu gone, so the real Clear lags by only one tick.
+const CLEAR_AFTER_MISSES: u8 = 2;
 
 /// The public view of a lane's rate-limit pause, read by `overlay_agents` for the TUI.
 #[derive(Debug, Clone)]
@@ -47,6 +54,10 @@ struct Sched {
     /// We've already selected "Stop and wait for limit to reset" on Claude's menu for this
     /// pause, so don't select it again (reset only when the lane clears).
     menu_confirmed: bool,
+    /// Consecutive ticks the limit message has been *absent* while still tracking this pause. The
+    /// loop bumps it on a missed detection and resets it on a hit; [`decide`] only clears once it
+    /// reaches [`CLEAR_AFTER_MISSES`], so a single flaky pane capture can't fake a resume.
+    miss_streak: u8,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -128,14 +139,14 @@ fn decide(
                 }
             }
         },
-        // No limit message on screen — if we were tracking one, the agent resumed.
-        None => {
-            if current.is_some() {
-                Action::Clear
-            } else {
-                Action::Nothing
-            }
-        }
+        // No limit message on screen — if we were tracking one, the agent *may* have resumed, but
+        // the detection flaps, so only believe it once the message has been gone for a couple of
+        // consecutive ticks (the loop bumps `miss_streak`). A single miss is treated as noise.
+        None => match current {
+            Some(s) if s.miss_streak >= CLEAR_AFTER_MISSES => Action::Clear,
+            Some(_) => Action::Nothing,
+            None => Action::Nothing,
+        },
     }
 }
 
@@ -186,6 +197,15 @@ pub async fn auto_continue_watcher(ctx: Arc<Ctx>) {
                 };
             let detection = detect_usage_limit(&pane);
             let armed = global_on && !off.contains(&lane);
+            // Track the absent-message streak so a single flaky capture doesn't read as a resume:
+            // bump on a miss, reset on a hit. `decide` clears only once it reaches the threshold.
+            if let Some(s) = sched.get_mut(&lane) {
+                if detection.is_some() {
+                    s.miss_streak = 0;
+                } else {
+                    s.miss_streak = s.miss_streak.saturating_add(1);
+                }
+            }
             let action = decide(sched.get(&lane), detection.as_ref(), armed, now);
             apply(&ctx, &mut sched, lane, action, &message, now).await;
         }
@@ -216,6 +236,7 @@ async fn apply(
                     gave_up: false,
                     cooldown_until: None,
                     menu_confirmed: false,
+                    miss_streak: 0,
                 },
             );
             ctx.rate_limits
@@ -303,6 +324,7 @@ mod tests {
             gave_up,
             cooldown_until: cooldown_in.map(|s| n + chrono::Duration::seconds(s)),
             menu_confirmed: true, // default: menu already handled, so tests reach the Send path
+            miss_streak: 0,
         }
     }
 
@@ -405,8 +427,20 @@ mod tests {
     }
 
     #[test]
-    fn clears_when_message_gone() {
-        let s = sched(-1, false, None);
+    fn single_missed_detection_does_not_clear() {
+        // One tick with the limit message absent (miss_streak just bumped to 1) is treated as a
+        // flaky capture, not a resume — clearing here is what re-fired RateLimited/Resumed in a
+        // loop across the pause.
+        let mut s = sched(-1, false, None);
+        s.miss_streak = 1;
+        assert_eq!(decide(Some(&s), None, true, now()), Action::Nothing);
+    }
+
+    #[test]
+    fn clears_after_consecutive_missed_detections() {
+        // The message has been gone for CLEAR_AFTER_MISSES consecutive ticks: believe the resume.
+        let mut s = sched(-1, false, None);
+        s.miss_streak = CLEAR_AFTER_MISSES;
         assert_eq!(decide(Some(&s), None, true, now()), Action::Clear);
     }
 

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -48,6 +48,11 @@ pub struct Ctx {
     /// Cache of how many live `claude` processes have each working dir (ps/lsof, ~2s TTL), so
     /// `/exit`ed sessions whose transcripts linger aren't counted as running.
     pub live_cwds: Mutex<Option<(Instant, HashMap<PathBuf, usize>)>>,
+    /// Per-worktree "highest count seen recently" used to make [`live_cwds`] sticky-high: a single
+    /// `pgrep`/`lsof` undercount can otherwise drop a session from the overlay (then re-add it next
+    /// probe), churning the lane list and — before the notification activity-latch — re-firing
+    /// alerts. We hold the higher count for a short grace so one bad sample can't hide a session.
+    pub cwds_sticky: Mutex<HashMap<PathBuf, (usize, Instant)>>,
     /// The composite `lane.list` overlay (lanes + live agent sessions), cached for a short TTL so
     /// many clients polling every ~1s don't each re-run the tmux/lsof/transcript scan. Invalidated
     /// on structural changes (spawn/adopt/stop/lane create/delete) so user actions show at once.
@@ -120,6 +125,7 @@ impl Ctx {
             viewport: Mutex::new(Vec::new()),
             viewport_focus: Mutex::new(None),
             live_cwds: Mutex::new(None),
+            cwds_sticky: Mutex::new(HashMap::new()),
             overlay_cache: Mutex::new(None),
             prompt_cache: Mutex::new(HashMap::new()),
             rate_limits: Mutex::new(HashMap::new()),

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -12,10 +12,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use repomon_core::model::{AgentStatus, LaneId};
 use repomon_core::notify::{
-    compose, diff_session_transitions, session_by_key, session_statuses, slot_by_key, NotifKind,
-    SessKey,
+    activity_allows_refire, compose, diff_session_transitions, session_by_key, session_statuses,
+    slot_by_key, NotifKind, SessKey,
 };
 use repomon_core::Config;
 use serde_json::json;
@@ -31,6 +32,11 @@ use crate::{push, rpc, Ctx};
 const TICK: Duration = Duration::from_secs(2);
 /// Don't re-fire the same session's notification within this window (status flapping).
 const DEBOUNCE: Duration = Duration::from_secs(30);
+/// How long to keep an alert's activity latch after its session leaves the snapshot, so a
+/// vanish+reappear (an `lsof` undercount, the 6h recency gate, `claude --resume` churn) can't slip
+/// a repeat through the gap. Covers the longest flap window — a multi-hour usage-limit pause —
+/// comfortably; a transcript gone longer than this can't re-enter under the same id anyway.
+const LATCH_GRACE: Duration = Duration::from_secs(6 * 60 * 60);
 /// How long since the local TUI's last request before we treat it as parked (attached) or closed
 /// and let the daemon fire desktop popups itself. The TUI refreshes ~1s, so a few seconds of
 /// silence means it isn't watching.
@@ -43,6 +49,11 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
     let mut prev: HashMap<(LaneId, SessKey), AgentStatus> = HashMap::new();
     let mut seeded = false;
     let mut debounce: HashMap<(LaneId, SessKey, NotifKind), Instant> = HashMap::new();
+    // Activity-anchored re-fire latch: the session's `last_activity_at` (transcript mtime) at the
+    // moment each (lane, session, kind) last fired. A repeat is allowed only once that advances —
+    // i.e. the agent did real work since — so status flapping can't re-alert (see
+    // `activity_allows_refire`). Applies to NeedsYou/RateLimited/Resumed; Idle stays on `debounce`.
+    let mut latch: HashMap<(LaneId, SessKey, NotifKind), (DateTime<Utc>, Instant)> = HashMap::new();
     // The subagent-inclusion setting the current `prev` snapshot was built with. When it flips,
     // the set of tracked keys changes wholesale (inferred sessions appear/vanish), so we re-seed
     // rather than diff — otherwise toggling it off would fire a spurious Idle for every subagent.
@@ -56,6 +67,7 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
             prev.clear();
             seeded = false;
             debounce.clear();
+            latch.clear();
             continue;
         }
         // The TUI fires its own desktop popups while it's actively watching; the daemon takes over
@@ -97,13 +109,37 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
             if debounce.get(&dkey).is_some_and(|t| t.elapsed() < DEBOUNCE) {
                 continue;
             }
-            debounce.insert(dkey, Instant::now());
+            // Activity latch: suppress a repeat of this alert unless the session's transcript has
+            // advanced since it last fired. Defeats the status flapping (idle-decay, lsof
+            // undercount, sniff wobble) that the time-debounce can't. Idle has no activity anchor
+            // (it fires on disappearance), so it stays on the debounce alone.
+            let activity = lanes
+                .iter()
+                .find(|l| l.id == key.0)
+                .and_then(|l| session_by_key(l, &key.1, subagents))
+                .map(|s| s.last_activity_at);
+            if kind != NotifKind::Idle
+                && !activity_allows_refire(latch.get(&dkey).map(|(t, _)| *t), activity)
+            {
+                continue;
+            }
+            debounce.insert(dkey.clone(), Instant::now());
+            if kind != NotifKind::Idle {
+                if let Some(a) = activity {
+                    latch.insert(dkey, (a, Instant::now()));
+                }
+            }
             fires.push((key, kind));
         }
         prev = now;
         let snapshot = &prev;
         debounce.retain(|(lane, sess, _), t| {
             snapshot.contains_key(&(*lane, sess.clone())) || t.elapsed() < DEBOUNCE
+        });
+        // Keep latch entries through a vanish+reappear (that's the repeat we're stopping); only
+        // drop one once its session has been gone longer than it could plausibly return.
+        latch.retain(|(lane, sess, _), (_, seen)| {
+            snapshot.contains_key(&(*lane, sess.clone())) || seen.elapsed() < LATCH_GRACE
         });
 
         for ((lane_id, key), kind) in fires {
@@ -124,9 +160,20 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
             let prompt = dialog
                 .clone()
                 .or_else(|| sess.and_then(|s| s.last_message.clone()));
+            // Stable dedup id: a genuine re-alert advances the session's activity and so gets a new
+            // id, but a flapped re-send (same lane/session/kind, same activity) repeats the id — so
+            // a client that briefly reconnects or APNs that double-delivers can drop the duplicate.
+            let session_id = sess.and_then(|s| s.session_id.clone());
+            let activity_epoch = sess.map(|s| s.last_activity_at.timestamp()).unwrap_or(0);
+            let dedup_id = format!(
+                "{lane_id}:{}:{}:{activity_epoch}",
+                session_id.as_deref().unwrap_or("-"),
+                kind.slug(),
+            );
             let payload = json!({
+                "id": dedup_id,
                 "lane_id": lane_id,
-                "session_id": sess.and_then(|s| s.session_id.clone()),
+                "session_id": session_id,
                 "kind": kind,
                 "title": title,
                 "body": body,

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -23,9 +23,12 @@ use serde_json::json;
 use crate::{push, rpc, Ctx};
 
 /// How often the watcher re-reads the fleet for remote/push notifications. Each tick recomputes
-/// the overlay (transcript parses, pane sniffs, process probes), so this trades notification
-/// latency for idle CPU — a phone alert a few seconds later is fine, a daemon pegging a core isn't.
-const TICK: Duration = Duration::from_secs(8);
+/// the overlay, but the overlay's own caches absorb most of the cost: the composite snapshot is
+/// reused for `OVERLAY_TTL` (~750ms), the `lsof`/`pgrep` process probe for ~10s, and each pane
+/// sniff for ~20s. So a tick that only re-reads warm caches is cheap, and a 2s cadence cuts the
+/// old 8s worst-case alert latency to ~2s (the daemon owns *all* remote delivery and the local
+/// desktop popup whenever the TUI is parked/closed) without pegging a core.
+const TICK: Duration = Duration::from_secs(2);
 /// Don't re-fire the same session's notification within this window (status flapping).
 const DEBOUNCE: Duration = Duration::from_secs(30);
 /// How long since the local TUI's last request before we treat it as parked (attached) or closed
@@ -40,6 +43,10 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
     let mut prev: HashMap<(LaneId, SessKey), AgentStatus> = HashMap::new();
     let mut seeded = false;
     let mut debounce: HashMap<(LaneId, SessKey, NotifKind), Instant> = HashMap::new();
+    // The subagent-inclusion setting the current `prev` snapshot was built with. When it flips,
+    // the set of tracked keys changes wholesale (inferred sessions appear/vanish), so we re-seed
+    // rather than diff — otherwise toggling it off would fire a spurious Idle for every subagent.
+    let mut prev_subagents = false;
 
     loop {
         tick.tick().await;
@@ -62,13 +69,15 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
         let Ok(lanes) = rpc::lanes_with_agents_fresh(&ctx).await else {
             continue;
         };
+        let subagents = cfg.notify_subagents;
         let now: HashMap<(LaneId, SessKey), AgentStatus> = lanes
             .iter()
-            .flat_map(|l| session_statuses(l.id, &l.agent_sessions))
+            .flat_map(|l| session_statuses(l.id, &l.agent_sessions, subagents))
             .collect();
-        if !seeded {
+        if !seeded || subagents != prev_subagents {
             prev = now;
             seeded = true;
+            prev_subagents = subagents;
             continue;
         }
 
@@ -101,12 +110,12 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
             let Some(lane) = lanes.iter().find(|l| l.id == lane_id) else {
                 continue;
             };
-            let sess = session_by_key(lane, &key);
+            let sess = session_by_key(lane, &key, subagents);
             let (title, body) = compose(
                 kind,
                 lane,
                 sess,
-                slot_by_key(lane, &key),
+                slot_by_key(lane, &key, subagents),
                 cfg.notify_show_why,
             );
             // The actual on-screen dialog, when there is one — what a push's Approve acts on.

--- a/crates/repomon-daemon/src/push.rs
+++ b/crates/repomon-daemon/src/push.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 
 use a2::{
-    Client, ClientConfig, DefaultNotificationBuilder, Endpoint, ErrorReason, NotificationBuilder,
-    NotificationOptions, Priority,
+    Client, ClientConfig, CollapseId, DefaultNotificationBuilder, Endpoint, ErrorReason,
+    NotificationBuilder, NotificationOptions, Priority,
 };
 use repomon_core::config::PushConfig;
 use serde_json::Value;
@@ -77,9 +77,27 @@ impl Push {
             .set_body(body)
             .set_sound("default")
             .set_category(category);
+        // Collapse duplicates of the same alert on the lock screen: the daemon stamps each payload
+        // with a stable `id` (lane:session:kind:activity) that only changes on real new activity,
+        // so a flapped re-send replaces rather than stacks. APNs caps the value at 64 bytes; our
+        // ids are ASCII, so a byte slice is a safe truncation.
+        let collapse = data
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(|s| {
+                // Cap at 64 bytes (APNs limit), backing up to a char boundary so a future
+                // multibyte id can't panic the slice (today's ids are ASCII).
+                let mut end = s.len().min(64);
+                while end > 0 && !s.is_char_boundary(end) {
+                    end -= 1;
+                }
+                &s[..end]
+            })
+            .and_then(|s| CollapseId::new(s).ok());
         let options = NotificationOptions {
             apns_topic: Some(&self.topic),
             apns_priority: Some(Priority::High),
+            apns_collapse_id: collapse,
             ..Default::default()
         };
         let mut payload = builder.build(device_token, options);

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -326,6 +326,13 @@ struct Browse {
 /// Dispatch a single request to its handler.
 pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<Value, RpcError> {
     match method {
+        // ---- system ----
+        // The local TUI calls this just before parking in a full-screen tmux attach (where it
+        // stops sending its lane.list heartbeat). `socket` special-cases the method to age out
+        // `local_watcher_seen` so the daemon takes over desktop popups on its very next tick
+        // instead of waiting out LOCAL_TTL — closing the handoff gap. The dispatch is a no-op ack.
+        "watcher.park" => to_value(()),
+
         // ---- repos ----
         "repo.list" => to_value(ctx.registry.list().await.map_err(internal)?),
         "repo.add" => {
@@ -1165,6 +1172,10 @@ const MAX_SESSIONS_PER_LANE: usize = 8;
 /// agent in it — the fallback that surfaces Claude Code worktree-isolated subagents, which leave
 /// no transcript or process of their own. Short, so the indicator tracks actual work.
 const ACTIVITY_WINDOW_SECS: i64 = 90;
+/// Extra grace before an inferred (file-activity) session is dropped, so a brief lull between a
+/// subagent's edits doesn't read as a finish and flap the session present→absent→present (which,
+/// with subagent notifications on, would fire an Idle on each lull).
+const INFERRED_GRACE_SECS: i64 = 30;
 
 /// TTL for the cached lane overlay. Short enough that a freshly-spawned agent's window placeholder
 /// (and exited-agent / rate-limit transitions) still surface within a refresh or two; long enough
@@ -1239,6 +1250,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         let mut prev = ctx.last_managed_windows.lock().await;
         if prev.difference(&managed_now).next().is_some() {
             *ctx.live_cwds.lock().await = None;
+            // Also drop the sticky-high counts so a `/exit`ed managed agent disappears within one
+            // refresh instead of being held for the grace (tmux closes the window as its process
+            // dies, so this is the genuine-exit signal — see `live_cwds_cached`).
+            ctx.cwds_sticky.lock().await.clear();
         }
         *prev = managed_now;
     }
@@ -1316,7 +1331,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             // runs inside its parent's process and leaves no transcript or process here). The main
             // checkout is excluded so hand-edits there don't masquerade as an agent.
             let active = !lane.worktree.is_main
-                && (chrono::Utc::now() - changed).num_seconds() < ACTIVITY_WINDOW_SECS;
+                && (chrono::Utc::now() - changed).num_seconds()
+                    < ACTIVITY_WINDOW_SECS + INFERRED_GRACE_SECS;
             if active {
                 if changed > lane.last_activity_at {
                     lane.last_activity_at = changed;
@@ -1364,7 +1380,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // choices). Neither is in the JSONL. Sniff the panes of managed Running/Waiting sessions:
     // a detected dialog sets `pending_prompt` (clients gate approve/menu controls on it),
     // becomes the notification-ready "why", and flips Running → Waiting.
-    let candidates: Vec<(usize, usize, String)> = lanes
+    let candidates: Vec<(usize, usize, String, AgentStatus)> = lanes
         .iter()
         .enumerate()
         .flat_map(|(li, lane)| {
@@ -1376,7 +1392,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                         && !s.inferred
                         && matches!(s.status, AgentStatus::Running | AgentStatus::Waiting);
                     sniffable
-                        .then(|| s.tmux_window.clone().map(|w| (li, si, w)))
+                        .then(|| s.tmux_window.clone().map(|w| (li, si, w, s.status)))
                         .flatten()
                 })
         })
@@ -1386,13 +1402,26 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         // subprocess cost. Reuse a recent result per window and only re-capture stale ones, so
         // rapid overlays (notify_watch + client polls) share one sniff per window per TTL.
         const SNIFF_TTL: std::time::Duration = std::time::Duration::from_secs(20);
+        // A Running session is the one that can *newly* raise a dialog (its transcript ends in a
+        // tool call, but the pane may be on a permission/plan/menu prompt that only the sniff
+        // sees), so a NeedsYou can be up to SNIFF_TTL late. Re-capture those on a much shorter TTL
+        // to cut that latency; a session already classified Waiting has its dialog confirmed, so
+        // let its result ride the full TTL. The extra captures are bounded — only while a session
+        // is actively Running — and the notification engine's activity latch absorbs any added
+        // flap from sniffing more often.
+        const RUNNING_SNIFF_TTL: std::time::Duration = std::time::Duration::from_secs(5);
         let mut prompts: Vec<Option<String>> = Vec::with_capacity(candidates.len());
         let mut misses: Vec<usize> = Vec::new();
         {
             let cache = ctx.prompt_cache.lock().await;
-            for (idx, (_, _, w)) in candidates.iter().enumerate() {
+            for (idx, (_, _, w, status)) in candidates.iter().enumerate() {
+                let ttl = if *status == AgentStatus::Running {
+                    RUNNING_SNIFF_TTL
+                } else {
+                    SNIFF_TTL
+                };
                 match cache.get(w) {
-                    Some((t, p)) if t.elapsed() < SNIFF_TTL => prompts.push(p.clone()),
+                    Some((t, p)) if t.elapsed() < ttl => prompts.push(p.clone()),
                     _ => {
                         prompts.push(None);
                         misses.push(idx);
@@ -1421,7 +1450,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 prompts[i] = p;
             }
         }
-        for ((li, si, _), found) in candidates.into_iter().zip(prompts) {
+        for ((li, si, _, _), found) in candidates.into_iter().zip(prompts) {
             if let Some(summary) = found {
                 let s = &mut lanes[li].agent_sessions[si];
                 s.status = AgentStatus::Waiting;
@@ -1650,14 +1679,38 @@ async fn live_cwds_cached(ctx: &Ctx) -> Option<HashMap<PathBuf, usize>> {
             }
         }
     }
-    let fresh = tokio::task::spawn_blocking(live_claude_cwds)
+    let map = tokio::task::spawn_blocking(live_claude_cwds)
         .await
         .ok()
-        .flatten();
-    if let Some(map) = &fresh {
-        *ctx.live_cwds.lock().await = Some((std::time::Instant::now(), map.clone()));
+        .flatten()?;
+    // Sticky-high: a single `pgrep`/`lsof` undercount must not drop a session from the overlay
+    // (then re-add it next probe), which churns the lane list and used to re-fire alerts. Hold each
+    // worktree's highest recently-observed count for a short grace, so one bad sample can't hide a
+    // session; a genuine count drop decays after the grace. Managed exits stay prompt because the
+    // managed-window-vanish path clears this map (and tmux closes the window the moment the process
+    // dies), so this lingering only ever affects external sessions — acceptable, like the cache TTL.
+    const STICKY_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+    let now = std::time::Instant::now();
+    let mut effective = map.clone();
+    {
+        let mut sticky = ctx.cwds_sticky.lock().await;
+        // Refresh a worktree's held high only when this sample meets or exceeds it — an under-read
+        // leaves the high's timestamp untouched so it can age out (real exits eventually decay).
+        for (k, &c) in &map {
+            let refresh = sticky.get(k).map(|(hi, _)| c >= *hi).unwrap_or(true);
+            if refresh {
+                sticky.insert(k.clone(), (c, now));
+            }
+        }
+        sticky.retain(|_, (_, seen)| seen.elapsed() < STICKY_GRACE);
+        // Lift the fresh count to the surviving held high (covers worktrees missing from `map`).
+        for (k, (hi, _)) in sticky.iter() {
+            let e = effective.entry(k.clone()).or_insert(0);
+            *e = (*e).max(*hi);
+        }
     }
-    fresh
+    *ctx.live_cwds.lock().await = Some((now, effective.clone()));
+    Some(effective)
 }
 
 /// Is the command's program on PATH (or an absolute/relative path that exists)?

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -49,6 +49,7 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "notify_coalesce": cfg.notify_coalesce,
         "notify_click_focus": cfg.notify_click_focus,
         "usage_probe": cfg.usage_probe,
+        "expand_agents": cfg.expand_agents,
     })
 }
 
@@ -218,10 +219,20 @@ struct ConfigSet {
     notify_click_focus: Option<bool>,
     #[serde(default)]
     usage_probe: Option<bool>,
+    #[serde(default)]
+    expand_agents: Option<bool>,
 }
 #[derive(Deserialize)]
 struct PushDevice {
     device_token: String,
+}
+#[derive(Deserialize)]
+struct SessionRename {
+    /// The transcript session id to label (durable across restarts).
+    session_id: String,
+    /// The new label; `None`/absent or empty clears it.
+    #[serde(default)]
+    label: Option<String>,
 }
 #[derive(Deserialize)]
 struct AgentTranscript {
@@ -671,6 +682,9 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 if let Some(b) = p.usage_probe {
                     cfg.usage_probe = b;
                 }
+                if let Some(b) = p.expand_agents {
+                    cfg.expand_agents = b;
+                }
                 if let Err(e) = cfg.save_to(&ctx.config_path) {
                     *cfg = prev;
                     return Err(internal(e));
@@ -1117,6 +1131,19 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             to_value(out)
         }
 
+        // Set/clear a user label for a session (keyed by transcript session_id; persisted).
+        "session.rename" => {
+            let p: SessionRename = parse(params)?;
+            let label = p.label.map(|l| l.trim().to_string()).filter(|l| !l.is_empty());
+            ctx.store
+                .set_session_label(p.session_id, label)
+                .await
+                .map_err(internal)?;
+            ctx.invalidate_overlay().await;
+            ctx.broadcast(crate::pubsub::topic::AGENT_STATUS, json!({ "renamed": true }));
+            Ok(Value::Null)
+        }
+
         other => Err(RpcError::method_not_found(other)),
     }
 }
@@ -1187,6 +1214,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     .unwrap_or_default();
 
     let metas = ctx.store.list_lane_meta().await.unwrap_or_default();
+    // User-set session labels (keyed by transcript session_id), overlaid below.
+    let labels = ctx.store.list_session_labels().await.unwrap_or_default();
     let tmux = ctx.tmux.clone();
     let windows = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
         .await
@@ -1248,6 +1277,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     lane.last_activity_at = s.last_activity;
                 }
                 let mut session = s.into_session(lane.repo.id, lane.worktree.id);
+                session.custom_label = session
+                    .session_id
+                    .as_ref()
+                    .and_then(|id| labels.get(id).cloned());
                 if idx < paired {
                     session.external = false;
                     session.tmux_window = Some(lane_windows[paired - 1 - idx].clone());
@@ -1302,6 +1335,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     last_message: None,
                     pending_prompt: None,
                     config_dir: None,
+                    custom_label: None,
                 });
             }
         }
@@ -1551,6 +1585,7 @@ fn window_placeholder_session(lane: &Lane, kind: AgentKind, window: String) -> A
         last_message: None,
         pending_prompt: None,
         config_dir: None,
+        custom_label: None,
     }
 }
 

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -48,6 +48,7 @@ fn config_json(cfg: &repomon_core::config::Config) -> Value {
         "notify_show_why": cfg.notify_show_why,
         "notify_coalesce": cfg.notify_coalesce,
         "notify_click_focus": cfg.notify_click_focus,
+        "notify_subagents": cfg.notify_subagents,
         "usage_probe": cfg.usage_probe,
         "expand_agents": cfg.expand_agents,
     })
@@ -217,6 +218,8 @@ struct ConfigSet {
     notify_coalesce: Option<bool>,
     #[serde(default)]
     notify_click_focus: Option<bool>,
+    #[serde(default)]
+    notify_subagents: Option<bool>,
     #[serde(default)]
     usage_probe: Option<bool>,
     #[serde(default)]
@@ -678,6 +681,9 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 }
                 if let Some(b) = p.notify_click_focus {
                     cfg.notify_click_focus = b;
+                }
+                if let Some(b) = p.notify_subagents {
+                    cfg.notify_subagents = b;
                 }
                 if let Some(b) = p.usage_probe {
                     cfg.usage_probe = b;

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -80,7 +80,13 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
                 // A local request means the TUI is actively watching; its 1s lane.list refresh
                 // keeps this fresh and stops the instant the TUI parks in an attach or closes —
                 // which is how the notification engine knows to take over desktop popups.
-                *ctx.local_watcher_seen.lock().await = Some(std::time::Instant::now());
+                // `watcher.park` is the explicit "I'm parking now" signal: zero the heartbeat so
+                // the daemon takes over on its very next tick instead of waiting out LOCAL_TTL.
+                if req.method == "watcher.park" {
+                    *ctx.local_watcher_seen.lock().await = None;
+                } else {
+                    *ctx.local_watcher_seen.lock().await = Some(std::time::Instant::now());
+                }
                 if req.method == "subscribe" {
                     forwarding = true;
                 }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Position, Rect};
 use ratatui::text::Line;
@@ -17,7 +18,8 @@ use repomon_core::model::{
     RepoId, TimelineData, WorkSession,
 };
 use repomon_core::notify::{
-    diff_session_transitions, session_by_key, session_statuses, slot_by_key, SessKey,
+    activity_allows_refire, diff_session_transitions, session_by_key, session_statuses, slot_by_key,
+    SessKey,
 };
 use repomon_core::protocol::Notification;
 use serde_json::json;
@@ -33,6 +35,9 @@ use crate::view;
 pub const NOTIF_BANNER_TTL: Duration = Duration::from_secs(6);
 /// Don't re-fire the same session's notification within this window (suppresses status flapping).
 const NOTIF_DEBOUNCE: Duration = Duration::from_secs(30);
+/// How long to keep an alert's activity latch after its session leaves the snapshot, so a
+/// vanish+reappear can't slip a repeat through (mirrors the daemon's `LATCH_GRACE`).
+const NOTIF_LATCH_GRACE: Duration = Duration::from_secs(6 * 60 * 60);
 /// Cap on the in-app notification history feed.
 const NOTIF_HISTORY_CAP: usize = 200;
 
@@ -252,6 +257,12 @@ pub struct App {
     /// genuinely different transition (e.g. a usage-limit alert right after a needs-you one);
     /// keying on the session lets two agents in one lane each raise the same kind of alert.
     notif_debounce: HashMap<(LaneId, SessKey, NotifKind), Instant>,
+    /// Activity-anchored re-fire latch: the session's `last_activity_at` (transcript mtime) when
+    /// each (lane, session, kind) last fired. A repeat fires only once that advances — real work
+    /// since the last alert — so the status flapping a 30s debounce can't catch (idle-decay, lsof
+    /// undercount, sniff wobble) doesn't re-alert. Covers NeedsYou/RateLimited/Resumed; Idle keeps
+    /// to `notif_debounce`. The `Instant` is for pruning only.
+    notif_latch: HashMap<(LaneId, SessKey, NotifKind), (DateTime<Utc>, Instant)>,
     /// In-app notification history (newest last), shown in the Notifications view.
     pub notifications: VecDeque<NotifEvent>,
     /// Cursor in the Notifications view: offset into the feed, newest-first (0 = newest).
@@ -405,6 +416,7 @@ impl App {
             notif_reseed: false,
             notif_subagents: false,
             notif_debounce: HashMap::new(),
+            notif_latch: HashMap::new(),
             notifications: VecDeque::new(),
             notif_sel: 0,
             notif_banner: None,
@@ -765,7 +777,26 @@ impl App {
                     continue;
                 }
             }
-            self.notif_debounce.insert(dkey, Instant::now());
+            // Activity latch: don't re-fire an alert for a session that hasn't done real work
+            // since it last fired — gates out the status flapping (idle-decay, lsof undercount,
+            // sniff wobble) the time-debounce can't. Idle has no activity anchor, so it's exempt.
+            let activity = self
+                .lanes
+                .iter()
+                .find(|l| l.id == key.0)
+                .and_then(|l| session_by_key(l, &key.1, subagents))
+                .map(|s| s.last_activity_at);
+            if kind != NotifKind::Idle
+                && !activity_allows_refire(self.notif_latch.get(&dkey).map(|(t, _)| *t), activity)
+            {
+                continue;
+            }
+            self.notif_debounce.insert(dkey.clone(), Instant::now());
+            if kind != NotifKind::Idle {
+                if let Some(a) = activity {
+                    self.notif_latch.insert(dkey, (a, Instant::now()));
+                }
+            }
             fires.push((key, kind));
         }
 
@@ -776,6 +807,11 @@ impl App {
         let prev = &self.prev_status;
         self.notif_debounce.retain(|(lane, sess, _), t| {
             prev.contains_key(&(*lane, sess.clone())) || t.elapsed() < NOTIF_DEBOUNCE
+        });
+        // The latch keeps entries through a vanish+reappear (the repeat we're stopping); drop one
+        // only once its session has been gone longer than it could plausibly return.
+        self.notif_latch.retain(|(lane, sess, _), (_, seen)| {
+            prev.contains_key(&(*lane, sess.clone())) || seen.elapsed() < NOTIF_LATCH_GRACE
         });
 
         // A burst (≥2 alerts in one tick) coalesces into a single popup + banner so the desktop
@@ -3801,6 +3837,9 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
         return;
     }
     app.input_suspended.store(true, Ordering::Relaxed);
+    // Tell the daemon we're parking now so it takes over desktop popups on its next tick rather
+    // than waiting out LOCAL_TTL for our heartbeat to go stale — closes the handoff gap.
+    let _ = app.client.call("watcher.park", None).await;
     tokio::time::sleep(Duration::from_millis(120)).await; // let the reader thread release stdin
     disable_mouse();
     ratatui::restore();
@@ -3826,6 +3865,8 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
         return;
     }
     app.input_suspended.store(true, Ordering::Relaxed);
+    // Signal the park so the daemon covers desktop popups immediately (see do_attach).
+    let _ = app.client.call("watcher.park", None).await;
     tokio::time::sleep(Duration::from_millis(120)).await; // let the reader thread release stdin
     disable_mouse();
     ratatui::restore();

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -524,12 +524,16 @@ impl App {
             .iter()
             .map(|l| (l.id, self.lane_attention(l)))
             .collect();
+        // Within a repo + pin + attention bucket, order by lane id (creation order) — a STABLE
+        // key. Sorting by recent activity here made lanes bubble around on every agent output
+        // (visible jumbling, worse with the expanded agent tree). Needs-you still floats up via
+        // the `attention` bucket; only the within-bucket churn is removed.
         self.lanes.sort_by_key(|l| {
             (
                 repo_order[&l.repo.id],
                 !l.pinned,
                 attention[&l.id],
-                std::cmp::Reverse(l.last_activity_at),
+                l.id,
             )
         });
     }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -859,10 +859,26 @@ impl App {
     /// agents expands into a header row plus one row per agent when `expand_agents` is on. `selected`
     /// indexes this list. Render and navigation BOTH go through here so they never drift.
     pub fn fleet_rows(&self) -> Vec<FleetRow> {
-        build_fleet_rows(
-            self.visible_lanes().iter().map(|l| l.agent_sessions.len()),
-            self.settings.expand_agents,
-        )
+        let lanes = self.visible_lanes();
+        let mut rows = Vec::new();
+        for (i, lane) in lanes.iter().enumerate() {
+            rows.push(FleetRow {
+                lane_idx: i,
+                session: None,
+            });
+            if self.settings.expand_agents && lane.agent_sessions.len() > 1 {
+                // Emit sub-rows in a STABLE order (by durable session identity), not the daemon's
+                // newest-active-first order — otherwise renamed rows jump around as agents take
+                // turns. `session` keeps the real index so selection still targets the right agent.
+                for s in stable_session_order(&lane.agent_sessions) {
+                    rows.push(FleetRow {
+                        lane_idx: i,
+                        session: Some(s),
+                    });
+                }
+            }
+        }
+        rows
     }
 
     fn selected_row(&self) -> Option<FleetRow> {
@@ -2638,6 +2654,11 @@ impl App {
             self.focus_insert = true;
             return;
         }
+        // `R` renames the selected agent sub-row (the editor shows in the sidebar tree).
+        if key.code == KeyCode::Char('R') {
+            self.start_rename();
+            return;
+        }
         match key.code {
             KeyCode::Tab => return self.cycle_session(true),
             KeyCode::BackTab => return self.cycle_session(false),
@@ -3527,25 +3548,20 @@ enum SessionRef {
     Transcript(String),
 }
 
-/// Build the fleet sidebar's rows from each visible lane's agent count. A lane is always one
-/// header row; when `expand` is on and the lane runs >1 agent, its agents follow as sub-rows.
-fn build_fleet_rows(session_counts: impl Iterator<Item = usize>, expand: bool) -> Vec<FleetRow> {
-    let mut rows = Vec::new();
-    for (i, n) in session_counts.enumerate() {
-        rows.push(FleetRow {
-            lane_idx: i,
-            session: None,
-        });
-        if expand && n > 1 {
-            for s in 0..n {
-                rows.push(FleetRow {
-                    lane_idx: i,
-                    session: Some(s),
-                });
-            }
-        }
-    }
-    rows
+/// Indices into `sessions` in a STABLE display order — by durable identity (`session_id`, then
+/// transcript path / window) — so expanded sub-rows (and their user labels) keep their position
+/// instead of reshuffling when the daemon re-sorts sessions by recent activity.
+fn stable_session_order(sessions: &[AgentSession]) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..sessions.len()).collect();
+    let key = |s: &AgentSession| {
+        (
+            s.session_id.clone(),
+            s.manifest_path.clone(),
+            s.tmux_window.clone(),
+        )
+    };
+    idx.sort_by(|&a, &b| key(&sessions[a]).cmp(&key(&sessions[b])));
+    idx
 }
 
 /// The stable identity of a session, or `None` for an inferred/keyless one (nothing to pin to).
@@ -4059,34 +4075,26 @@ mod tests {
     }
 
     #[test]
-    fn fleet_rows_collapsed_is_one_per_lane() {
-        // Toggle off: always one row per lane, regardless of agent count.
-        let rows = build_fleet_rows([0usize, 1, 3].into_iter(), false);
-        assert_eq!(
-            rows,
-            vec![
-                FleetRow { lane_idx: 0, session: None },
-                FleetRow { lane_idx: 1, session: None },
-                FleetRow { lane_idx: 2, session: None },
-            ]
-        );
-    }
-
-    #[test]
-    fn fleet_rows_expands_only_multi_agent_lanes() {
-        // Toggle on: a 3-agent lane becomes a header + 3 sub-rows; 0/1-agent lanes stay single.
-        let rows = build_fleet_rows([1usize, 3, 0].into_iter(), true);
-        assert_eq!(
-            rows,
-            vec![
-                FleetRow { lane_idx: 0, session: None }, // 1 agent → just the lane
-                FleetRow { lane_idx: 1, session: None }, // header
-                FleetRow { lane_idx: 1, session: Some(0) },
-                FleetRow { lane_idx: 1, session: Some(1) },
-                FleetRow { lane_idx: 1, session: Some(2) },
-                FleetRow { lane_idx: 2, session: None }, // 0 agents → just the lane
-            ]
-        );
+    fn stable_session_order_sorts_by_durable_id() {
+        // Order follows session_id (stable), NOT the input order (which the daemon churns by
+        // activity), so renamed sub-rows hold their position. Input ids c, a, b → indices 1,2,0.
+        let sessions = [
+            sess(Some("ccc"), AgentStatus::Running, false),
+            sess(Some("aaa"), AgentStatus::Running, false),
+            sess(Some("bbb"), AgentStatus::Running, false),
+        ];
+        assert_eq!(stable_session_order(&sessions), vec![1, 2, 0]);
+        // Reversing the input yields the SAME display order (stability under reshuffle).
+        let rev = [
+            sess(Some("bbb"), AgentStatus::Running, false),
+            sess(Some("aaa"), AgentStatus::Running, false),
+            sess(Some("ccc"), AgentStatus::Running, false),
+        ];
+        let ordered: Vec<&str> = stable_session_order(&rev)
+            .into_iter()
+            .map(|i| rev[i].session_id.as_deref().unwrap())
+            .collect();
+        assert_eq!(ordered, vec!["aaa", "bbb", "ccc"]);
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -134,6 +134,7 @@ pub struct Settings {
     pub notify_show_why: bool,
     pub notify_coalesce: bool,
     pub notify_click_focus: bool,
+    pub notify_subagents: bool,
     pub usage_probe: bool,
     pub expand_agents: bool,
 }
@@ -144,7 +145,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 17;
+const SETTINGS_COUNT: usize = 18;
 
 pub struct App {
     pub client: DaemonClient,
@@ -239,6 +240,13 @@ pub struct App {
     /// True once the first lane list has seeded `prev_status` (so startup doesn't notify for
     /// every already-running agent at once).
     notif_seeded: bool,
+    /// Set when the TUI returns from a full-screen attach: forces the next `detect_notifications`
+    /// to re-seed instead of diffing. The daemon owned desktop popups while the TUI was parked
+    /// (its heartbeat went stale), so replaying the gap's transitions would double-fire them.
+    notif_reseed: bool,
+    /// Whether `prev_status` was built including subagents (the `notify_subagents` toggle). When it
+    /// flips, the tracked key set changes wholesale, so `detect_notifications` re-seeds.
+    notif_subagents: bool,
     /// Debounce keyed by (lane, session, kind): the last time each *kind* of alert fired for a
     /// session. Keying on the kind suppresses a flapping identical alert without swallowing a
     /// genuinely different transition (e.g. a usage-limit alert right after a needs-you one);
@@ -394,6 +402,8 @@ impl App {
             settings_geom: std::cell::Cell::new(0),
             prev_status: HashMap::new(),
             notif_seeded: false,
+            notif_reseed: false,
+            notif_subagents: false,
             notif_debounce: HashMap::new(),
             notifications: VecDeque::new(),
             notif_sel: 0,
@@ -706,16 +716,25 @@ impl App {
     /// Diff the freshly-fetched per-session statuses against the previous snapshot and fire a
     /// notification on each meaningful transition. The first call only seeds the snapshot.
     fn detect_notifications(&mut self) {
-        // Snapshot the new statuses, one entry per real agent session.
+        // Snapshot the new statuses, one entry per real agent session. Inferred file-activity
+        // sessions (worktree-isolated subagents) only count when the user opted in.
+        let subagents = self.settings.notify_subagents;
         let now: HashMap<(LaneId, SessKey), AgentStatus> = self
             .lanes
             .iter()
-            .flat_map(|l| session_statuses(l.id, &l.agent_sessions))
+            .flat_map(|l| session_statuses(l.id, &l.agent_sessions, subagents))
             .collect();
 
-        if !self.notif_seeded {
+        // Re-seed (don't diff) on the first list, or after returning from a full-screen attach.
+        // While the TUI was parked the daemon owned desktop popups (its `local_watcher_seen`
+        // heartbeat went stale), so replaying the transitions that happened in the gap would
+        // double-fire what the daemon already delivered. The subagent toggle flipping likewise
+        // changes the tracked key set wholesale, so re-seed there too.
+        if !self.notif_seeded || self.notif_reseed || subagents != self.notif_subagents {
             self.prev_status = now;
             self.notif_seeded = true;
+            self.notif_reseed = false;
+            self.notif_subagents = subagents;
             return;
         }
 
@@ -803,10 +822,11 @@ impl App {
     fn fire_notification(&mut self, id: LaneId, key: &SessKey, kind: NotifKind, quiet: bool) {
         // Compose under an immutable borrow that ends before we mutate `self`. The session may
         // be gone when its disappearance was the trigger — compose degrades to a generic line.
+        let subagents = self.settings.notify_subagents;
         let Some((title, body, session_id)) = self.lanes.iter().find(|l| l.id == id).map(|l| {
-            let sess = session_by_key(l, key);
+            let sess = session_by_key(l, key, subagents);
             // Which of the lane's side-by-side agents this is (1-based in the body when >1).
-            let slot = slot_by_key(l, key);
+            let slot = slot_by_key(l, key, subagents);
             let (t, b) = notify::compose(kind, l, sess, slot, self.settings.notify_show_why);
             (t, b, sess.and_then(|s| s.session_id.clone()))
         }) else {
@@ -1875,6 +1895,9 @@ impl App {
         if let Some(x) = b("notify_click_focus") {
             self.settings.notify_click_focus = x;
         }
+        if let Some(x) = b("notify_subagents") {
+            self.settings.notify_subagents = x;
+        }
         if let Some(x) = b("usage_probe") {
             self.settings.usage_probe = x;
         }
@@ -1906,6 +1929,7 @@ impl App {
             "notify_show_why": self.settings.notify_show_why,
             "notify_coalesce": self.settings.notify_coalesce,
             "notify_click_focus": self.settings.notify_click_focus,
+            "notify_subagents": self.settings.notify_subagents,
             "usage_probe": self.settings.usage_probe,
             "expand_agents": self.settings.expand_agents,
         });
@@ -2043,10 +2067,14 @@ impl App {
                 self.save_settings().await;
             }
             15 => {
-                self.settings.usage_probe = !self.settings.usage_probe;
+                self.settings.notify_subagents = !self.settings.notify_subagents;
                 self.save_settings().await;
             }
             16 => {
+                self.settings.usage_probe = !self.settings.usage_probe;
+                self.save_settings().await;
+            }
+            17 => {
                 // Toggling changes the fleet row count, so re-anchor the cursor to the same
                 // lane/agent afterward (else `selected` drifts to a different — or out-of-range — row).
                 let keep = self.selected_lane().map(|l| l.id);
@@ -2064,7 +2092,7 @@ impl App {
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 | 5..=16 => self.adjust_setting(true).await,
+            0..=2 | 5..=17 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
             _ => {}
         }
@@ -3786,6 +3814,9 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     app.input_suspended.store(false, Ordering::Relaxed);
     app.last_viewport.clear(); // force a viewport resync after returning
     app.last_title.clear(); // tmux set its own title; re-assert ours next tick
+    // The daemon fired desktop popups while we were parked (our heartbeat went stale); re-seed
+    // notification edge-detection so the next refresh doesn't replay — and double-fire — them.
+    app.notif_reseed = true;
     app.status = "back from the agent (it's still running) — ↵ to reopen".into();
 }
 
@@ -3809,6 +3840,8 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
     app.last_viewport.clear();
     app.last_title.clear(); // tmux set its own title; re-assert ours next tick
     app.terminals_lane = None; // the shell may have exited; refresh the terminal list
+    // Re-seed notification edge-detection — the daemon owned popups while we were parked.
+    app.notif_reseed = true;
 }
 
 /// Attach to a `session:window` target on repomon's dedicated tmux socket (the socket label is

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -86,7 +86,20 @@ pub struct Pane {
 pub struct ClickZone {
     pub rect: Rect,
     pub lane: LaneId,
+    /// Which agent within the lane this row targets, when the sidebar is expanded into per-agent
+    /// rows; `None` for a normal lane row / lane header.
+    pub session: Option<usize>,
     pub interactive: bool,
+}
+
+/// A row in the fleet sidebar: a lane (header), or — when `expand_agents` is on and the lane runs
+/// several agents — one of that lane's agent sub-rows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FleetRow {
+    /// Index into [`App::visible_lanes`].
+    pub lane_idx: usize,
+    /// `Some(i)` = the lane's `i`-th agent sub-row; `None` = the lane header / single-agent row.
+    pub session: Option<usize>,
 }
 
 /// Two left-clicks on the same lane within this window count as a double-click (→ open the real
@@ -122,6 +135,7 @@ pub struct Settings {
     pub notify_coalesce: bool,
     pub notify_click_focus: bool,
     pub usage_probe: bool,
+    pub expand_agents: bool,
 }
 
 /// Accent choices the Settings view cycles through (`mono` = no color).
@@ -130,7 +144,7 @@ const ACCENTS: &[&str] = &[
 ];
 
 /// Number of editable rows in the Settings view.
-const SETTINGS_COUNT: usize = 16;
+const SETTINGS_COUNT: usize = 17;
 
 pub struct App {
     pub client: DaemonClient,
@@ -142,6 +156,12 @@ pub struct App {
     pub selected: usize,
     pub filter: String,
     pub filtering: bool,
+    /// Inline rename of the selected agent sub-row (expanded sidebar): active flag, edit buffer,
+    /// and the pinned target — the agent's durable transcript `session_id`, captured when the
+    /// rename starts so a cursor move / refresh during the edit can't retarget it.
+    pub renaming: bool,
+    pub rename_buf: String,
+    rename_target: Option<String>,
     pub status: String,
     pub nl_repo_idx: usize,
     pub nl_branch: String,
@@ -321,6 +341,9 @@ impl App {
             selected: 0,
             filter: String::new(),
             filtering: false,
+            renaming: false,
+            rename_buf: String::new(),
+            rename_target: None,
             status: String::new(),
             nl_repo_idx: 0,
             nl_branch: String::new(),
@@ -464,8 +487,10 @@ impl App {
     pub async fn refresh_lanes(&mut self) {
         match self.client.call_typed::<Vec<Lane>>("lane.list", None).await {
             Ok(l) => {
-                // Keep the cursor on the same lane across the attention re-sort below.
+                // Keep the cursor on the same lane (and the same agent sub-row, when expanded)
+                // across the attention re-sort below.
                 let keep = self.selected_lane().map(|l| l.id);
+                let keep_ref = self.selected_session_ref();
                 self.lanes = l;
                 // Forget remembered agent selections for lanes that no longer exist.
                 self.session_memory
@@ -476,9 +501,7 @@ impl App {
                 self.detect_notifications();
                 self.sort_lanes();
                 if let Some(id) = keep {
-                    if let Some(i) = self.visible_lanes().iter().position(|l| l.id == id) {
-                        self.selected = i;
-                    }
+                    self.select_lane_session(id, keep_ref);
                 }
             }
             Err(e) => self.status = format!("lane.list failed: {e}"),
@@ -534,37 +557,36 @@ impl App {
             .and_then(|_| self.notifications.back())
             .map(|e| e.lane_id);
 
-        // Resolve the target under one immutable borrow of the lanes, then mutate.
-        let lanes = self.visible_lanes();
-        let hits: Vec<usize> = lanes
-            .iter()
-            .enumerate()
-            .filter(|(_, l)| self.lane_needs_attention(l))
-            .map(|(i, _)| i)
-            .collect();
-        let banner_idx = banner_lane
-            .and_then(|id| lanes.iter().position(|l| l.id == id))
-            .filter(|&i| i != self.selected);
-        let label = |i: usize| format!("{}/{}", lanes[i].repo.name, lanes[i].worktree.name);
-
-        let (target, msg) = if let Some(i) = banner_idx {
-            (Some(i), format!("→ {} (just alerted)", label(i)))
-        } else if hits.is_empty() {
-            (None, "no agents need you".to_string())
-        } else {
-            let next = hits
+        // Work in lane-index space (rows can be per-agent), then map the chosen lane to its row.
+        let cur = self.selected_row().map(|r| r.lane_idx).unwrap_or(0);
+        let (target_id, msg) = {
+            let lanes = self.visible_lanes();
+            let hits: Vec<usize> = lanes
                 .iter()
-                .copied()
-                .find(|&i| i > self.selected)
-                .unwrap_or(hits[0]);
-            let pos = hits.iter().position(|&i| i == next).unwrap_or(0);
-            (
-                Some(next),
-                format!("needs you {}/{} — {}", pos + 1, hits.len(), label(next)),
-            )
+                .enumerate()
+                .filter(|(_, l)| self.lane_needs_attention(l))
+                .map(|(i, _)| i)
+                .collect();
+            let banner_idx = banner_lane
+                .and_then(|id| lanes.iter().position(|l| l.id == id))
+                .filter(|&i| i != cur);
+            let label = |i: usize| format!("{}/{}", lanes[i].repo.name, lanes[i].worktree.name);
+
+            if let Some(i) = banner_idx {
+                (Some(lanes[i].id), format!("→ {} (just alerted)", label(i)))
+            } else if hits.is_empty() {
+                (None, "no agents need you".to_string())
+            } else {
+                let next = hits.iter().copied().find(|&i| i > cur).unwrap_or(hits[0]);
+                let pos = hits.iter().position(|&i| i == next).unwrap_or(0);
+                (
+                    Some(lanes[next].id),
+                    format!("needs you {}/{} — {}", pos + 1, hits.len(), label(next)),
+                )
+            }
         };
-        if let Some(i) = target {
-            self.selected = i;
+        if let Some(id) = target_id {
+            self.select_lane_session(id, None);
         }
         self.status = msg;
     }
@@ -661,22 +683,19 @@ impl App {
 
     /// Select lane `id` — clearing any filter that hides it — and open it in Focus.
     fn jump_to_lane(&mut self, id: LaneId) {
-        let find = |me: &Self| me.visible_lanes().iter().position(|l| l.id == id);
-        let mut idx = find(self);
-        if idx.is_none() && (!self.filter.is_empty() || self.urgent_only) {
+        let exists = |me: &Self| me.visible_lanes().iter().any(|l| l.id == id);
+        if !exists(self) && (!self.filter.is_empty() || self.urgent_only) {
             self.filter.clear();
             self.filtering = false;
             self.urgent_only = false;
-            idx = find(self);
         }
-        match idx {
-            Some(i) => {
-                self.selected = i;
-                self.focus_insert = false;
-                self.reset_scroll();
-                self.view = View::Focus;
-            }
-            None => self.status = "that lane no longer exists".into(),
+        if exists(self) {
+            self.select_lane_session(id, None);
+            self.focus_insert = false;
+            self.reset_scroll();
+            self.view = View::Focus;
+        } else {
+            self.status = "that lane no longer exists".into();
         }
     }
 
@@ -836,8 +855,61 @@ impl App {
             .collect()
     }
 
+    /// The sidebar rows in display order. One row per visible lane, except a lane running several
+    /// agents expands into a header row plus one row per agent when `expand_agents` is on. `selected`
+    /// indexes this list. Render and navigation BOTH go through here so they never drift.
+    pub fn fleet_rows(&self) -> Vec<FleetRow> {
+        build_fleet_rows(
+            self.visible_lanes().iter().map(|l| l.agent_sessions.len()),
+            self.settings.expand_agents,
+        )
+    }
+
+    fn selected_row(&self) -> Option<FleetRow> {
+        self.fleet_rows().get(self.selected).copied()
+    }
+
+    fn rows_len(&self) -> usize {
+        self.fleet_rows().len()
+    }
+
     pub fn selected_lane(&self) -> Option<&Lane> {
-        self.visible_lanes().into_iter().nth(self.selected)
+        let row = self.fleet_rows().get(self.selected).copied()?;
+        self.visible_lanes().into_iter().nth(row.lane_idx)
+    }
+
+    /// The stable identity of the agent on the selected row, when it's an agent sub-row.
+    fn selected_session_ref(&self) -> Option<SessionRef> {
+        let row = self.selected_row()?;
+        let s = row.session?;
+        let lane = self.visible_lanes().into_iter().nth(row.lane_idx)?;
+        lane.agent_sessions.get(s).and_then(agent_session_ref)
+    }
+
+    /// Move the fleet cursor onto `lane_id`, preferring the agent sub-row matching `sref` (stable
+    /// across refreshes/reorders), else that lane's header row. No-op when the lane isn't visible.
+    fn select_lane_session(&mut self, lane_id: LaneId, sref: Option<SessionRef>) {
+        let (lane_pos, want) = {
+            let lanes = self.visible_lanes();
+            let Some(lane_pos) = lanes.iter().position(|l| l.id == lane_id) else {
+                return;
+            };
+            let want = sref
+                .as_ref()
+                .and_then(|r| session_index_for_ref(&lanes[lane_pos].agent_sessions, r));
+            (lane_pos, want)
+        };
+        let rows = self.fleet_rows();
+        let target = rows
+            .iter()
+            .position(|r| r.lane_idx == lane_pos && r.session == want)
+            .or_else(|| {
+                rows.iter()
+                    .position(|r| r.lane_idx == lane_pos && r.session.is_none())
+            });
+        if let Some(t) = target {
+            self.selected = t;
+        }
     }
 
     /// Lane ids to babysit in the grid: pinned first, then by attention, then most-active.
@@ -857,7 +929,7 @@ impl App {
     }
 
     fn clamp_selection(&mut self) {
-        let n = self.visible_lanes().len();
+        let n = self.rows_len();
         if n == 0 {
             self.selected = 0;
         } else if self.selected >= n {
@@ -992,6 +1064,61 @@ impl App {
     /// to the number of sessions on that lane.
     fn sync_session_cursor(&mut self) {
         let sel = self.selected_lane().map(|l| l.id);
+        // Honor a just-spawned agent's focus intent FIRST — before the expanded early-return below,
+        // which would otherwise skip it. Once its window appears on the spawn lane, point the
+        // cursor (and, when expanded, the selected row) at the new agent.
+        if let Some((lane, window)) = self.pending_focus_window.clone() {
+            if sel == Some(lane) {
+                let hit = self.selected_lane().and_then(|l| {
+                    l.agent_sessions
+                        .iter()
+                        .position(|s| s.tmux_window.as_deref() == Some(window.as_str()))
+                });
+                match hit {
+                    Some(i) => {
+                        self.session_idx = i;
+                        self.pending_focus_window = None;
+                        self.pending_focus_ticks = 0;
+                        self.reset_scroll();
+                        if self.settings.expand_agents {
+                            let sref = self
+                                .selected_lane()
+                                .and_then(|l| l.agent_sessions.get(i))
+                                .and_then(agent_session_ref);
+                            self.select_lane_session(lane, sref);
+                        }
+                        return;
+                    }
+                    None => {
+                        self.pending_focus_ticks = self.pending_focus_ticks.saturating_add(1);
+                        if self.pending_focus_ticks > 5 {
+                            self.pending_focus_window = None;
+                            self.pending_focus_ticks = 0;
+                        }
+                    }
+                }
+            } else {
+                // Selection moved off the spawn lane before the agent appeared — drop the intent.
+                self.pending_focus_window = None;
+                self.pending_focus_ticks = 0;
+            }
+        }
+        // In expanded mode an agent sub-row IS the session cursor — drive `session_idx` straight
+        // from the selected row (the memory logic below is for the collapsed lane rows).
+        if self.settings.expand_agents {
+            if let Some(FleetRow {
+                session: Some(s), ..
+            }) = self.selected_row()
+            {
+                let lane_id = self.selected_lane().map(|l| l.id);
+                if self.session_idx != s || self.session_lane != lane_id {
+                    self.reset_scroll();
+                }
+                self.session_lane = lane_id;
+                self.session_idx = s;
+                return;
+            }
+        }
         if sel != self.session_lane {
             // Remember the agent the outgoing lane had selected, then restore the one we last
             // had on the lane we're arriving at — so returning to a multi-agent project keeps
@@ -1018,37 +1145,6 @@ impl App {
                 })
                 .unwrap_or(0);
             self.reset_scroll(); // scrollback buffer belonged to the previous lane
-        }
-        // After a spawn, jump the cursor onto the new agent's window the moment it shows up in
-        // the lane list (the daemon surfaces it as a placeholder right away), so you land on the
-        // agent you just started — not the lane's existing one. Give up after a few refreshes so
-        // a window that never appears can't pin the cursor.
-        if let Some((lane, window)) = self.pending_focus_window.clone() {
-            if sel == Some(lane) {
-                let hit = self.selected_lane().and_then(|l| {
-                    l.agent_sessions
-                        .iter()
-                        .position(|s| s.tmux_window.as_deref() == Some(window.as_str()))
-                });
-                match hit {
-                    Some(i) => {
-                        self.session_idx = i;
-                        self.pending_focus_window = None;
-                        self.pending_focus_ticks = 0;
-                    }
-                    None => {
-                        self.pending_focus_ticks = self.pending_focus_ticks.saturating_add(1);
-                        if self.pending_focus_ticks > 5 {
-                            self.pending_focus_window = None;
-                            self.pending_focus_ticks = 0;
-                        }
-                    }
-                }
-            } else {
-                // Selection moved off the spawn lane before the agent appeared — drop the intent.
-                self.pending_focus_window = None;
-                self.pending_focus_ticks = 0;
-            }
         }
         let n = self
             .selected_lane()
@@ -1084,9 +1180,7 @@ impl App {
     fn select_grid_active(&mut self) {
         let ids = self.grid_lane_ids();
         if let Some(&id) = ids.get(self.grid_active) {
-            if let Some(pos) = self.visible_lanes().iter().position(|l| l.id == id) {
-                self.selected = pos;
-            }
+            self.select_lane_session(id, None);
         }
     }
 
@@ -1211,6 +1305,17 @@ impl App {
         // The scrollback snapshot belonged to the previous agent's window — drop it so the new
         // agent shows its own live tail instead of stale lines.
         self.reset_scroll();
+        // In expanded mode the selected row drives session_idx, so move the cursor onto the new
+        // agent's sub-row — otherwise the per-tick cursor sync snaps session_idx straight back.
+        if self.settings.expand_agents {
+            if let Some(lane_id) = self.selected_lane().map(|l| l.id) {
+                let sref = self
+                    .selected_lane()
+                    .and_then(|l| l.agent_sessions.get(self.session_idx))
+                    .and_then(agent_session_ref);
+                self.select_lane_session(lane_id, sref);
+            }
+        }
     }
 
     async fn on_notification(&mut self, note: Notification) {
@@ -1253,6 +1358,11 @@ impl App {
                 return;
             }
             Event::Mouse(me) => {
+                // Inline rename is modal: ignore the pointer too, so a click/scroll can't retarget
+                // the rename to a different agent.
+                if self.renaming {
+                    return;
+                }
                 use ratatui::crossterm::event::{MouseButton, MouseEventKind};
                 // Remember the real pointer column from positioned events — wheel events report
                 // column 0 on many terminals, so this is how we know which pane the wheel is over.
@@ -1327,6 +1437,8 @@ impl App {
         }
         self.status.clear();
         match self.view {
+            // Inline session rename is modal: while active it swallows every key, in any view.
+            _ if self.renaming => self.rename_key(key).await,
             View::NewLane => self.new_lane_key(key).await,
             View::Split => self.split_key(key).await,
             View::Focus => self.focus_key(key).await,
@@ -1342,10 +1454,91 @@ impl App {
             View::LaneJump => self.lane_jump_key(key),
             _ if self.filtering => self.filter_key(key),
             _ => {
-                if let Some(action) = keybinds::nav(key) {
+                // `R` renames the selected agent sub-row in the expanded fleet sidebar.
+                if key.code == KeyCode::Char('R') {
+                    self.start_rename();
+                } else if let Some(action) = keybinds::nav(key) {
                     self.apply(action).await;
                 }
             }
+        }
+    }
+
+    /// Begin renaming the agent on the selected sub-row. Pins the target's transcript `session_id`
+    /// now (resolved from the selected ROW, not the laggy `session_idx`) so a cursor move or a 1s
+    /// refresh during the edit can't retarget the rename. No-op unless an agent row is selected.
+    fn start_rename(&mut self) {
+        let Some(FleetRow {
+            lane_idx,
+            session: Some(s),
+        }) = self.selected_row()
+        else {
+            self.status =
+                "rename: select an agent row (turn on 'expand agent rows' in settings)".into();
+            return;
+        };
+        let (sid, label) = {
+            let lanes = self.visible_lanes();
+            let Some(sess) = lanes
+                .into_iter()
+                .nth(lane_idx)
+                .and_then(|l| l.agent_sessions.get(s))
+            else {
+                return;
+            };
+            (sess.session_id.clone(), sess.custom_label.clone())
+        };
+        let Some(sid) = sid else {
+            self.status = "can't rename — this session has no transcript id yet".into();
+            return;
+        };
+        self.rename_target = Some(sid);
+        self.rename_buf = label.unwrap_or_default();
+        self.renaming = true;
+    }
+
+    async fn rename_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char(c) => self.rename_buf.push(c),
+            KeyCode::Backspace => {
+                self.rename_buf.pop();
+            }
+            KeyCode::Enter => self.commit_rename().await,
+            KeyCode::Esc => {
+                self.renaming = false;
+                self.rename_buf.clear();
+                self.rename_target = None;
+            }
+            _ => {}
+        }
+    }
+
+    /// Persist the rename (empty buffer clears the label), keyed by the pinned transcript id.
+    async fn commit_rename(&mut self) {
+        self.renaming = false;
+        let label = std::mem::take(&mut self.rename_buf).trim().to_string();
+        let Some(session_id) = self.rename_target.take() else {
+            return;
+        };
+        let label_val = if label.is_empty() {
+            serde_json::Value::Null
+        } else {
+            json!(label)
+        };
+        match self
+            .client
+            .call("session.rename", Some(json!({ "session_id": session_id, "label": label_val })))
+            .await
+        {
+            Ok(_) => {
+                self.status = if label.is_empty() {
+                    "label cleared".into()
+                } else {
+                    format!("renamed → {label}")
+                };
+                self.refresh_lanes().await; // show the new label at once
+            }
+            Err(e) => self.status = format!("rename failed: {e}"),
         }
     }
 
@@ -1665,6 +1858,9 @@ impl App {
         if let Some(x) = b("usage_probe") {
             self.settings.usage_probe = x;
         }
+        if let Some(x) = b("expand_agents") {
+            self.settings.expand_agents = x;
+        }
     }
 
     /// Persist the current settings to the daemon config and apply the accent live.
@@ -1691,6 +1887,7 @@ impl App {
             "notify_coalesce": self.settings.notify_coalesce,
             "notify_click_focus": self.settings.notify_click_focus,
             "usage_probe": self.settings.usage_probe,
+            "expand_agents": self.settings.expand_agents,
         });
         match self.client.call("config.set", Some(params)).await {
             Ok(v) => self.apply_settings_value(&v),
@@ -1829,13 +2026,25 @@ impl App {
                 self.settings.usage_probe = !self.settings.usage_probe;
                 self.save_settings().await;
             }
+            16 => {
+                // Toggling changes the fleet row count, so re-anchor the cursor to the same
+                // lane/agent afterward (else `selected` drifts to a different — or out-of-range — row).
+                let keep = self.selected_lane().map(|l| l.id);
+                let keep_ref = self.selected_session_ref();
+                self.settings.expand_agents = !self.settings.expand_agents;
+                self.save_settings().await;
+                match keep {
+                    Some(id) => self.select_lane_session(id, keep_ref),
+                    None => self.clamp_selection(),
+                }
+            }
             _ => {}
         }
     }
 
     async fn activate_setting(&mut self) {
         match self.settings_idx {
-            0..=2 | 5..=15 => self.adjust_setting(true).await,
+            0..=2 | 5..=16 => self.adjust_setting(true).await,
             3..=4 => self.settings_editing = true,
             _ => {}
         }
@@ -1907,6 +2116,17 @@ impl App {
         if let Some(i) = idx {
             self.session_lane = Some(lane_id); // keep sync_session_cursor from resetting it
             self.session_idx = i;
+            // In expanded mode, also land the fleet cursor on that agent's row so the per-tick
+            // cursor sync (which keys off the selected row) keeps it there.
+            if self.settings.expand_agents {
+                let sref = self
+                    .lanes
+                    .iter()
+                    .find(|l| l.id == lane_id)
+                    .and_then(|l| l.agent_sessions.get(i))
+                    .and_then(agent_session_ref);
+                self.select_lane_session(lane_id, sref);
+            }
         }
     }
 
@@ -2196,10 +2416,17 @@ impl App {
 
     /// Make `id` the active lane: move the Fleet cursor to it and, in Grid, the tile cursor too,
     /// so `selected_lane()` (which key-forwarding targets) points at it.
-    fn activate_lane(&mut self, id: LaneId) {
-        if let Some(pos) = self.visible_lanes().iter().position(|l| l.id == id) {
-            self.selected = pos;
-        }
+    fn activate_lane(&mut self, id: LaneId, session: Option<usize>) {
+        let sref = match session {
+            Some(s) => self
+                .visible_lanes()
+                .iter()
+                .find(|l| l.id == id)
+                .and_then(|l| l.agent_sessions.get(s))
+                .and_then(agent_session_ref),
+            None => None,
+        };
+        self.select_lane_session(id, sref);
         if self.view == View::Grid {
             if let Some(gi) = self.grid_lane_ids().iter().position(|&l| l == id) {
                 self.grid_active = gi;
@@ -2232,7 +2459,7 @@ impl App {
                 let now = std::time::Instant::now();
                 let dbl = is_double_click(self.last_click, z.lane, now);
                 self.last_click = Some((now, z.lane));
-                self.activate_lane(z.lane);
+                self.activate_lane(z.lane, z.session);
                 if dbl {
                     self.focus_insert = false;
                     self.attach_request = Some(z.lane); // double-click → real terminal
@@ -2263,7 +2490,7 @@ impl App {
                 self.grid_active = self.grid_active.saturating_sub(1);
             }
         } else {
-            let n = self.visible_lanes().len();
+            let n = self.rows_len();
             if down && n > 0 && self.selected + 1 < n {
                 self.selected += 1;
             } else if !down {
@@ -3019,7 +3246,7 @@ impl App {
         match action {
             Action::MoveUp => self.selected = self.selected.saturating_sub(1),
             Action::MoveDown => {
-                let n = self.visible_lanes().len();
+                let n = self.rows_len();
                 if n > 0 && self.selected + 1 < n {
                     self.selected += 1;
                 }
@@ -3298,6 +3525,27 @@ fn attention_rank(sessions: &[AgentSession], auto_continue_armed: bool) -> u8 {
 enum SessionRef {
     Window(String),
     Transcript(String),
+}
+
+/// Build the fleet sidebar's rows from each visible lane's agent count. A lane is always one
+/// header row; when `expand` is on and the lane runs >1 agent, its agents follow as sub-rows.
+fn build_fleet_rows(session_counts: impl Iterator<Item = usize>, expand: bool) -> Vec<FleetRow> {
+    let mut rows = Vec::new();
+    for (i, n) in session_counts.enumerate() {
+        rows.push(FleetRow {
+            lane_idx: i,
+            session: None,
+        });
+        if expand && n > 1 {
+            for s in 0..n {
+                rows.push(FleetRow {
+                    lane_idx: i,
+                    session: Some(s),
+                });
+            }
+        }
+    }
+    rows
 }
 
 /// The stable identity of a session, or `None` for an inferred/keyless one (nothing to pin to).
@@ -3729,6 +3977,7 @@ mod tests {
             last_message: None,
             pending_prompt: None,
             config_dir: None,
+            custom_label: None,
         }
     }
 
@@ -3807,6 +4056,37 @@ mod tests {
         );
         assert_eq!(attention_rank(&[sess(None, Waiting, true)], true), 3);
         assert_eq!(attention_rank(&[], true), 3);
+    }
+
+    #[test]
+    fn fleet_rows_collapsed_is_one_per_lane() {
+        // Toggle off: always one row per lane, regardless of agent count.
+        let rows = build_fleet_rows([0usize, 1, 3].into_iter(), false);
+        assert_eq!(
+            rows,
+            vec![
+                FleetRow { lane_idx: 0, session: None },
+                FleetRow { lane_idx: 1, session: None },
+                FleetRow { lane_idx: 2, session: None },
+            ]
+        );
+    }
+
+    #[test]
+    fn fleet_rows_expands_only_multi_agent_lanes() {
+        // Toggle on: a 3-agent lane becomes a header + 3 sub-rows; 0/1-agent lanes stay single.
+        let rows = build_fleet_rows([1usize, 3, 0].into_iter(), true);
+        assert_eq!(
+            rows,
+            vec![
+                FleetRow { lane_idx: 0, session: None }, // 1 agent → just the lane
+                FleetRow { lane_idx: 1, session: None }, // header
+                FleetRow { lane_idx: 1, session: Some(0) },
+                FleetRow { lane_idx: 1, session: Some(1) },
+                FleetRow { lane_idx: 1, session: Some(2) },
+                FleetRow { lane_idx: 2, session: None }, // 0 agents → just the lane
+            ]
+        );
     }
 
     #[test]

--- a/crates/repomon-tui/src/lib.rs
+++ b/crates/repomon-tui/src/lib.rs
@@ -23,7 +23,7 @@ use repomon_core::{config, Config};
 #[command(
     name = "repomon",
     version,
-    about = "Terminal mission control for parallel coding agents"
+    about = "Run a fleet of AI coding agents across all your repos, from one terminal"
 )]
 struct Cli {
     #[command(subcommand)]

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -17,7 +17,7 @@ use crate::notify::NotifKind;
 use crate::theme;
 
 const FLEET_KEYS: &str =
-    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
+    "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term · R rename  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
     "↑↓ lane · tab session  ·  click focus · wheel/PgUp scroll · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str =
@@ -32,10 +32,12 @@ const NEWLANE_KEYS: &str =
     "↑↓ repo · tab agent · ^a manage  ·  type branch · ↵ create + spawn  ·  esc cancel";
 
 /// Record a clickable lane region for the mouse handler to hit-test (see `App::handle_click`).
-fn click_zone(app: &App, rect: Rect, lane: LaneId, interactive: bool) {
+/// `session` targets one agent within the lane when the sidebar is expanded into per-agent rows.
+fn click_zone(app: &App, rect: Rect, lane: LaneId, session: Option<usize>, interactive: bool) {
     app.click_zones.borrow_mut().push(ClickZone {
         rect,
         lane,
+        session,
         interactive,
     });
 }
@@ -191,7 +193,7 @@ fn render_settings(f: &mut Frame, app: &App) {
         s.default_agent.clone()
     };
     let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
-    let items: [(&str, String, &str); 16] = [
+    let items: [(&str, String, &str); 17] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
         ("auto-continue", onoff(s.auto_continue), "space toggles"),
@@ -240,6 +242,11 @@ fn render_settings(f: &mut Frame, app: &App) {
             "usage corner (spawns claude)",
             onoff(s.usage_probe),
             "/usage probe · space toggles",
+        ),
+        (
+            "expand agent rows",
+            onoff(s.expand_agents),
+            "per-agent sidebar rows · space toggles",
         ),
     ];
     // Size the columns to the content so values and hints line up no matter how long a label is:
@@ -814,8 +821,8 @@ fn render_fleet(f: &mut Frame, app: &App) {
         .map(|sl| sl.saturating_sub(h / 2))
         .unwrap_or(0)
         .min(max_scroll);
-    // Click-to-select: register each *visible* lane row at its on-screen position (scroll-adjusted).
-    for (li, lane_id) in &lane_rows {
+    // Click-to-select: register each *visible* row at its on-screen position (scroll-adjusted).
+    for (li, lane_id, session) in &lane_rows {
         if *li >= scroll && *li < scroll + h {
             click_zone(
                 app,
@@ -826,6 +833,7 @@ fn render_fleet(f: &mut Frame, app: &App) {
                     height: 1,
                 },
                 *lane_id,
+                *session,
                 false,
             );
         }
@@ -892,7 +900,7 @@ fn render_split(f: &mut Frame, app: &App) {
     f.render_widget(Paragraph::new(right), body[2]);
     // Clicking the pane focuses the selected agent for typing (double-click → real terminal).
     if let Some(id) = id {
-        click_zone(app, body[2], id, true);
+        click_zone(app, body[2], id, None, true);
     }
     // Show the agent's text cursor where you're typing — INSERT mode at the live tail only.
     if app.focus_insert && app.scroll == 0 && has_output {
@@ -1063,7 +1071,7 @@ fn render_grid(f: &mut Frame, app: &App) {
             }
             let cell = cells[c * 2];
             let lane = app.lanes.iter().find(|l| l.id == ids[idx]);
-            click_zone(app, cell, ids[idx], true);
+            click_zone(app, cell, ids[idx], None, true);
             f.render_widget(
                 Paragraph::new(tile_lines(
                     app,
@@ -1525,17 +1533,18 @@ fn render_new_lane(f: &mut Frame, app: &App) {
 
 // ---- shared line builders ----------------------------------------------------
 
+#[allow(clippy::type_complexity)]
 fn fleet_lines(
     app: &App,
     content: Rect,
-) -> (Vec<Line<'static>>, Option<usize>, Vec<(usize, LaneId)>) {
+) -> (Vec<Line<'static>>, Option<usize>, Vec<(usize, LaneId, Option<usize>)>) {
     let width = content.width;
     let now = Utc::now();
     let mut lines = Vec::new();
-    // The selected lane's line index (so the caller can scroll to keep it visible) and every lane
-    // row's line index (so a click maps back to its lane through the scroll offset).
+    // The selected row's line index (so the caller can scroll to keep it visible) and every row's
+    // (line index, lane, agent session) so a click maps back through the scroll offset.
     let mut selected_line: Option<usize> = None;
-    let mut lane_rows: Vec<(usize, LaneId)> = Vec::new();
+    let mut lane_rows: Vec<(usize, LaneId, Option<usize>)> = Vec::new();
     lines.push(header_line(width, "REPOMON", &fmt_clock(), app));
     lines.push(rule(width, true, app));
     lines.push(Line::raw(""));
@@ -1578,22 +1587,29 @@ fn fleet_lines(
         lines.push(Line::raw("  then n to create a lane.".to_string()));
     }
 
+    let rows = app.fleet_rows();
     let mut current: Option<RepoId> = None;
-    for (i, lane) in visible.iter().enumerate() {
-        if current != Some(lane.repo.id) {
+    for (ri, row) in rows.iter().enumerate() {
+        let Some(&lane) = visible.get(row.lane_idx) else {
+            continue;
+        };
+        if row.session.is_none() && current != Some(lane.repo.id) {
             if current.is_some() {
                 lines.push(Line::raw("")); // a gap between repo groups
             }
             current = Some(lane.repo.id);
             lines.push(repo_header(width, &lane.repo.name, app));
         }
-        let selected = i == app.selected;
-        let mut line = lane_row(lane, now, app, selected);
-        if !selected && app.hover_lane == Some(lane.id) {
+        let selected = ri == app.selected;
+        let mut line = match row.session {
+            None => lane_row(lane, now, app, selected),
+            Some(s) => agent_subrow(&lane.agent_sessions[s], app, selected),
+        };
+        if !selected && row.session.is_none() && app.hover_lane == Some(lane.id) {
             line = line.style(app.theme.hover());
         }
         let li = lines.len();
-        lane_rows.push((li, lane.id));
+        lane_rows.push((li, lane.id, row.session));
         if selected {
             selected_line = Some(li);
         }
@@ -1624,43 +1640,53 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
         )),
         Line::raw(""),
     ];
+    let _ = now;
+    let rows = app.fleet_rows();
     let mut current: Option<RepoId> = None;
-    for (i, lane) in visible.iter().enumerate() {
-        if current != Some(lane.repo.id) {
+    for (ri, row) in rows.iter().enumerate() {
+        let Some(&lane) = visible.get(row.lane_idx) else {
+            continue;
+        };
+        if row.session.is_none() && current != Some(lane.repo.id) {
             current = Some(lane.repo.id);
             lines.push(Line::from(Span::styled(
                 lane.repo.name.clone(),
                 app.theme.muted(),
             )));
         }
-        let glyph = status_glyph(lane);
-        let counts = dirty_str(&lane.state.dirty);
-        let rest = format!(" {:<10} {}", trunc(&lane_name(lane), 10), counts);
-        let count = agent_count_badge(lane);
-        let _ = now;
-        let mut line = if i == app.selected {
-            let badge = count.as_deref().map(|c| format!(" {c}")).unwrap_or_default();
-            Line::from(Span::styled(
-                format!(" {glyph}{rest}{badge}"),
-                app.theme.selected(),
-            ))
-        } else {
-            let glyph_style = if lane.state.dirty.is_clean() {
-                app.theme.muted()
-            } else {
-                app.theme.accented()
-            };
-            let mut spans = vec![
-                Span::raw(" "),
-                Span::styled(glyph.to_string(), glyph_style),
-                Span::raw(rest),
-            ];
-            if let Some(c) = &count {
-                spans.push(Span::styled(format!(" {c}"), app.theme.accented()));
+        let selected = ri == app.selected;
+        let mut line = match row.session {
+            None => {
+                let glyph = status_glyph(lane);
+                let counts = dirty_str(&lane.state.dirty);
+                let rest = format!(" {:<10} {}", trunc(&lane_name(lane), 10), counts);
+                let count = agent_count_badge(lane);
+                if selected {
+                    let badge = count.as_deref().map(|c| format!(" {c}")).unwrap_or_default();
+                    Line::from(Span::styled(
+                        format!(" {glyph}{rest}{badge}"),
+                        app.theme.selected(),
+                    ))
+                } else {
+                    let glyph_style = if lane.state.dirty.is_clean() {
+                        app.theme.muted()
+                    } else {
+                        app.theme.accented()
+                    };
+                    let mut spans = vec![
+                        Span::raw(" "),
+                        Span::styled(glyph.to_string(), glyph_style),
+                        Span::raw(rest),
+                    ];
+                    if let Some(c) = &count {
+                        spans.push(Span::styled(format!(" {c}"), app.theme.accented()));
+                    }
+                    Line::from(spans)
+                }
             }
-            Line::from(spans)
+            Some(s) => agent_subrow(&lane.agent_sessions[s], app, selected),
         };
-        if i != app.selected && app.hover_lane == Some(lane.id) {
+        if !selected && row.session.is_none() && app.hover_lane == Some(lane.id) {
             line = line.style(app.theme.hover());
         }
         let li = lines.len() as u16;
@@ -1674,6 +1700,7 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
                     height: 1,
                 },
                 lane.id,
+                row.session,
                 true,
             );
         }
@@ -1888,6 +1915,62 @@ fn repo_header(width: u16, name: &str, app: &App) -> Line<'static> {
 fn agent_count_badge(lane: &Lane) -> Option<String> {
     let n = lane.agent_sessions.len();
     (n > 1).then(|| format!("×{n}"))
+}
+
+/// A short 1-4 word summary of an agent session for the expanded sidebar: the user's `custom_label`
+/// when set, else the first few words of the session's title (its opening prompt), else its last
+/// message, falling back to the agent name.
+fn agent_summary(sess: &repomon_core::model::AgentSession) -> String {
+    if let Some(l) = &sess.custom_label {
+        if !l.is_empty() {
+            return l.clone();
+        }
+    }
+    let src = sess
+        .title
+        .as_deref()
+        .or(sess.last_message.as_deref())
+        .unwrap_or("");
+    let words: Vec<&str> = src.split_whitespace().take(4).collect();
+    if words.is_empty() {
+        sess.agent.short().to_string()
+    } else {
+        words.join(" ")
+    }
+}
+
+/// One agent sub-row under an expanded lane: `↳ summary   <status glyph>`. While the selected row
+/// is being renamed, shows the live edit buffer with a cursor instead of the summary.
+fn agent_subrow(
+    sess: &repomon_core::model::AgentSession,
+    app: &App,
+    selected: bool,
+) -> Line<'static> {
+    use repomon_core::model::AgentStatus;
+    let (glyph, gstyle) = match sess.status {
+        AgentStatus::RateLimited => (theme::RATE_LIMITED, app.theme.rate_limited()),
+        AgentStatus::Waiting => (theme::WAITING, app.theme.needs_you()),
+        AgentStatus::Running => (theme::AGENT_ACTIVE, app.theme.running()),
+        _ if sess.inferred => (theme::INFERRED_ACTIVE, app.theme.dim()),
+        _ => ("·", app.theme.dim()),
+    };
+    let summary = if selected && app.renaming {
+        format!("{}_", app.rename_buf) // live rename buffer + cursor
+    } else {
+        trunc(&agent_summary(sess), 30)
+    };
+    if selected {
+        return Line::from(Span::styled(
+            format!("     ↳ {summary}  {glyph}"),
+            app.theme.selected(),
+        ));
+    }
+    Line::from(vec![
+        Span::raw("     ↳ "),
+        Span::styled(format!("{summary:<30}"), app.theme.muted()),
+        Span::raw(" "),
+        Span::styled(glyph.to_string(), gstyle),
+    ])
 }
 
 fn lane_row(lane: &Lane, now: DateTime<Utc>, app: &App, selected: bool) -> Line<'static> {

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -19,7 +19,7 @@ use crate::theme;
 const FLEET_KEYS: &str =
     "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term · R rename  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · g/G needs-you · C auto-cont  ·  2 timeline · 3 sessions · 4 search  ·  spc grid · q";
 const SPLIT_KEYS: &str =
-    "↑↓ lane · tab session  ·  click focus · wheel/PgUp scroll · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · C auto-cont  ·  ←/esc back";
+    "↑↓ lane · tab session  ·  click focus · wheel/PgUp scroll · dbl terminal · ↵ open · → focus · i quick-type  ·  e spawn · o adopt · R rename · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str =
     "keys → agent (esc · ⇧⇥ · ^C sent) · PgUp/PgDn scroll  ·  ^O / click-out blur";
 const FOCUS_CMD_KEYS: &str =

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -193,7 +193,7 @@ fn render_settings(f: &mut Frame, app: &App) {
         s.default_agent.clone()
     };
     let onoff = |b: bool| if b { "on" } else { "off" }.to_string();
-    let items: [(&str, String, &str); 17] = [
+    let items: [(&str, String, &str); 18] = [
         ("accent", s.accent.clone(), "←/→ cycle · live"),
         ("default agent", default_agent, "←/→ cycle"),
         ("auto-continue", onoff(s.auto_continue), "space toggles"),
@@ -237,6 +237,11 @@ fn render_settings(f: &mut Frame, app: &App) {
             "  · click focuses terminal",
             onoff(s.notify_click_focus),
             "needs terminal-notifier",
+        ),
+        (
+            "  · subagents finishing",
+            onoff(s.notify_subagents),
+            "off = only the main agent",
         ),
         (
             "usage corner (spawns claude)",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -169,6 +169,21 @@ Codex's 5-hour/weekly or (Free plan) monthly. Caveats, by design:
   PM`), or shows nothing. If a tool restyles its screen, recapture the fixture
   (`crates/repomon-core/src/agent/fixtures/`) and adjust the parser.
 
+## Expanded agent rows + rename
+
+By default a lane running several agents shows as one sidebar row with an `×N` badge. Turn on
+**`expand agent rows`** in Settings (`,`) to instead show the lane as a small tree: the lane header
+(keeping `×N`) with one indented row per agent — `↳ <summary>  <status>`. The summary is auto-derived
+(the first 1–4 words of that agent's opening prompt), and each agent's own status glyph is shown, so
+you can see and select individual agents directly in the Fleet/Split sidebars. Up/down navigate the
+rows; selecting an agent row makes it the active agent (Enter/focus/attach/stop/keys target it).
+
+Press **`R`** on a selected agent row to **rename** it inline (Enter saves, Esc cancels; an empty
+name clears the custom label). The label persists in the daemon keyed by the agent's transcript id,
+so it survives refreshes and daemon restarts, and never bleeds onto a different agent that later
+reuses the slot. (Sessions without a transcript id yet — a just-spawned placeholder — can't be
+renamed until their transcript appears.) See `session.rename` in `docs/protocol.md`.
+
 ## External sessions (running in another terminal)
 
 Because status comes from the transcript, a `claude` you start in any other terminal inside a

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -76,6 +76,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.signal` | `{ lane_id, key, window? }` | `null` |
 | `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
 | `agent.pin` | `{ lane_id, pinned }` | `null` |
+| `session.rename` | `{ session_id, label? }` | `null` (set/clear a user label for a session, keyed by its durable transcript id; empty/absent `label` clears it; overlaid onto `AgentSession.custom_label`) |
 | `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
 | `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
 | `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |


### PR DESCRIPTION
## What

An opt-in **"expand agent rows"** Settings toggle. When on, a lane running several agents renders in the **Fleet and Split sidebars** as a tree — the lane header (keeping its `×N` badge) with one indented row per agent:

```
 AliHamzaAzam
  ● main                    ×3
     ↳ refactor parser      ▶
     ↳ write tests          ⏸
     ↳ fix CI flake         ▶
```

Each agent row is individually selectable (up/down), and selecting one makes it the active agent (focus/attach/stop/keys target it). The summary is auto-derived from the agent's opening prompt (1–4 words); press **`R`** to rename it inline. Default **off** → behavior is byte-identical to before.

## How

- **Selection model**: `fleet_rows()` projects visible lanes into `(lane, optional agent)` rows; `selected` indexes that. The existing per-agent session cursor (`session_idx`/`selected_window`) is *driven by* the selected row, so the ~15 agent-targeting call sites needed no changes. `ClickZone` carries the agent; refresh/jump/grid/click re-anchor by row (stable across the 1s refresh via `SessionRef`).
- **Rename persistence**: keyed by the durable transcript `session_id` (survives refreshes + daemon restarts; never bleeds onto a slot's successor). New `session_labels` table (migration 0004), `session.rename` RPC, `AgentSession.custom_label` overlaid in `overlay_agents`.
- **Tree rendering** + summary in both sidebars; `expand_agents` settings toggle + config plumbing.

## Verification

- Unit tests for `fleet_rows` (collapsed = one row/lane; expanded = header + sub-rows for multi-agent lanes). Full `cargo test` + clippy green.
- `session.rename` → store → overlay → `custom_label` confirmed **live** on the daemon (set/clear round-trip).
- Ran a 10-agent **adversarial review** of the diff; it confirmed 7 expand-mode defects (Tab cycling reverting, spawn not focusing the new agent, toggle jumping the cursor, and rename retargeting under coalesced input / mid-rename refresh / mouse clicks) — **all fixed** in this branch and re-tested.

## Notes

- Rename is triggered from the **Fleet** sidebar (`R` on an agent row); the Split sidebar also shows the tree.
- Couldn't headlessly screenshot the live tree (it renders only in the interactive TUI, which loads settings at startup) — the rendering is unit-tested + the daemon path verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)