### PR TITLE
fix(security): close agent.adopt RCE + lock down the remote bridge (audit PR1)

### DIFF
--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -164,7 +164,12 @@ pub fn agent_variants() -> Vec<(String, String)> {
                     .unwrap_or_else(|| "claude".to_string());
                 (
                     label,
-                    format!("CLAUDE_CONFIG_DIR={} claude", base.display()),
+                    // Runs via `sh -c` (tmux new-window), so quote the path — a config dir with a
+                    // space or shell metacharacter must not break the `VAR=val cmd` parse or inject.
+                    format!(
+                        "CLAUDE_CONFIG_DIR={} claude",
+                        super::shell_quote(&base.display().to_string())
+                    ),
                 )
             }
         })

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -15,6 +15,14 @@ use crate::error::{Error, Result};
 
 pub const DEFAULT_WORKTREE_TEMPLATE: &str = "~/code/{repo}-wt/{branch}";
 pub const DEFAULT_TMUX_SESSION: &str = "repomon";
+
+/// A tmux session name is safe to use as the `-L <label>` socket and in `session:window` targets.
+/// It's injected into many tmux command args, so restrict it to `[A-Za-z0-9_-]` — a name with a
+/// `:`, `=`, whitespace, or other metachar would corrupt target resolution (`exact_target` builds
+/// `{session}:={window}`). Empty is invalid.
+pub fn valid_tmux_session(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
 pub const DEFAULT_TIME_FORMAT: &str = "%H:%M %a %d %b %Y";
 
 /// Top-level user configuration.
@@ -175,7 +183,20 @@ impl Config {
     /// Load config from a specific file (used by tests; [`load`] wraps this).
     pub fn load_from(path: &std::path::Path) -> Result<Config> {
         match std::fs::read_to_string(path) {
-            Ok(s) => toml::from_str(&s).map_err(|e| Error::Config(e.to_string())),
+            Ok(s) => {
+                let mut cfg: Config = toml::from_str(&s).map_err(|e| Error::Config(e.to_string()))?;
+                // A malformed tmux session name would corrupt every tmux target it's spliced into;
+                // reset to the default rather than fail the daemon over a bad config char.
+                if !valid_tmux_session(&cfg.tmux_session) {
+                    tracing::warn!(
+                        "invalid tmux_session {:?} in config; using {:?}",
+                        cfg.tmux_session,
+                        DEFAULT_TMUX_SESSION
+                    );
+                    cfg.tmux_session = DEFAULT_TMUX_SESSION.to_string();
+                }
+                Ok(cfg)
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
             Err(e) => Err(Error::Io(e)),
         }
@@ -305,6 +326,26 @@ fn default_socket_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tmux_session_name_validation() {
+        assert!(valid_tmux_session("repomon"));
+        assert!(valid_tmux_session("work-2_b"));
+        assert!(!valid_tmux_session("")); // empty
+        assert!(!valid_tmux_session("a:b")); // colon corrupts session:window targets
+        assert!(!valid_tmux_session("a b")); // whitespace
+        assert!(!valid_tmux_session("a=b"));
+        assert!(!valid_tmux_session("a;rm -rf"));
+    }
+
+    #[test]
+    fn invalid_tmux_session_falls_back_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "tmux_session = \"bad:name\"\n").unwrap();
+        let c = Config::load_from(&path).unwrap();
+        assert_eq!(c.tmux_session, DEFAULT_TMUX_SESSION);
+    }
 
     #[test]
     fn defaults_are_sane() {

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -24,6 +24,11 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0004_session_labels.sql"),
 ];
 
+/// Cap on registered push devices. Re-registration refreshes a token's timestamp; beyond this the
+/// oldest are evicted, so a misbehaving/abusive client can't grow the table (or per-alert APNs
+/// fan-out) without bound.
+const MAX_DEVICES: usize = 32;
+
 type Job = Box<dyn FnOnce(&mut Connection) + Send + 'static>;
 
 /// A handle to the store. Cheap to clone; all clones talk to the same worker thread.
@@ -314,6 +319,13 @@ impl Store {
                 "INSERT INTO devices (device_token, registered_at) VALUES (?1, ?2)
                  ON CONFLICT(device_token) DO UPDATE SET registered_at = ?2",
                 params![token, Utc::now().to_rfc3339()],
+            )?;
+            // Keep only the newest MAX_DEVICES tokens so an abusive client can't grow the table
+            // (or the per-alert APNs fan-out) without bound.
+            c.execute(
+                "DELETE FROM devices WHERE device_token NOT IN
+                 (SELECT device_token FROM devices ORDER BY registered_at DESC LIMIT ?1)",
+                params![MAX_DEVICES as i64],
             )?;
             Ok(())
         })
