### PR TITLE
fix(agents): reap orphaned lane windows + order sub-rows by slot

### DIFF
--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -6,7 +6,7 @@
 //! there with full scrollback. All methods are synchronous; the daemon calls them from
 //! `spawn_blocking`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::error::{Error, Result};
@@ -51,6 +51,33 @@ impl TmuxRuntime {
         } else {
             format!("lane-{lane}-{slot}")
         }
+    }
+
+    /// Parse a managed agent window name back into `(lane, slot)` — the inverse of
+    /// [`window_name`]/[`slot_name`]. `lane-7` → `(7, 1)`, `lane-7-3` → `(7, 3)`. Returns `None`
+    /// for any name that isn't a well-formed lane window (a terminal, the usage probe, or a
+    /// malformed `lane-…`), so callers can safely ignore non-agent windows. Matches the exact
+    /// shapes [`lane_windows_in`] counts, so the reaper and the overlay agree on what's a slot.
+    pub fn parse_lane_window(name: &str) -> Option<(LaneId, usize)> {
+        let rest = name.strip_prefix("lane-")?;
+        match rest.split_once('-') {
+            None => rest.parse::<LaneId>().ok().map(|id| (id, 1)),
+            Some((id, slot)) => {
+                let id = id.parse::<LaneId>().ok()?;
+                let slot = slot.parse::<usize>().ok().filter(|&s| s >= 2)?;
+                Some((id, slot))
+            }
+        }
+    }
+
+    /// The lane a managed window belongs to, or `None` if it isn't a lane window.
+    pub fn lane_id_of(name: &str) -> Option<LaneId> {
+        Self::parse_lane_window(name).map(|(id, _)| id)
+    }
+
+    /// The 1-based agent slot a managed window occupies, or `None` if it isn't a lane window.
+    pub fn slot_of_window(name: &str) -> Option<usize> {
+        Self::parse_lane_window(name).map(|(_, slot)| slot)
     }
 
     /// Filter `names` down to `lane`'s agent windows, in slot order (= spawn order). Exact
@@ -166,6 +193,31 @@ impl TmuxRuntime {
         let out =
             self.run_allow_absent(&["list-windows", "-t", &self.session, "-F", "#{window_name}"])?;
         Ok(out.lines().map(str::to_string).collect())
+    }
+
+    /// Each window's name, current pane working directory, and last pane-activity time (Unix
+    /// epoch seconds). Used by the orphan reaper: the cwd spots `lane-<id>` windows whose cwd no
+    /// longer matches the worktree that id maps to (a stale window left by a re-registered /
+    /// renumbered worktree), and the activity time lets it spare a window whose agent is still
+    /// actively producing output.
+    pub fn list_windows_with_activity(&self) -> Result<Vec<(String, PathBuf, i64)>> {
+        let out = self.run_allow_absent(&[
+            "list-windows",
+            "-t",
+            &self.session,
+            "-F",
+            "#{window_name}\t#{pane_current_path}\t#{window_activity}",
+        ])?;
+        Ok(out
+            .lines()
+            .filter_map(|l| {
+                let mut it = l.splitn(3, '\t');
+                let name = it.next()?.to_string();
+                let path = PathBuf::from(it.next()?);
+                let activity = it.next().and_then(|s| s.trim().parse::<i64>().ok()).unwrap_or(0);
+                Some((name, path, activity))
+            })
+            .collect())
     }
 
     pub fn has_window(&self, lane: LaneId) -> bool {
@@ -514,6 +566,31 @@ mod tests {
         );
         assert_eq!(TmuxRuntime::lane_windows_in(&names, 12), vec!["lane-12"]);
         assert!(TmuxRuntime::lane_windows_in(&names, 3).is_empty());
+    }
+
+    #[test]
+    fn parses_lane_windows_back_to_id_and_slot() {
+        // Base window is slot 1; `-N` suffix is slot N (N >= 2).
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-7"), Some((7, 1)));
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-7-2"), Some((7, 2)));
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-81-3"), Some((81, 3)));
+        // Non-lane windows and malformed names are not agent windows.
+        assert_eq!(TmuxRuntime::parse_lane_window("term-1"), None);
+        assert_eq!(TmuxRuntime::parse_lane_window("usage-probe-work"), None);
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-"), None);
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-1-x"), None);
+        // Slot 1 is only ever spelled `lane-7`, never `lane-7-1`.
+        assert_eq!(TmuxRuntime::parse_lane_window("lane-7-1"), None);
+    }
+
+    #[test]
+    fn lane_id_and_slot_accessors() {
+        assert_eq!(TmuxRuntime::lane_id_of("lane-42-2"), Some(42));
+        assert_eq!(TmuxRuntime::lane_id_of("lane-42"), Some(42));
+        assert_eq!(TmuxRuntime::lane_id_of("term-1"), None);
+        assert_eq!(TmuxRuntime::slot_of_window("lane-42"), Some(1));
+        assert_eq!(TmuxRuntime::slot_of_window("lane-42-3"), Some(3));
+        assert_eq!(TmuxRuntime::slot_of_window("term-1"), None);
     }
 
     #[test]

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -8,6 +8,7 @@ pub mod auto_continue;
 pub mod notify_watch;
 pub mod pubsub;
 pub mod push;
