### PR TITLE
fix(tui): defensive indexing, sync ordering, flush-before-attach (audit PR4)

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1184,7 +1184,7 @@ impl App {
                     }
                     None => {
                         self.pending_focus_ticks = self.pending_focus_ticks.saturating_add(1);
-                        if self.pending_focus_ticks > 5 {
+                        if self.pending_focus_ticks > PENDING_FOCUS_GIVE_UP_TICKS {
                             self.pending_focus_window = None;
                             self.pending_focus_ticks = 0;
                         }
@@ -3663,6 +3663,10 @@ enum SessionRef {
 /// within ~grace refreshes.
 const FOCUS_DETACH_GRACE: u8 = 3;
 
+/// How many ~1s refreshes to keep trying to land the cursor on a just-spawned agent's window
+/// before giving up (the transcript/window may take a moment to appear).
+const PENDING_FOCUS_GIVE_UP_TICKS: u8 = 5;
+
 /// Next consecutive-missing count for the focused agent after a lane refresh: reset to 0 when a
 /// managed session is present, else incremented (saturating). Counted per refresh (≈1s), NOT per
 /// render tick, so the grace measures seconds rather than event-loop iterations.
@@ -3775,11 +3779,13 @@ async fn event_loop(
     let mut events_alive = true;
     let mut tick = tokio::time::interval(Duration::from_secs(1));
     loop {
+        // Resolve the selected session/window BEFORE syncing the viewport, so a just-spawned
+        // window isn't momentarily streamed as the wrong pane (selected_window() is correct).
+        app.sync_session_cursor();
         app.sync_viewport().await;
         app.sync_pane_size().await;
         app.sync_recent_commits().await;
         app.sync_terminals().await;
-        app.sync_session_cursor();
         app.sync_title();
         app.check_focus_alive();
         // Expire a stale notification banner so the footer hints come back.
@@ -3869,6 +3875,10 @@ async fn event_loop(
 /// Suspend the TUI, attach to the lane's tmux window (the selected agent's, when several run
 /// side by side), then re-enter.
 async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) {
+    // Flush any input buffered just before the attach (e.g. a paste finished as the user hit attach)
+    // so it isn't silently dropped when the TUI suspends — attach requested outside the input burst
+    // skips the event-loop's post-burst flush.
+    app.flush_pending_input().await;
     let window = app.selected_window();
     let resp = app
         .client

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -1608,7 +1608,10 @@ fn fleet_lines(
         let selected = ri == app.selected;
         let mut line = match row.session {
             None => lane_row(lane, now, app, selected),
-            Some(s) => agent_subrow(&lane.agent_sessions[s], app, selected),
+            Some(s) => match lane.agent_sessions.get(s) {
+                Some(sess) => agent_subrow(sess, app, selected),
+                None => continue, // index stale (lane list changed mid-frame) — skip defensively
+            },
         };
         if !selected && row.session.is_none() && app.hover_lane == Some(lane.id) {
             line = line.style(app.theme.hover());
@@ -1689,7 +1692,10 @@ fn sidebar_lines(app: &App, content: Rect) -> Vec<Line<'static>> {
                     Line::from(spans)
                 }
             }
-            Some(s) => agent_subrow(&lane.agent_sessions[s], app, selected),
+            Some(s) => match lane.agent_sessions.get(s) {
+                Some(sess) => agent_subrow(sess, app, selected),
+                None => continue, // index stale (lane list changed mid-frame) — skip defensively
+            },
         };
         if !selected && row.session.is_none() && app.hover_lane == Some(lane.id) {
             line = line.style(app.theme.hover());


### PR DESCRIPTION
Final phased audit PR — **TUI robustness**.

- **view.rs:** the two `lane.agent_sessions[s]` raw indexes now use `.get(s)` and skip the row if the index is stale — a lane list that changes mid-frame can no longer panic the whole TUI.
- **app.rs event loop:** resolve the selected session/window (`sync_session_cursor`) **before** `sync_viewport`, so a just-spawned window isn't briefly streamed as the wrong pane.
- **`do_attach`:** flush pending input before suspending the TUI, so a paste finished right as the user hits attach isn't dropped.
- name the pending-focus give-up magic number (`PENDING_FOCUS_GIVE_UP_TICKS`).

## Deferred with rationale (analyzed, not worth the change)
- **T2 lost-popup** — the audit premise is incorrect: only the unix socket bumps `local_watcher_seen` (socket.rs:109), **not** the remote bridge, so the iOS app can't keep it fresh; and with two local TUIs the active one fires its own popups. Effectively a non-bug.
- **T3a multi-fallback wrong session, T3d dismiss-during-concurrent-fire, T3e tiny-terminal scroll budget** — rare edges / cosmetic.

## Tests
Full workspace suite green (129 core / 30 daemon / 9 integration / 2 remote / 20 tui), clippy clean. (These are event-loop/render changes not unit-testable without a full TUI harness; the indexing change is purely defensive.)

Completes the audit-fix series: #29 (security), #30 (reliability), #32 (root-cause/leaks), this (TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)