### PR TITLE
fix(tui): stop stale [detached] on quit + harden attach stdin handoff

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -4004,6 +4004,14 @@ fn tmux_attach(target: &str) {
         start.elapsed().as_secs_f32(),
         status.as_ref().ok().map(|s| s.code())
     ));
+    // On detach, tmux prints "[detached (from session …)]" to the PRIMARY screen (it just left its
+    // own alternate screen). repomon re-enters its alternate screen and hides it during use — but
+    // it resurfaces when repomon finally exits the alternate screen on quit. We're on the primary
+    // screen right now, so wipe it (clear + home) to leave a clean terminal behind on quit.
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    let _ = write!(out, "\x1b[H\x1b[2J");
+    let _ = out.flush();
 }
 
 /// Append a timestamped diagnostic line to the TUI log. The TUI can't use tracing/stderr (ratatui

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -3952,6 +3952,10 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     // notification edge-detection so the next refresh doesn't replay — and double-fire — them.
     app.notif_reseed = true;
     app.status = "back from the agent (it's still running) — ↵ to reopen".into();
+    // Snap straight back to FleetView: paint now, in the freshly re-init'd alternate screen, so the
+    // user doesn't sit looking at tmux's "[detached]" line + a stale/garbled screen while the next
+    // loop iteration's sync RPCs (which run before its own draw) complete.
+    let _ = terminal.draw(|f| view::render(f, app));
 }
 
 /// Suspend the TUI, attach to an arbitrary tmux target (e.g. a plain terminal), then re-enter.
@@ -3978,6 +3982,8 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
     app.terminals_lane = None; // the shell may have exited; refresh the terminal list
     // Re-seed notification edge-detection — the daemon owned popups while we were parked.
     app.notif_reseed = true;