@@ -707,6 +719,20 @@ mod tests {
     async fn migrates_and_starts_empty() {
         let s = store().await;
         assert!(s.list_repos().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_device_caps_to_newest() {
+        let s = store().await;
+        for i in 0..(MAX_DEVICES + 5) {
+            // registered_at is set to now(); distinct tokens, newest registered last.
+            s.register_device(format!("token-{i:03}")).await.unwrap();
+        }
+        let devices = s.list_devices().await.unwrap();
+        assert_eq!(devices.len(), MAX_DEVICES, "device count is capped");
+        // The earliest tokens were evicted; the most recent survive.
+        assert!(devices.iter().any(|t| t == &format!("token-{:03}", MAX_DEVICES + 4)));
+        assert!(!devices.iter().any(|t| t == "token-000"));
     }
 
     #[tokio::test]

--- a/crates/repomon-daemon/src/push.rs
+++ b/crates/repomon-daemon/src/push.rs
@@ -13,6 +13,7 @@ use a2::{
     Client, ClientConfig, CollapseId, DefaultNotificationBuilder, Endpoint, ErrorReason,
     NotificationBuilder, NotificationOptions, Priority,
 };
+use futures::StreamExt;
 use repomon_core::config::PushConfig;
 use serde_json::Value;
 
@@ -134,17 +135,25 @@ pub async fn send_all(ctx: &Arc<Ctx>, title: &str, body: &str, category: &str, d
     let Some(push) = Push::from_config(&cfg) else {
         return;
     };
-    for token in devices {
-        match push.send(&token, title, body, category, data).await {
-            Ok(true) => {}
-            Ok(false) => {
-                tracing::info!(
-                    "push: evicting dead device token {}…",
-                    &token[..8.min(token.len())]
-                );
-                let _ = ctx.store.unregister_device(token).await;
+    // Send concurrently (bounded) rather than serially, so N devices don't add N round-trips of
+    // latency to every alert; the device cap keeps N small regardless.
+    const SEND_CONCURRENCY: usize = 8;
+    futures::stream::iter(devices)
+        .for_each_concurrent(SEND_CONCURRENCY, |token| {
+            let push = &push;
+            async move {
+                match push.send(&token, title, body, category, data).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::info!(
+                            "push: evicting dead device token {}…",
+                            &token[..8.min(token.len())]
+                        );
+                        let _ = ctx.store.unregister_device(token).await;
+                    }
+                    Err(e) => tracing::warn!("push: send failed: {e}"),
+                }
             }
-            Err(e) => tracing::warn!("push: send failed: {e}"),
-        }
-    }
+        })
+        .await;
 }

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -7,33 +7,92 @@
 //! connection state. Bind this to a private address — typically the machine's Tailscale IP —
 //! never the open internet.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use futures::{SinkExt, StreamExt};
-use repomon_core::protocol::{Request, Response, RpcError};
+use repomon_core::protocol::{Request, Response, RpcError, MAX_FRAME_BYTES};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast::error::RecvError;
 use tokio_tungstenite::tungstenite::handshake::server::{
     ErrorResponse, Request as HsRequest, Response as HsResponse,
 };
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::{rpc, Ctx};
+
+/// Max concurrent remote connections — a coarse DoS backstop (auth precedes the upgrade, so this
+/// only bounds authenticated clients/reconnect churn).
+const MAX_REMOTE_CONNS: usize = 64;
+
+/// WebSocket frame/message limits for the bridge. Matches the Unix socket's `MAX_FRAME_BYTES` so a
+/// large `agent.capture` isn't truncated, but is set explicitly rather than left to tungstenite's
+/// default (which gave the remote path no stated bound).
+fn remote_ws_config() -> WebSocketConfig {
+    WebSocketConfig::default()
+        .max_message_size(Some(MAX_FRAME_BYTES))
+        .max_frame_size(Some(MAX_FRAME_BYTES))
+}
+
+/// Decrements the live-connection counter when a handler task ends.
+struct ConnGuard(Arc<AtomicUsize>);
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Methods the remote WebSocket bridge may invoke. **Default-deny**: anything not listed here
+/// (including any future RPC) is rejected over the network, so the bridge can't be used to manage
+/// the host. Allows read + interaction with *existing* agents and the companion's own push
+/// registration; blocks host-management (repo/lane/worktree mutation, agent spawn/adopt/stop,
+/// config writes, terminal/filesystem access, daemon shutdown) and secret-exposing reads
+/// (`config.get` can carry the remote token). The local Unix socket is unaffected.
+fn remote_method_allowed(method: &str) -> bool {
+    matches!(
+        method,
+        // health check
+        "ping"
+        // reads
+        | "repo.list" | "lane.list" | "lane.get"
+        | "commit.today" | "commit.range" | "commit.search" | "commit.recent"
+        | "agent.capture" | "agent.transcript"
+        | "usage.get" | "daemon.status"
+        // event stream + per-client streaming hint
+        | "subscribe" | "viewport.set"
+        // drive an existing agent
+        | "agent.send_input" | "agent.signal" | "agent.key" | "agent.scroll"
+        | "agent.target" | "agent.resize"
+        // benign metadata
+        | "agent.pin" | "session.rename"
+        // companion self-registration for push
+        | "push.register" | "push.unregister"
+    )
+}
 
 /// Bind the WebSocket bridge and serve until shutdown is requested.
 pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str, token: String) -> std::io::Result<()> {
     let listener = TcpListener::bind(bind).await?;
     tracing::info!("remote bridge listening on ws://{bind}");
     let token = Arc::new(token);
+    let conns = Arc::new(AtomicUsize::new(0));
 
     loop {
         tokio::select! {
             _ = ctx.shutdown.notified() => break,
             accepted = listener.accept() => match accepted {
                 Ok((stream, addr)) => {
+                    // Reserve a slot; over the cap we drop the connection (guard decrements).
+                    let guard = ConnGuard(conns.clone());
+                    if conns.fetch_add(1, Ordering::Relaxed) >= MAX_REMOTE_CONNS {
+                        tracing::warn!("remote connection cap reached, dropping {addr}");
+                        continue; // `guard` drops here, undoing the increment
+                    }
                     let ctx = ctx.clone();
                     let token = token.clone();
                     tokio::spawn(async move {
+                        let _guard = guard;
                         if let Err(e) = handle_conn(ctx, stream, &token).await {
                             tracing::debug!("remote conn {addr}: {e}");
                         }
@@ -56,9 +115,12 @@ async fn handle_conn(
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
     // Check the token during the handshake — an unauthorized client never completes the
     // upgrade and learns nothing but "401".
-    let ws =
-        tokio_tungstenite::accept_hdr_async(stream, |req: &HsRequest, resp| auth(req, resp, token))
-            .await?;
+    let ws = tokio_tungstenite::accept_hdr_async_with_config(
+        stream,
+        |req: &HsRequest, resp| auth(req, resp, token),
+        Some(remote_ws_config()),
+    )
+    .await?;
     let (mut sink, mut source) = ws.split();
 
     // Every connection holds an event receiver, but only forwards once subscribed —
@@ -88,13 +150,25 @@ async fn handle_conn(
                         continue;
                     }
                 };
-                if req.method == "subscribe" {
-                    forwarding = true;
-                }
                 let id = req.id;
-                let resp = match rpc::dispatch(&ctx, &req.method, req.params).await {
-                    Ok(value) => Response::ok(id, value),
-                    Err(err) => Response::err(id, err),
+                let resp = if remote_method_allowed(&req.method) {
+                    if req.method == "subscribe" {
+                        forwarding = true;
+                    }
+                    match rpc::dispatch(&ctx, &req.method, req.params).await {
+                        Ok(value) => Response::ok(id, value),
+                        Err(err) => Response::err(id, err),
+                    }
+                } else {
+                    // Default-deny: host-management RPCs aren't reachable over the network.
+                    tracing::warn!("remote bridge rejected method {:?}", req.method);
+                    Response::err(
+                        id,
+                        RpcError::new(
+                            -32601,
+                            format!("method '{}' not permitted over remote bridge", req.method),
+                        ),
+                    )
                 };
                 send_json(&mut sink, &resp).await?;
             }
@@ -177,5 +251,28 @@ mod tests {
         assert!(!constant_time_eq(b"secret", b"secrex"));
         assert!(!constant_time_eq(b"secret", b"secret1"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn remote_allowlist_permits_read_and_interaction_only() {
+        // Read + interaction with existing agents, and the companion's own push registration.
+        for m in [
+            "ping", "repo.list",
+            "lane.list", "lane.get", "commit.recent", "agent.capture", "agent.transcript",
+            "agent.send_input", "agent.signal", "agent.key", "agent.scroll", "agent.target",
+            "agent.resize", "agent.pin", "subscribe", "viewport.set", "usage.get",
+            "daemon.status", "push.register", "push.unregister", "session.rename",
+        ] {
+            assert!(remote_method_allowed(m), "{m} should be allowed");
+        }
+        // Host-management, dangerous, and secret-exposing methods are blocked over the bridge.
+        for m in [
+            "agent.adopt", "agent.spawn", "agent.stop", "repo.add", "repo.remove", "repo.discover",
+            "lane.create", "lane.delete", "lane.merge", "lane.focus", "config.get", "config.set",
+            "terminal.open", "fs.browse", "daemon.shutdown", "agent.add", "agent.remove",
+            "agent.detect", "watcher.park", "some.future.method",
+        ] {
+            assert!(!remote_method_allowed(m), "{m} must be blocked");
+        }
     }
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -760,6 +760,13 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 let cfg = ctx.config.read().await;
                 (cfg.default_agent.clone(), cfg.agents.clone())
             };
+            // `command` is ultimately run via `sh -c` by tmux, so a session id that isn't a plain
+            // transcript id (UUID / `[A-Za-z0-9_-]`) could inject shell. Reject it up front.
+            if let Some(sid) = &p.session_id {
+                if !valid_session_id(sid) {
+                    return Err(RpcError::invalid_params("invalid session_id"));
+                }
+            }
             let detect = path.clone();
             let session_id = p.session_id.clone();
             let command = tokio::task::spawn_blocking(move || {
@@ -767,7 +774,8 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 let (config_dir, resume) = match &session_id {
                     Some(sid) => (
                         agent::claude::config_base_for_session(&detect, sid).flatten(),
-                        format!("--resume {sid}"),
+                        // Validated above; quote anyway as defense-in-depth.
+                        format!("--resume {}", agent::tmux::shell_quote(sid)),
                     ),
                     None => (
                         agent::claude::summary_for(&detect).and_then(|s| s.config_dir),
@@ -1648,6 +1656,14 @@ fn placeholder_window_index(shown: usize, managed_n: usize) -> Option<usize> {
     (managed_n > shown).then(|| managed_n - 1)
 }
 
+/// A Claude session id is safe to interpolate into a resume command (`claude --resume <id>`).
+/// Transcript ids are UUIDs / `[A-Za-z0-9_-]`; anything else (whitespace, `;`, `$`, quotes, `|`,
+/// backticks…) is rejected so `agent.adopt` can't be turned into shell injection — the command is
+/// ultimately run via `sh -c` by tmux. Empty is invalid.
+fn valid_session_id(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// Pick the tmux window list for this overlay tick. On a successful probe, return the fresh list
 /// and remember it as last-good. On a probe *failure* (a transient fork/connection fault, e.g.
 /// `tmux` failing to spawn under load — distinct from a genuinely empty server), reuse the
@@ -1826,6 +1842,21 @@ async fn commits_in_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_id_validation_blocks_injection() {
+        // Real transcript ids pass.
+        assert!(valid_session_id("44ba81d8-be2c-4f0b-b9b3-c228fa53cc79"));
+        assert!(valid_session_id("abc_123-DEF"));
+        // Anything that could break out of `claude --resume <id>` under `sh -c` is rejected.
+        assert!(!valid_session_id("")); // empty
+        assert!(!valid_session_id("x; touch /tmp/pwned"));
+        assert!(!valid_session_id("$(id)"));
+        assert!(!valid_session_id("a`whoami`"));
+        assert!(!valid_session_id("a b")); // whitespace
+        assert!(!valid_session_id("a|b"));
+        assert!(!valid_session_id("../../etc"));
+    }
 
     #[test]
     fn resolve_windows_reuses_last_good_only_on_probe_failure() {


### PR DESCRIPTION
First of the phased audit PRs — **security**.

## What & why
The remote WebSocket bridge forwarded the *entire* local RPC dispatch, and `agent.adopt` shell-injected its `session_id` (run via `sh -c` by tmux) — together a **remote-reachable RCE**.

- **`agent.adopt` (rpc.rs):** validate `session_id` to `[A-Za-z0-9_-]` and `shell_quote` it; reject crafted ids. (`agent.spawn` already quoted its task.)
- **Remote bridge (remote.rs):** strict **default-deny** method allowlist — only read + interaction with *existing* agents and the companion's own push registration. Host-management (repo/lane/worktree mutation, agent spawn/adopt/stop, config writes, terminal/fs, `daemon.shutdown`) is rejected over the network. The local Unix socket is unaffected.
- **Remote bridge:** explicit WebSocket message/frame size limits + a concurrent-connection cap.
- **Push (store + push.rs):** cap registered devices to the newest `MAX_DEVICES` (evict oldest); send APNs concurrently (bounded) instead of serially.
- **Shell strings (claude.rs/config.rs):** `shell_quote` the `CLAUDE_CONFIG_DIR` path; validate `config.tmux_session` to `[A-Za-z0-9_-]` at load (reset to default on bad input, no hard fail).

## Tests
TDD throughout: `session_id` validator (injection rejected), remote allowlist allow/deny table, `tmux_session` validation + fallback, device-cap eviction. Full workspace suite green (incl. the remote integration test, updated to expect `ping`/`repo.list` allowed).

Part of the phased audit-fix plan; reliability / root-cause / TUI PRs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)