### PR TITLE
fix(overlay,tui): survive transient probe flaps instead of dropping agents

### DIFF
--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -88,6 +88,10 @@ pub struct Ctx {
     /// count immediately so the vanished agent drops from the `×N` count without waiting out the
     /// `live_cwds` cache TTL.
     pub last_managed_windows: Mutex<HashSet<String>>,
+    /// Last tmux window list a probe returned successfully. Reused for one overlay tick when
+    /// `list_windows` fails transiently (fork/connection fault under load), so a single bad
+    /// snapshot doesn't drop every managed agent — see `rpc::resolve_windows`.
+    pub last_good_windows: Mutex<Vec<String>>,
     pub shutdown: Notify,
 }
 
@@ -136,6 +140,7 @@ impl Ctx {
             local_watcher_seen: Mutex::new(None),
             input_seen: Mutex::new(HashMap::new()),
             last_managed_windows: Mutex::new(HashSet::new()),
+            last_good_windows: Mutex::new(Vec::new()),
             shutdown: Notify::new(),
         })
     }

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -118,10 +118,22 @@ pub async fn notify_watch(ctx: Arc<Ctx>) {
                 .find(|l| l.id == key.0)
                 .and_then(|l| session_by_key(l, &key.1, subagents))
                 .map(|s| s.last_activity_at);
-            if kind != NotifKind::Idle
-                && !activity_allows_refire(latch.get(&dkey).map(|(t, _)| *t), activity)
-            {
+            let prev_fired = latch.get(&dkey).map(|(t, _)| *t);
+            if kind != NotifKind::Idle && !activity_allows_refire(prev_fired, activity) {
                 continue;
+            }
+            // Diagnostic for the "repeats an alert I already handled" report: a re-fire is only
+            // legitimate when the transcript advanced since last time (current_activity > prev_fired).
+            // If these logs show a re-fire with current_activity <= prev_fired (or prev_fired None
+            // for a session that clearly fired before), the latch is being bypassed.
+            if kind == NotifKind::NeedsYou {
+                tracing::info!(
+                    lane = key.0,
+                    session = ?key.1,
+                    prev_fired = ?prev_fired,
+                    current_activity = ?activity,
+                    "notify: NeedsYou firing"
+                );
             }
             debounce.insert(dkey.clone(), Instant::now());
             if kind != NotifKind::Idle {

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1234,9 +1234,23 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // User-set session labels (keyed by transcript session_id), overlaid below.
     let labels = ctx.store.list_session_labels().await.unwrap_or_default();
     let tmux = ctx.tmux.clone();
-    let windows = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
-        .await
-        .unwrap_or_default();
+    // Distinguish a *failed* probe from a genuinely empty server: on failure reuse the last-good
+    // window set for this tick (a transient tmux fork/connection fault must not momentarily drop
+    // every managed agent — that flips sessions to `external`, detaches the focused TUI, and fires
+    // stale notifications). A real empty result still clears.
+    let fresh: Result<Vec<String>, String> =
+        match tokio::task::spawn_blocking(move || tmux.list_windows()).await {
+            Ok(Ok(w)) => Ok(w),
+            Ok(Err(e)) => Err(e.to_string()),
+            Err(e) => Err(e.to_string()),
+        };
+    if let Err(ref e) = fresh {
+        tracing::warn!("tmux list-windows failed; reusing last-good window set this overlay: {e}");
+    }
+    let windows = {
+        let mut last_good = ctx.last_good_windows.lock().await;
+        resolve_windows(fresh, &mut last_good)
+    };
     // If a managed (`lane-…`) window vanished since the last overlay — an agent `/exit`ed or was
     // stopped — the cached live-process count is now stale-high and would keep the dead session in
     // the lane's `×N` count for up to the cache TTL. Drop the cache so `live_cwds_cached` recomputes
@@ -1634,6 +1648,21 @@ fn placeholder_window_index(shown: usize, managed_n: usize) -> Option<usize> {
     (managed_n > shown).then(|| managed_n - 1)
 }
 
+/// Pick the tmux window list for this overlay tick. On a successful probe, return the fresh list
+/// and remember it as last-good. On a probe *failure* (a transient fork/connection fault, e.g.
+/// `tmux` failing to spawn under load — distinct from a genuinely empty server), reuse the
+/// last-good list so a single bad snapshot doesn't momentarily drop every managed agent — which
+/// would flip sessions to `external`, detach the focused TUI, and fire stale notifications.
+fn resolve_windows(fresh: Result<Vec<String>, String>, last_good: &mut Vec<String>) -> Vec<String> {
+    match fresh {
+        Ok(w) => {
+            *last_good = w.clone();
+            w
+        }
+        Err(_) => last_good.clone(),
+    }
+}
+
 /// How many live `claude` CLI processes have each working directory. claude doesn't hold its
 /// transcript open, but its cwd is the worktree it runs in — so the count per worktree bounds
 /// how many of that worktree's sessions are actually running. `None` if the probe couldn't
@@ -1679,10 +1708,16 @@ async fn live_cwds_cached(ctx: &Ctx) -> Option<HashMap<PathBuf, usize>> {
             }
         }
     }
-    let map = tokio::task::spawn_blocking(live_claude_cwds)
-        .await
-        .ok()
-        .flatten()?;
+    let map = match tokio::task::spawn_blocking(live_claude_cwds).await.ok().flatten() {
+        Some(m) => m,
+        None => {
+            // The probe couldn't run (pgrep/lsof spawn failed, e.g. under load). Returning None
+            // means "don't filter" — callers keep all recent sessions rather than truncating to a
+            // bogus low count — but it was silent; log it so a recurring flap is visible.
+            tracing::warn!("live claude-process probe (pgrep/lsof) failed; not truncating sessions");
+            return None;
+        }
+    };
     // Sticky-high: a single `pgrep`/`lsof` undercount must not drop a session from the overlay
     // (then re-add it next probe), which churns the lane list and used to re-fire alerts. Hold each
     // worktree's highest recently-observed count for a short grace, so one bad sample can't hide a
@@ -1791,6 +1826,26 @@ async fn commits_in_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_windows_reuses_last_good_only_on_probe_failure() {
+        let mut last: Vec<String> = vec![];
+        // A successful probe is returned verbatim and remembered as last-good.
+        assert_eq!(
+            resolve_windows(Ok(vec!["lane-1".into(), "lane-2".into()]), &mut last),
+            vec!["lane-1", "lane-2"]
+        );
+        assert_eq!(last, vec!["lane-1", "lane-2"]);
+        // A probe FAILURE reuses last-good instead of collapsing to empty (no spurious drop).
+        assert_eq!(
+            resolve_windows(Err("tmux spawn failed".into()), &mut last),
+            vec!["lane-1", "lane-2"]
+        );
+        assert_eq!(last, vec!["lane-1", "lane-2"]); // unchanged by failure
+        // A genuinely empty SUCCESS still clears (every agent really exited).
+        assert_eq!(resolve_windows(Ok(vec![]), &mut last), Vec::<String>::new());
+        assert!(last.is_empty());
+    }
 
     #[test]
     fn placeholder_for_the_newest_unpaired_window() {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -184,6 +184,10 @@ pub struct App {
     /// True while Focus is driving a repomon-managed agent — so when it exits (`/exit` or
     /// stop) we can drop back out of Focus instead of staring at a dead pane.
     focus_managed: bool,
+    /// Consecutive lane refreshes the focused agent has been absent. Detach (Focus → Split) only
+    /// once it reaches [`FOCUS_DETACH_GRACE`], so a transient overlay flap that drops the session
+    /// for a refresh or two doesn't kick the user out of a still-running agent.
+    focus_missing_ticks: u8,
     /// Whether repomon captures the mouse (for scroll-wheel nav). When off, the terminal owns
     /// the mouse so you can drag-select and copy the rendered output natively.
     pub mouse_on: bool,
@@ -374,6 +378,7 @@ impl App {
             output: HashMap::new(),
             focus_insert: false,
             focus_managed: false,
+            focus_missing_ticks: 0,
             // Mouse captured so the wheel scrolls the agent pane and drag-selects copy to the
             // clipboard. `y` releases it for native terminal selection/scroll if preferred.
             mouse_on: true,
@@ -525,6 +530,17 @@ impl App {
                 self.sort_lanes();
                 if let Some(id) = keep {
                     self.select_lane_session(id, keep_ref);
+                }
+                // Track how many consecutive refreshes the focused agent has been missing, so a
+                // transient overlay flap (one bad snapshot) doesn't detach the user — only a
+                // sustained absence does. Counted here (per data refresh), consumed by
+                // `check_focus_alive` (which runs every render tick). See [`FOCUS_DETACH_GRACE`].
+                if self.focus_managed {
+                    let present = self
+                        .selected_lane()
+                        .map(|l| l.agent_sessions.iter().any(|s| !s.external))
+                        .unwrap_or(false);
+                    self.focus_missing_ticks = next_focus_missing(present, self.focus_missing_ticks);
                 }
             }
             Err(e) => self.status = format!("lane.list failed: {e}"),
@@ -1237,6 +1253,7 @@ impl App {
     fn check_focus_alive(&mut self) {
         if self.view != View::Focus {
             self.focus_managed = false;
+            self.focus_missing_ticks = 0;
             return;
         }
         let has_managed = self
@@ -1245,8 +1262,12 @@ impl App {
             .unwrap_or(false);
         if has_managed {
             self.focus_managed = true;
-        } else if self.focus_managed {
+            self.focus_missing_ticks = 0;
+        } else if self.focus_managed && self.focus_missing_ticks >= FOCUS_DETACH_GRACE {
+            // Sustained absence (counted per lane refresh in `refresh_lanes`, not per render tick)
+            // — a real exit, not a one-snapshot flap. Drop back to Split.
             self.focus_managed = false;
+            self.focus_missing_ticks = 0;
             self.focus_insert = false;
             self.view = View::Split;
             self.status = "agent exited".into();
@@ -3636,6 +3657,23 @@ enum SessionRef {
     Transcript(String),
 }
 
+/// Consecutive lane refreshes a focused lane may show no managed session before Focus detaches.
+/// More than one, so a single transient overlay flap (one bad snapshot — a tmux/lsof probe blip)
+/// doesn't kick the user out of a still-running agent; a real exit stays absent and detaches
+/// within ~grace refreshes.
+const FOCUS_DETACH_GRACE: u8 = 3;
+
+/// Next consecutive-missing count for the focused agent after a lane refresh: reset to 0 when a
+/// managed session is present, else incremented (saturating). Counted per refresh (≈1s), NOT per
+/// render tick, so the grace measures seconds rather than event-loop iterations.
+fn next_focus_missing(present: bool, missing: u8) -> u8 {
+    if present {
+        0
+    } else {
+        missing.saturating_add(1)
+    }
+}
+
 /// Indices into `sessions` in a STABLE display order — managed agents by tmux **slot** (= spawn
 /// order: `lane-N`, `lane-N-2`, `lane-N-3`), then windowless/external sessions by start time — so
 /// expanded sub-rows (and their user labels) keep their position instead of reshuffling when the
@@ -4172,6 +4210,26 @@ mod tests {
         );
         assert_eq!(attention_rank(&[sess(None, Waiting, true)], true), 3);
         assert_eq!(attention_rank(&[], true), 3);
+    }
+
+    #[test]
+    fn focus_detach_waits_for_sustained_absence() {
+        // A present managed session resets the miss count (recovered flap).
+        assert_eq!(next_focus_missing(true, 2), 0);
+        // Consecutive absences accumulate, staying below the grace for the first couple refreshes…
+        let mut m = 0u8;
+        m = next_focus_missing(false, m);
+        assert_eq!(m, 1);
+        assert!(m < FOCUS_DETACH_GRACE, "one flap must not detach");
+        m = next_focus_missing(false, m);
+        assert_eq!(m, 2);
+        assert!(m < FOCUS_DETACH_GRACE, "a two-tick flap must not detach");
+        // …until a sustained absence reaches the grace (a real exit).
+        m = next_focus_missing(false, m);
+        assert_eq!(m, 3);
+        assert!(m >= FOCUS_DETACH_GRACE, "sustained absence detaches");
+        // A flicker back resets, so the next single absence won't detach.
+        assert_eq!(next_focus_missing(true, m), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

repomon was glitchy: agents intermittently disappeared (flicker back), the TUI detached from a focused agent **at random / when idle**, and notifications re-fired "needs you" for already-handled agents.

**Investigation cleared the v0.2.1 reaper** — the full daemon log shows it ran exactly once (startup) and never since; `err.log` empty. The symptoms share one root: **a managed session momentarily drops out of a single overlay snapshot, and every consumer over-reacts to that one bad snapshot.** The overlay was silently swallowing transient tmux/`lsof` probe failures (`unwrap_or_default()` → empty), and `check_focus_alive` detached instantly with no grace.

## Changes

- **Overlay resilience** (`rpc.rs` + `Ctx.last_good_windows` in `lib.rs`): a *failed* `tmux list-windows` reuses the last-good window set instead of collapsing to empty (a fork/connection blip under load no longer drops every managed agent). A genuinely empty result still clears. Both probe failures now emit a **WARN** instead of being silent.
- **Detach grace** (`app.rs`): Focus detaches only after the managed session is absent for `FOCUS_DETACH_GRACE` (3) **consecutive lane refreshes**, counted per refresh (not per render tick), so a one-snapshot flap can't kick the user out.
- **Notification diagnostic** (`notify_watch.rs`): logs each `NeedsYou` fire with prior-fired vs current activity timestamps — **no behavior change**; the anti-flap latch is left intact pending this evidence.

## Tests

- TDD: `resolve_windows` (reuse-on-failure / clear-on-empty), `next_focus_missing` + `FOCUS_DETACH_GRACE` (one/two-tick flap doesn't detach; sustained absence does).
- Full workspace green (core 118, daemon 25, tui + integration), clippy clean.

## Verified live

Rebuilt + restarted the daemon (v0.2.1): all 7 running agents (lanes 1 + 2) survived, startup reaper found no orphans, no probe WARNs, daemon serving normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)