+pub mod reap;
 pub mod remote;
 pub mod rpc;
 pub mod socket;

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -142,6 +142,12 @@ async fn main() {
     // `[usage_probe]` and a TUI being attached, so it costs nothing until enabled and watched.
     tokio::spawn(repomon_daemon::usage_watch::usage_watcher(ctx.clone()));
 
+    // Reap orphaned `lane-<id>` windows whose id no longer maps to the worktree they claim —
+    // leftovers from a re-registered worktree or a store reset the long-lived tmux server
+    // outlived. Sweeps immediately on startup, then slowly, so phantom "exited" sessions
+    // (idle `claude` processes that never exit on their own) clean themselves up.
+    tokio::spawn(repomon_daemon::reap::reap_watcher(ctx.clone()));
+
     // Index commit history in the background (timeline / sessions / search).
     {
         let indexer = repomon_core::Indexer::new(ctx.store.clone(), ctx.registry.clone());

--- a/crates/repomon-daemon/src/reap.rs
+++ b/crates/repomon-daemon/src/reap.rs
@@ -1,0 +1,195 @@
+//! Orphaned agent-window reaper.
+//!
+//! repomon's tmux server (`tmux -L <session>`) is long-lived — it survives daemon restarts and
+//! even a wiped store. When the store is reset or a worktree is re-registered, lane ids get
+//! reassigned, but the `lane-<id>` windows spawned under the old ids keep running. Those windows
+//! (and their idle `claude` processes, which never exit on their own) become unreachable garbage:
+//! they no longer map to the worktree their name claims, yet their cwd still inflates the
+//! path-keyed live-process count in `overlay_agents`, surfacing phantom "external" sessions the
+//! user can't dismiss. This module finds and kills them.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use repomon_core::agent::tmux::TmuxRuntime;
+use repomon_core::model::LaneId;
+
+use crate::Ctx;
+
+/// How often the reaper sweeps. The first sweep runs immediately (tokio interval fires at once),
+/// so a daemon that just started against a tmux server full of stale windows self-heals on boot;
+/// the slow cadence after that catches runtime churn without racing freshly-spawned windows.
+const TICK: Duration = Duration::from_secs(60);
+
+/// A managed tmux window as the reaper sees it: name, canonical pane cwd, and whether its agent
+/// is currently active (pane produced output within [`RUNNING_GRACE`]).
+struct Win {
+    name: String,
+    cwd: PathBuf,
+    active: bool,
+}
+
+/// Output silence after which an orphan's agent is treated as idle (not running) and so reapable.
+/// An actively-working `claude` streams tokens/tool output continuously, so its window's activity
+/// time stays fresh; an idle one sitting at its prompt goes quiet. Generous, so a brief lull in a
+/// long task doesn't get an active agent reaped — the user's "don't reap a running agent" rule.
+const RUNNING_GRACE: Duration = Duration::from_secs(300);
+
+/// Names of stale `lane-<id>` agent windows to reap: the id maps to no current lane, or the
+/// worktree for that id no longer lives at the window's pane cwd. Both mean the window is a
+/// leftover from a re-registered / renumbered worktree (e.g. the tmux server outliving a store
+/// reset) — a managed `claude` is spawned with `-c <worktree>` and never chdirs, so a cwd
+/// mismatch is proof the window belongs to a defunct generation. An **active** window is never
+/// reaped, even when orphaned, so a still-running agent is left alone. Non-lane windows
+/// (terminals, the usage probe) are ignored.
+fn orphan_lane_windows(windows: &[Win], lane_paths: &HashMap<LaneId, PathBuf>) -> Vec<String> {
+    windows
+        .iter()
+        .filter_map(|w| {
+            if w.active {
+                return None; // a running agent is spared regardless of orphan status
+            }
+            let id = TmuxRuntime::lane_id_of(&w.name)?;
+            match lane_paths.get(&id) {
+                None => Some(w.name.clone()),
+                Some(path) if path != &w.cwd => Some(w.name.clone()),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn canonical(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Find and kill orphaned `lane-<id>` windows once, then drop the overlay cache so the phantom
+/// sessions they were propping up disappear on the next `lane.list`.
+pub async fn reap_orphan_windows(ctx: &Ctx) {
+    let Ok(lanes) = ctx.lanes.list().await else {
+        return;
+    };
+    let lane_paths: HashMap<LaneId, PathBuf> = lanes
+        .iter()
+        .map(|l| (l.id, canonical(&l.worktree.path)))
+        .collect();
+
+    let tmux = ctx.tmux.clone();
+    let raw = match tokio::task::spawn_blocking(move || tmux.list_windows_with_activity()).await {
+        Ok(Ok(w)) => w,
+        _ => return,
+    };
+    let now = chrono::Utc::now().timestamp();
+    let windows: Vec<Win> = raw
+        .into_iter()
+        .map(|(name, cwd, activity)| Win {
+            name,
+            cwd: canonical(&cwd),
+            active: now.saturating_sub(activity) < RUNNING_GRACE.as_secs() as i64,
+        })
+        .collect();
+
+    let orphans = orphan_lane_windows(&windows, &lane_paths);
+    if orphans.is_empty() {
+        return;
+    }
+    tracing::info!(?orphans, "reaping orphaned agent windows");
+
+    let tmux = ctx.tmux.clone();
+    let to_kill = orphans.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        for w in &to_kill {
+            let _ = tmux.kill_named(w);
+        }
+    })
+    .await;
+    ctx.invalidate_overlay().await;
+}
+
+/// Periodic reaper task; the first sweep runs immediately (covers daemon startup).
+pub async fn reap_watcher(ctx: Arc<Ctx>) {
+    let mut tick = tokio::time::interval(TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tick.tick().await;
+        reap_orphan_windows(&ctx).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    /// An idle managed window (the common reaper input).
+    fn idle(name: &str, cwd: &str) -> Win {
+        Win {
+            name: name.to_string(),
+            cwd: p(cwd),
+            active: false,
+        }
+    }
+
+    #[test]
+    fn flags_renumbered_and_unknown_lane_windows() {
+        // The real bug: the tmux server outlives store generations, so a repo (here at /aaa, now
+        // lane 35) ends up with leftover windows named for ids it used to have — lane-81 (now no
+        // lane at all) and lane-42 (that id has since been reused for a different worktree, /sxx).
+        // Both are orphans; only windows whose id+cwd match a current lane are kept.
+        let lane_paths: HashMap<LaneId, PathBuf> = [
+            (1, p("/repo")),
+            (35, p("/aaa")),
+            (42, p("/sxx")),
+        ]
+        .into_iter()
+        .collect();
+
+        let windows = vec![
+            idle("lane-81", "/aaa"),   // id 81: no such lane -> orphan
+            idle("lane-81-2", "/aaa"), // orphan
+            idle("lane-42", "/aaa"),   // id 42 is now /sxx, not /aaa -> cwd mismatch -> orphan
+            idle("lane-1", "/repo"),   // matches lane 1 -> keep
+            idle("lane-35", "/aaa"),   // matches lane 35 -> keep
+            idle("term-1", "/anywhere"),         // not a lane window -> ignored
+            idle("usage-probe-work", "/anywhere"), // not a lane window -> ignored
+        ];
+
+        assert_eq!(
+            orphan_lane_windows(&windows, &lane_paths),
+            vec!["lane-81", "lane-81-2", "lane-42"]
+        );
+    }
+
+    #[test]
+    fn keeps_everything_when_all_windows_match() {
+        let lane_paths: HashMap<LaneId, PathBuf> =
+            [(1, p("/repo")), (2, p("/other"))].into_iter().collect();
+        let windows = vec![
+            idle("lane-1", "/repo"),
+            idle("lane-1-2", "/repo"),
+            idle("lane-2", "/other"),
+        ];
+        assert!(orphan_lane_windows(&windows, &lane_paths).is_empty());
+    }
+
+    #[test]
+    fn spares_orphans_with_a_running_agent() {
+        // An orphan whose agent is actively producing output is left alone (the user's
+        // "don't reap a running agent" rule); the idle orphan beside it is still reaped.
+        let lane_paths: HashMap<LaneId, PathBuf> = HashMap::new(); // no current lanes -> all orphan
+        let windows = vec![
+            Win {
+                name: "lane-2".to_string(),
+                cwd: p("/Users/x/Developer/Work/SAAS"),
+                active: true,
+            },
+            idle("lane-13", "/Users/x/Developer/Aven/flick"),
+        ];
+        assert_eq!(orphan_lane_windows(&windows, &lane_paths), vec!["lane-13"]);
+    }
+}

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -22,6 +22,7 @@ use repomon_core::notify::{
     SessKey,
 };
 use repomon_core::protocol::Notification;
+use repomon_core::TmuxRuntime;
 use serde_json::json;
 use tokio::sync::{broadcast, mpsc};
 
@@ -3248,6 +3249,25 @@ impl App {
     }
 
     async fn stop_agent(&mut self) {
+        // On an expanded agent sub-row with no tmux window — an external (not repomon-managed)
+        // session — there's nothing to kill, and falling through would kill the lane's primary
+        // window by default. The daemon reaps genuinely-orphaned windows on its own.
+        if let Some(FleetRow {
+            lane_idx,
+            session: Some(s),
+        }) = self.selected_row()
+        {
+            let windowless = self
+                .visible_lanes()
+                .into_iter()
+                .nth(lane_idx)
+                .and_then(|l| l.agent_sessions.get(s))
+                .is_some_and(|sess| sess.tmux_window.is_none());
+            if windowless {
+                self.status = "external session — not managed by repomon".into();
+                return;
+            }
+        }
         if let Some(id) = self.selected_lane().map(|l| l.id) {
             let _ = self
                 .client
@@ -3616,17 +3636,19 @@ enum SessionRef {
     Transcript(String),
 }
 
-/// Indices into `sessions` in a STABLE display order — by durable identity (`session_id`, then
-/// transcript path / window) — so expanded sub-rows (and their user labels) keep their position
-/// instead of reshuffling when the daemon re-sorts sessions by recent activity.
+/// Indices into `sessions` in a STABLE display order — managed agents by tmux **slot** (= spawn
+/// order: `lane-N`, `lane-N-2`, `lane-N-3`), then windowless/external sessions by start time — so
+/// expanded sub-rows (and their user labels) keep their position instead of reshuffling when the
+/// daemon re-sorts sessions by recent activity. `session_id` is only the final tiebreaker.
 fn stable_session_order(sessions: &[AgentSession]) -> Vec<usize> {
     let mut idx: Vec<usize> = (0..sessions.len()).collect();
     let key = |s: &AgentSession| {
-        (
-            s.session_id.clone(),
-            s.manifest_path.clone(),
-            s.tmux_window.clone(),
-        )
+        let slot = s
+            .tmux_window
+            .as_deref()
+            .and_then(TmuxRuntime::slot_of_window)
+            .unwrap_or(usize::MAX);
+        (slot, s.started_at, s.session_id.clone())
     };
     idx.sort_by(|&a, &b| key(&sessions[a]).cmp(&key(&sessions[b])));
     idx
@@ -4153,26 +4175,29 @@ mod tests {
     }
 
     #[test]
-    fn stable_session_order_sorts_by_durable_id() {
-        // Order follows session_id (stable), NOT the input order (which the daemon churns by
-        // activity), so renamed sub-rows hold their position. Input ids c, a, b → indices 1,2,0.
+    fn stable_session_order_follows_spawn_slot() {
+        // Managed agents order by tmux slot (lane-N, lane-N-2, lane-N-3), NOT by session_id and
+        // NOT by the daemon's input order (it churns by recent activity) — so sub-rows hold their
+        // position instead of reshuffling. session_ids here are anti-correlated with slot to prove
+        // the slot drives the order.
         let sessions = [
-            sess(Some("ccc"), AgentStatus::Running, false),
-            sess(Some("aaa"), AgentStatus::Running, false),
-            sess(Some("bbb"), AgentStatus::Running, false),
+            managed("lane-7", Some("zzz")),
+            managed("lane-7-2", Some("mmm")),
+            managed("lane-7-3", Some("aaa")),
         ];
-        assert_eq!(stable_session_order(&sessions), vec![1, 2, 0]);
-        // Reversing the input yields the SAME display order (stability under reshuffle).
-        let rev = [
-            sess(Some("bbb"), AgentStatus::Running, false),
-            sess(Some("aaa"), AgentStatus::Running, false),
-            sess(Some("ccc"), AgentStatus::Running, false),
-        ];
-        let ordered: Vec<&str> = stable_session_order(&rev)
+        let ordered: Vec<&str> = stable_session_order(&sessions)
             .into_iter()
-            .map(|i| rev[i].session_id.as_deref().unwrap())
+            .map(|i| sessions[i].tmux_window.as_deref().unwrap())
             .collect();
-        assert_eq!(ordered, vec!["aaa", "bbb", "ccc"]);
+        assert_eq!(ordered, vec!["lane-7", "lane-7-2", "lane-7-3"]);
+
+        // A windowless (external) session sorts after every managed one, regardless of its id.
+        let mixed = [
+            sess(Some("aaa"), AgentStatus::Running, false),
+            managed("lane-7-2", Some("mmm")),
+            managed("lane-7", Some("zzz")),
+        ];
+        assert_eq!(stable_session_order(&mixed), vec![2, 1, 0]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

FleetView showed phantom "exited" agents that couldn't be dismissed, and agent sub-rows reshuffled unpredictably.

**Root cause:** the `tmux -L repomon` server outlives store/DB generations, so `lane-<id>` windows linger with ids that no longer map to their lane (e.g. a repo that's now `lane-81` still has leftover `lane-42`/`lane-13` windows from earlier ids). A `claude` sitting idle at its prompt never exits, so these orphans keep running. Because the daemon's live-process count is keyed by cwd **path** (not lane), the orphan processes inflate the count for the real lane sharing that path — surfacing external phantom sessions with **no window the user can kill**. Separately, sub-rows were sorted by transcript **UUID** over a set whose membership flapped, hence the jumbling.

## Changes

- **`core/agent/tmux`** — `parse_lane_window` / `lane_id_of` / `slot_of_window` (inverse of the window-name helpers), and `list_windows_with_activity` returning `(name, cwd, last-activity epoch)`.
- **`daemon/reap`** (new) — kills `lane-<id>` windows whose id maps to no current lane, **or** whose pane cwd ≠ that lane's worktree path. **Never reaps a window whose agent is actively producing output** (`RUNNING_GRACE`), so a running agent is left alone even if orphaned. Sweeps immediately on daemon startup, then every 60s. Wired into `main.rs`.
- **`tui/app`** — `stable_session_order` now sorts by tmux **slot** (= spawn order), not UUID; pressing `s` on a windowless external row no longer kills the lane's primary agent.

## Tests

- TDD throughout: unit tests for `parse_lane_window`/`lane_id_of`/`slot_of_window`, the orphan predicate (id-absent, cwd-mismatch, and *spare-active* cases), and slot ordering.
- Full workspace green (`repomon-core` 118, `repomon-daemon` 24, `repomon-tui` + integration), clippy clean.

## Verified live

Installed + restarted the daemon: reaper logged `orphans=["lane-42","lane-42-2","lane-13"]`, kept all legit lanes (and the active SAAS deploy-poller), phantom rows gone, `claude` procs 6 → 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)