### PR TITLE
fix(accounts): make the default Claude account immune to a leaked CLAUDE_CONFIG_DIR

### DIFF
--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -146,32 +146,50 @@ fn config_bases_uncached() -> Vec<PathBuf> {
     bases
 }
 
+/// The launch command for the Claude account rooted at `base`, immune to a leaked
+/// `CLAUDE_CONFIG_DIR` in the daemon's own environment (the daemon is commonly started from a
+/// `claude-work` shell, so it may carry `CLAUDE_CONFIG_DIR=~/.claude-work`; a bare `claude` would
+/// silently inherit that, making "claude-code" and "claude-work" launch the *same* account).
+///
+/// - **Default account (`~/.claude`):** `env -u CLAUDE_CONFIG_DIR claude` — *unset* the variable.
+///   Claude Code reads the default profile from `~/.claude.json` (HOME) **only when the variable
+///   is unset**; `CLAUDE_CONFIG_DIR=~/.claude` instead points at the vestigial
+///   `~/.claude/.claude.json` stub (no account → onboarding), so we must strip the var, not pin it.
+/// - **Variant account:** `CLAUDE_CONFIG_DIR=<dir> claude` — pin it explicitly (shell-quoted, since
+///   this runs via `sh -c` from tmux `new-window`).
+///
+/// Account identity is unchanged: `account_key`/`account_label` stay keyed on the `config_dir`
+/// option, `command_account` reads the default (no `CLAUDE_CONFIG_DIR=`) back as `None`, and
+/// `program_of` sees through the `env -u …` prefix to the `claude` program.
+pub fn launch_command(base: &Path) -> String {
+    if canonical(base) == canonical(&default_config_base()) {
+        "env -u CLAUDE_CONFIG_DIR claude".to_string()
+    } else {
+        format!(
+            "CLAUDE_CONFIG_DIR={} claude",
+            super::shell_quote(&base.display().to_string())
+        )
+    }
+}
+
 /// Spawnable Claude agents, one per detected config dir: `(name, launch command)`. The default
-/// account is `("claude-code", "claude")`; a `~/.claude-work` dir becomes
-/// `("claude-work", "CLAUDE_CONFIG_DIR=/…/.claude-work claude")`.
+/// account is `("claude-code", "env -u CLAUDE_CONFIG_DIR claude")`; a `~/.claude-work` dir becomes
+/// `("claude-work", "CLAUDE_CONFIG_DIR=/…/.claude-work claude")`. Each command is immune to a
+/// daemon's own leaked `CLAUDE_CONFIG_DIR` (see [`launch_command`]).
 pub fn agent_variants() -> Vec<(String, String)> {
     let default = default_config_base();
     config_bases()
         .into_iter()
         .map(|base| {
-            if base == default {
-                ("claude-code".to_string(), "claude".to_string())
+            let name = if base == default {
+                "claude-code".to_string()
             } else {
-                let label = base
-                    .file_name()
+                base.file_name()
                     .and_then(|s| s.to_str())
                     .map(|n| n.trim_start_matches('.').to_string())
-                    .unwrap_or_else(|| "claude".to_string());
-                (
-                    label,
-                    // Runs via `sh -c` (tmux new-window), so quote the path — a config dir with a
-                    // space or shell metacharacter must not break the `VAR=val cmd` parse or inject.
-                    format!(
-                        "CLAUDE_CONFIG_DIR={} claude",
-                        super::shell_quote(&base.display().to_string())
-                    ),
-                )
-            }
+                    .unwrap_or_else(|| "claude".to_string())
+            };
+            (name, launch_command(&base))
         })
         .collect()
 }