+    // Paint immediately on return (see do_attach) so the detach message + stale screen don't linger.
+    let _ = terminal.draw(|f| view::render(f, app));
 }
 
 /// Attach to a `session:window` target on repomon's dedicated tmux socket (the socket label is

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -346,6 +346,10 @@ pub struct App {
     attach_target: Option<String>,
     /// When set, the stdin-reader thread pauses (so tmux owns the terminal during an attach).
     input_suspended: Arc<AtomicBool>,
+    /// Set by the reader thread once it has actually entered its paused branch — so an attach waits
+    /// for a CONFIRMED handoff (the reader is no longer touching stdin) instead of a guessed sleep,
+    /// preventing the reader from fighting tmux for the terminal (split input / spurious detach).
+    reader_parked: Arc<AtomicBool>,
     /// Per-account Claude usage (from the daemon's `/usage` probe), shown in the bottom-right
     /// corner for the focused agent's account. Empty unless `usage_probe` is enabled.
     pub usage: Vec<repomon_core::agent::AccountUsage>,
@@ -469,6 +473,7 @@ impl App {
             attach_request: None,
             attach_target: None,
             input_suspended: Arc::new(AtomicBool::new(false)),
+            reader_parked: Arc::new(AtomicBool::new(false)),
             usage: Vec::new(),
             last_usage_fetch: None,
         }
@@ -1365,6 +1370,21 @@ impl App {
         self.selected_lane()
             .and_then(|l| l.agent_sessions.get(self.session_idx))
             .and_then(|s| s.tmux_window.clone())
+    }
+
+    /// Wait (bounded) for the stdin reader thread to confirm it has parked, so `tmux attach` gets
+    /// sole ownership of the terminal — a confirmed handoff instead of a guessed sleep, so the
+    /// reader can't keep reading stdin and split keystrokes with tmux (which corrupts the terminal
+    /// and can feed tmux a sequence it misreads as a detach key). Bounded (~400ms) so a reader
+    /// wedged in a blocking read can't hang the attach; a timeout is logged for diagnosis.
+    async fn await_reader_parked(&self) {
+        for _ in 0..40 {
+            if self.reader_parked.load(Ordering::Relaxed) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        tui_log("WARN reader did not park before attach; terminal handoff may be racy");
     }
 
     /// The usage account key of the agent the user is looking at — the selected lane's selected
@@ -3593,13 +3613,18 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     // don't fight tmux for the terminal — otherwise keystrokes get split and the session
     // misbehaves. Polling (rather than a blocking read) lets us check the flag.
     let suspended = app.input_suspended.clone();
+    let parked = app.reader_parked.clone();
     std::thread::spawn(move || {
         use ratatui::crossterm::event;
         loop {
             if suspended.load(Ordering::Relaxed) {
-                std::thread::sleep(Duration::from_millis(40));
+                // Announce we're parked so an attach knows stdin is fully released to tmux, and
+                // poll the flag on a short interval so we resume promptly.
+                parked.store(true, Ordering::Relaxed);
+                std::thread::sleep(Duration::from_millis(20));
                 continue;
             }
+            parked.store(false, Ordering::Relaxed);
             match event::poll(Duration::from_millis(100)) {
                 Ok(true) => match event::read() {
                     Ok(ev) => {
@@ -3910,7 +3935,7 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     // Tell the daemon we're parking now so it takes over desktop popups on its next tick rather
     // than waiting out LOCAL_TTL for our heartbeat to go stale — closes the handoff gap.
     let _ = app.client.call("watcher.park", None).await;
-    tokio::time::sleep(Duration::from_millis(120)).await; // let the reader thread release stdin
+    app.await_reader_parked().await; // confirmed handoff: reader has released stdin to tmux
     disable_mouse();
     ratatui::restore();
     tmux_attach(&target);
@@ -3937,7 +3962,7 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
     app.input_suspended.store(true, Ordering::Relaxed);
     // Signal the park so the daemon covers desktop popups immediately (see do_attach).
     let _ = app.client.call("watcher.park", None).await;
-    tokio::time::sleep(Duration::from_millis(120)).await; // let the reader thread release stdin
+    app.await_reader_parked().await; // confirmed handoff: reader has released stdin to tmux
     disable_mouse();
     ratatui::restore();
     tmux_attach(target);
@@ -3960,10 +3985,34 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
 /// otherwise tmux refuses to attach ("sessions should be nested with care").
 fn tmux_attach(target: &str) {
     let socket = target.split(':').next().unwrap_or("repomon");
-    let _ = std::process::Command::new("tmux")
+    tui_log(&format!("attach -> {target}"));
+    let start = std::time::Instant::now();
+    let status = std::process::Command::new("tmux")
         .args(["-L", socket, "attach", "-t", target])
         .env_remove("TMUX")
         .status();
+    // Log when (and how) the attach ended so an *unexpected* detach is traceable after the fact:
+    // a very short duration / non-zero exit points at a failed attach or an external detach.
+    tui_log(&format!(
+        "attach <- {target} after {:.1}s status={:?}",
+        start.elapsed().as_secs_f32(),
+        status.as_ref().ok().map(|s| s.code())
+    ));
+}
+
+/// Append a timestamped diagnostic line to the TUI log. The TUI can't use tracing/stderr (ratatui
+/// owns the screen), so attach/detach diagnostics go straight to a file next to the daemon log.
+fn tui_log(line: &str) {
+    use std::io::Write;
+    let dir = repomon_core::service::log_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("repomon-tui.log"))
+    {
+        let _ = writeln!(f, "{} {line}", chrono::Utc::now().to_rfc3339());
+    }
 }
 
 /// Translate a key press into a tmux key spec. `(spec, literal)` — literal printable text


### PR DESCRIPTION
## What

Recovers and lands the three-commit fix for the full-screen-agent attach/detach experience. The branch was authored against v0.2.6 but never merged; this rebases it onto current `main` (edition 2024).

## Problem

Focusing a full-screen agent (a real `tmux attach`), detaching with F12, then quitting repomon left `[detached (from session repomon)]` sitting on the terminal, and the TUI sometimes looked frozen or garbled on return.

## Root cause and fixes

Three commits, touching only `crates/repomon-tui/src/app.rs`:

1. **`fix(tui): confirmed stdin handoff on attach`** — the stdin reader thread was paused with a guessed `sleep(120ms)` before handing the terminal to `tmux attach`, so it could still be reading stdin when tmux took over and split keystrokes (terminal corruption, occasional misread as a detach key). Replaced with a `reader_parked` atomic the reader sets when it actually enters its paused branch, plus a bounded (~400ms) `await_reader_parked()` both attach paths await. Adds `tui_log()` diagnostics (attach entry/exit, duration, exit status, park-timeout) to `<log_dir>/repomon-tui.log`.
2. **`fix(tui): snap back to FleetView on agent exit`** — paint FleetView immediately on return so the detached line and a stale frame do not linger during the sync RPCs that run before the next normal draw.
3. **`fix(tui): clear primary screen after attach`** — on detach, tmux prints `[detached (from session repomon)]` to the primary screen; repomon hides it under its alternate screen but it resurfaces on quit. After the attach returns we are on the primary screen, so clear it (`ESC[H ESC[2J`, scrollback preserved). This is the definitive fix for the stale line on quit.

## Verification

- `cargo build --workspace`: clean
- `cargo test --workspace`: all pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

Manual end-to-end (focus agent, F12 detach, confirm immediate FleetView, quit, confirm no `[detached]` residue) to be run against the freshly installed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