@@ -779,6 +797,34 @@ pub fn transcript_tail(path: &Path, max_items: usize) -> Vec<crate::model::Trans
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_variant_unsets_config_dir_against_env_leak() {
+        // The daemon is commonly launched from a `claude-work` shell, so its own environment may
+        // carry `CLAUDE_CONFIG_DIR=~/.claude-work`. A bare `claude` for the default account would
+        // inherit that and resolve to the wrong account (making "claude-code" and "claude-work"
+        // spawn the *same* account). The default account must UNSET the variable — not pin it to
+        // `~/.claude`, which reads the vestigial `~/.claude/.claude.json` stub (no account →
+        // onboarding) instead of the real default profile at `~/.claude.json`.
+        let variants = agent_variants();
+        let (_, cmd) = variants
+            .iter()
+            .find(|(n, _)| n == "claude-code")
+            .expect("default claude-code variant is always present");
+        assert_ne!(
+            cmd, "claude",
+            "bare `claude` would inherit a leaked CLAUDE_CONFIG_DIR"
+        );
+        assert!(
+            !cmd.contains("CLAUDE_CONFIG_DIR="),
+            "default must not PIN a config dir (that reads the ~/.claude stub), got: {cmd}"
+        );
+        assert!(
+            cmd.contains("env -u CLAUDE_CONFIG_DIR"),
+            "default must UNSET CLAUDE_CONFIG_DIR so it reads ~/.claude.json, got: {cmd}"
+        );
+        assert!(cmd.ends_with("claude"), "still launches claude, got: {cmd}");
+    }
 
     #[test]
     fn encodes_cwd_like_claude_code() {

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2028,17 +2028,76 @@ fn adopt_base_command(
     candidates.extend(agent::claude::agent_variants().into_iter().map(|(_, c)| c));
     candidates.extend(customs.values().cloned());
 
-    pick_for_account(&candidates, &want).unwrap_or_else(|| match config_dir {
-        Some(d) => format!("CLAUDE_CONFIG_DIR={} claude", d.display()),
-        None => "claude".to_string(),
+    pick_for_account(&candidates, &want).unwrap_or_else(|| {
+        // Build via `launch_command` so the fallback is immune to the daemon's own
+        // CLAUDE_CONFIG_DIR: the default account unsets it (`env -u …`), variants pin their dir.
+        let default = agent::claude::default_config_base();
+        agent::claude::launch_command(config_dir.as_deref().unwrap_or(&default))
     })
 }
 
 /// The account (CLAUDE_CONFIG_DIR, canonicalized) a command targets, or `None` for the default.
+///
+/// Variant accounts launch with an explicit, shell-quoted `CLAUDE_CONFIG_DIR=…` (see
+/// [`agent::claude::launch_command`]); the default account launches as `env -u CLAUDE_CONFIG_DIR
+/// claude` (no assignment). So this is `None` when the assignment is absent, parses the value
+/// honoring shell quoting (a config dir may contain spaces), and normalizes the *default* base back
+/// to `None` so the default account keeps its `None`/`"default"` identity regardless of spelling.
 fn command_account(cmd: &str) -> Option<PathBuf> {
-    cmd.split_whitespace()
-        .find_map(|t| t.strip_prefix("CLAUDE_CONFIG_DIR=").map(PathBuf::from))
-        .map(|p| p.canonicalize().unwrap_or(p))
+    let dir = PathBuf::from(config_dir_arg(cmd)?);
+    let dir = dir.canonicalize().unwrap_or(dir);
+    let default = agent::claude::default_config_base();
+    let default = default.canonicalize().unwrap_or(default);
+    (dir != default).then_some(dir)
+}
+
+/// The `CLAUDE_CONFIG_DIR=` value from a command's leading env assignment, shell-unquoted, or
+/// `None` if absent. Honors the single-quote grouping [`shell_quote`] emits, so a config dir
+/// containing spaces (`CLAUDE_CONFIG_DIR='/a b/.claude' claude`) parses as one whole path rather
+/// than being split on the inner space.
+fn config_dir_arg(cmd: &str) -> Option<String> {
+    const KEY: &str = "CLAUDE_CONFIG_DIR=";
+    let mut from = 0;
+    loop {
+        let at = from + cmd[from..].find(KEY)?;
+        // Only a real leading assignment (start of command, or right after whitespace).
+        if at == 0 || cmd.as_bytes()[at - 1].is_ascii_whitespace() {
+            return Some(unquote_shell_word(&cmd[at + KEY.len()..]));
+        }
+        from = at + KEY.len();
+    }
+}
+
+/// Read and unquote one shell word from the front of `s`, honoring the single-quote grouping and
+/// `'\''` escaping [`shell_quote`] emits; an unquoted word ends at the first whitespace.
+fn unquote_shell_word(s: &str) -> String {
+    let mut out = String::new();
+    let mut chars = s.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        match c {
+            c if c.is_whitespace() => break,
+            '\'' => {
+                chars.next(); // opening quote
+                for c in chars.by_ref() {
+                    if c == '\'' {
+                        break; // closing quote
+                    }
+                    out.push(c);
+                }
+            }
+            '\\' => {
+                chars.next(); // escape: next char is literal
+                if let Some(c) = chars.next() {
+                    out.push(c);
+                }
+            }
+            _ => {
+                out.push(c);
+                chars.next();
+            }
+        }
+    }
+    out
 }
 
 /// The first claude command from `candidates` whose account matches `want`.
@@ -2057,10 +2116,29 @@ fn is_env_assignment(tok: &str) -> bool {
     }
 }
 
-/// The program a command runs, skipping leading env assignments so commands like
-/// `CLAUDE_CONFIG_DIR=~/.claude-work claude` resolve to `claude`.
+/// The program a command runs, skipping a leading env prefix so both `CLAUDE_CONFIG_DIR=… claude`
+/// and `env -u CLAUDE_CONFIG_DIR claude` (the default account's launch, which *unsets* the var)
+/// resolve to `claude`.
 fn program_of(command: &str) -> Option<&str> {
-    command.split_whitespace().find(|t| !is_env_assignment(t))
+    let mut toks = command.split_whitespace().peekable();
+    // A leading `env [-i] [-u NAME]… [NAME=val]… program` — skip `env` and its options/
+    // assignments (note `-u` takes a NAME argument) so the real program surfaces.
+    if toks.peek() == Some(&"env") {
+        toks.next();
+        while let Some(&t) = toks.peek() {
+            if t == "-u" {
+                toks.next(); // the flag
+                toks.next(); // its NAME argument
+            } else if t.starts_with('-') || is_env_assignment(t) {
+                toks.next();
+            } else {
+                break;
+            }
+        }
+        return toks.next();
+    }
+    // Otherwise skip leading `VAR=val` assignments.
+    toks.find(|t| !is_env_assignment(t))
 }
 
 /// The agent kind repomon last spawned in a lane (from its persisted meta), defaulting to Claude
@@ -2626,6 +2704,11 @@ mod tests {
             Some("claude")
         );
         assert_eq!(program_of("FOO=1 BAR=2 aider --model x"), Some("aider"));
+        // The default account's launch UNSETS the var via `env -u` — still resolves to claude.
+        assert_eq!(
+            program_of("env -u CLAUDE_CONFIG_DIR claude"),
+            Some("claude")
+        );
         assert_eq!(program_of(""), None);
         assert!(is_env_assignment("CLAUDE_CONFIG_DIR=/x/.claude-work"));
         assert!(!is_env_assignment("claude"));
@@ -2658,6 +2741,36 @@ mod tests {
             Some(PathBuf::from("/x"))
         );
         assert_eq!(command_account("claude"), None);
+    }
+
+    #[test]
+    fn command_account_normalizes_pinned_default_and_strips_quotes() {
+        // The default account launches with `env -u CLAUDE_CONFIG_DIR claude` (no `CLAUDE_CONFIG_DIR=`
+        // prefix), so it reads back as the *default* account (None).
+        assert_eq!(command_account("env -u CLAUDE_CONFIG_DIR claude"), None);
+        // A hand-written pin to the default base also normalizes to the default account (defensive).
+        let default = agent::claude::default_config_base();
+        assert_eq!(
+            command_account(&format!("CLAUDE_CONFIG_DIR={} claude", default.display())),
+            None
+        );
+        // shell_quote wraps the path in single quotes; the parse must see through them — both for
+        // a variant account...
+        assert_eq!(
+            command_account("CLAUDE_CONFIG_DIR='/h/.claude-work' claude"),
+            Some(PathBuf::from("/h/.claude-work"))
+        );
+        // ...and for a quoted default base (still the default account).
+        assert_eq!(
+            command_account(&format!("CLAUDE_CONFIG_DIR='{}' claude", default.display())),
+            None
+        );
+        // A shell-quoted config dir containing spaces must parse as one whole path, not split on
+        // the inner space (shell_quote wraps it, so command_account must honor the quoting).
+        assert_eq!(
+            command_account("CLAUDE_CONFIG_DIR='/h/with a space/.claude-work' claude"),
+            Some(PathBuf::from("/h/with a space/.claude-work"))
+        );
     }
 
     #[test]

--- a/crates/repomon-daemon/src/usage_watch.rs
+++ b/crates/repomon-daemon/src/usage_watch.rs
@@ -202,10 +202,12 @@ fn accounts() -> Vec<Account> {
         .filter(|base| base.join("projects").is_dir())
         .map(|base| {
             let cfg_dir = (base != default).then(|| base.clone());
-            let command = match &cfg_dir {
-                None => "claude".to_string(),
-                Some(p) => format!("CLAUDE_CONFIG_DIR={} claude", p.display()),
-            };
+            // `launch_command` is immune to the daemon's own env: the default account unsets
+            // CLAUDE_CONFIG_DIR (`env -u …`) while variants pin their dir. A bare `claude` here
+            // would instead inherit the daemon's CLAUDE_CONFIG_DIR (it's started from a claude-work
+            // shell) and probe the wrong account, making two accounts read as one.
+            // `account_key`/`account_label` stay keyed on `cfg_dir`, so identity is intact.
+            let command = agent::claude::launch_command(&base);
             Account {
                 key: agent::claude::account_key(cfg_dir.as_deref()),
                 label: agent::claude::account_label(cfg_dir.as_deref()),


### PR DESCRIPTION
## Problem
The usage probe showed the **same** account for both "main" and "work" (the other account was never probed), and the spawn picker's `claude-code` and `claude-work` both launched the **same** `~/.claude-work` account.

## Root cause
repomon modeled "the default `~/.claude` account" as the *absence* of a `CLAUDE_CONFIG_DIR=` prefix (a bare `claude`). But `repomond` is normally started from a `claude-work` shell, so its own env carries `CLAUDE_CONFIG_DIR=~/.claude-work`, and tmux `new-window` inherits it — so every bare `claude` silently resolved to `~/.claude-work` too.

## Fix
The default account must **unset** the variable, not pin it: Claude Code reads its default profile from `~/.claude.json` (HOME) **only when `CLAUDE_CONFIG_DIR` is unset** (`process.env.CLAUDE_CONFIG_DIR || homedir()` joined with `.claude.json`). Setting `CLAUDE_CONFIG_DIR=~/.claude` instead reads the vestigial `~/.claude/.claude.json` stub (no account → onboarding).

`agent::claude::launch_command(base)`:
- default base → `env -u CLAUDE_CONFIG_DIR claude` (strip the leaked var)
- variant base → `CLAUDE_CONFIG_DIR=<dir> claude` (pin, shell-quoted)

Routed the spawn variants, the usage probe, and the adopt fallback through it. Account identity is unchanged: `account_key`/`account_label` stay keyed on the `config_dir` option; `command_account` reads the default (no prefix) as `None` and strips shell-quotes; `program_of` sees through the `env -u …` prefix.

The orchestrator's no-agent fallback is intentionally left bare `claude` (changing it would alter the running orchestrator's account); tracked separately.

## Tests / verification
- Regression tests: the default variant unsets (not pins) the config dir; `program_of` / `command_account` handle the `env -u` default and shell-quoted variants. Full workspace green, clippy clean.
- **Verified live** under the daemon's leak env: `main` → `azaleasazam@icloud.com`, `work` → `00starsolutions@gmail.com` (two distinct accounts; previously both were gmail). Confirmed the pinned form drops to onboarding, the `env -u` form comes up logged-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
