### PR TITLE
feat: switchable repomind orchestrator backend (Claude + Codex)

### DIFF
--- a/crates/repomon-core/src/agent/limit.rs
+++ b/crates/repomon-core/src/agent/limit.rs
@@ -57,15 +57,16 @@ fn is_wait_option(lower_text: &str) -> bool {
     lower_text.contains("stop and wait") || lower_text.contains("wait for limit")
 }
 
-/// Parse one menu-option-shaped line: optional `❯` cursor, optional `N.` number, then text.
-/// Returns `(has_cursor, number, text)`; `None` when the line isn't option-shaped.
-/// (Shared with the pending-prompt detector in [`super::prompt`].)
+/// Parse one menu-option-shaped line: optional selection cursor (`❯` as Claude draws it, `›` as
+/// Codex does), optional `N.` number, then text. Returns `(has_cursor, number, text)`; `None`
+/// when the line isn't option-shaped. (Shared with the pending-prompt detector in
+/// [`super::prompt`].)
 pub(crate) fn parse_option_line(line: &str) -> Option<(bool, Option<u32>, String)> {
     let clean = strip_ansi(line);
     let mut rest = clean.trim_start();
-    let cursor = rest.starts_with('❯');
+    let cursor = rest.starts_with('❯') || rest.starts_with('›');
     if cursor {
-        rest = rest.trim_start_matches('❯').trim_start();
+        rest = rest.trim_start_matches(['❯', '›']).trim_start();
     }
     let digits: String = rest
         .chars()

--- a/crates/repomon-core/src/agent/prompt.rs
+++ b/crates/repomon-core/src/agent/prompt.rs
@@ -172,6 +172,10 @@ pub fn classify_prompt(summary: &str) -> PromptClass {
         // has already explicitly registered with repomon, so trusting the folder is routine
         // housekeeping, not a decision-class ask — safe for an orchestrator to auto-answer.
         "do you trust",
+        // Codex's MCP tool-call approval ("Allow the repomon MCP server to run tool
+        // \"fleet_status\"?" — live fixture in the tests below): the same routine
+        // own-next-tool-call ask as Claude's "do you want to run".
+        "mcp server to run tool",
     ];
     if PERMISSION_MARKERS.iter().any(|m| l.contains(m)) {
         PromptClass::Permission
@@ -270,6 +274,27 @@ mod tests {
         // not enough evidence, so this must not match (guards against loosening detection).
         let pane = "Security guide\n\n❯ 1. Yes, I trust this folder\n  2. No, exit";
         assert_eq!(detect_pending_prompt(pane), None);
+    }
+
+    #[test]
+    fn detects_codex_mcp_tool_approval_dialog() {
+        // Ground-truth pane capture from a live codex orchestrator in supervised mode
+        // (`-a on-request`) hitting its MCP tool-call approval. Codex draws its selection
+        // cursor as `›` (U+203A), not Claude's `❯` (U+276F) — this dialog was invisible to the
+        // detector until `parse_option_line` learned the glyph.
+        let pane = "  Field 1/1\n\
+              Allow the repomon MCP server to run tool \"fleet_status\"?\n\
+              › 1. Allow                   Run the tool and continue.\n\
+                2. Allow for this session  Run the tool and remember this choice for this session.\n\
+                3. Always allow            Run the tool and remember this choice for future tool calls.\n\
+                4. Cancel                  Cancel this tool call\n\
+              enter to submit | esc to cancel";
+        let summary = detect_pending_prompt(pane);
+        assert_eq!(
+            summary.as_deref(),
+            Some("Allow the repomon MCP server to run tool \"fleet_status\"?")
+        );
+        assert_eq!(classify_prompt(&summary.unwrap()), PromptClass::Permission);
     }
 
     #[test]

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -102,9 +102,12 @@ pub struct Config {
     /// In the sidebars, expand a lane running several agents into one row per agent (a tree under
     /// the lane) instead of a single row with an `×N` badge. Off by default.
     pub expand_agents: bool,
-    /// Which agent (Claude account) powers the repomind orchestrator session — a built-in Claude
-    /// variant (e.g. `claude-work`) or a custom agent name. `None` falls back to bare `claude`.
-    /// An explicit override on `orchestrator.start` takes precedence over this.
+    /// Which agent powers the repomind orchestrator session — a built-in Claude variant (e.g.
+    /// `claude-work`), a custom agent name, or `codex` (the one non-Claude CLI with the MCP
+    /// client repomind needs; it runs with pane-only monitoring — no transcript chat view or
+    /// end-of-turn detection). Custom agents are composed with Claude-shaped flags, so their
+    /// commands must be `claude`-based. `None` falls back to bare `claude`. An explicit override
+    /// on `orchestrator.start` takes precedence over this.
     pub orchestrator_agent: Option<String>,
     /// The model the orchestrator session runs (e.g. `opus`, `sonnet`). `None` lets `claude` pick
     /// its default. An explicit override on `orchestrator.start` takes precedence.

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -48,18 +48,59 @@ pub struct OverlaySession {
 /// pane-streaming loop, so a rename can't desync them.
 pub(crate) const ORCHESTRATOR_WINDOW: &str = "orchestrator";
 
-/// The daemon-owned repomind orchestrator: a single `claude` session in a dedicated tmux window
-/// named `orchestrator` (deliberately NOT `lane-*`, so it stays out of the lane overlay/reaper and
-/// never pollutes the fleet `lane.list`). `agent`/`model` record what it was launched with.
-/// `autonomy` is the autonomy level it was started with (`REPOMON_MCP_AUTONOMY`); `None` when the
-/// session was adopted from a tmux window that survived a daemon restart, whose actual autonomy
-/// is unknown to this process.
+/// Which agent CLI powers the orchestrator session. This is the seam every backend-specific
+/// capability routes through: command construction lives in one
+/// `rpc::build_{claude,codex}_orchestrator_command` per variant, and everything else asks the
+/// predicates here. A future backend is a new variant — the compiler then walks you to every
+/// match site that needs an answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrchestratorBackend {
+    /// Claude Code — the default, and the only backend with full monitoring: its `~/.claude`
+    /// JSONL transcript is parseable and `--session-id` pins it at spawn.
+    Claude,
+    /// Codex CLI — MCP-capable, so it can drive the fleet tools, but monitored best-effort only:
+    /// its on-disk session format is unstable (same reason core's `CodexMonitor` reads nothing),
+    /// so no transcript chat view, no end-of-turn attention, no session pinning — pane-based
+    /// dialog detection only.
+    Codex,
+}
+
+impl OrchestratorBackend {
+    /// The wire word for the `backend` field of `orchestrator.status`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+
+    /// Whether this backend has a parseable on-disk transcript the daemon may read
+    /// (`orchestrator.transcript`, the end-of-turn attention check). When false, callers must
+    /// skip the transcript path entirely — NOT fall through to the "newest `~/.claude` transcript
+    /// with content" recency heuristic, which would misattribute some other live Claude session's
+    /// chat as this orchestrator's.
+    pub fn has_transcript(self) -> bool {
+        matches!(self, Self::Claude)
+    }
+}
+
+/// The daemon-owned repomind orchestrator: a single agent session (`backend` says which CLI) in a
+/// dedicated tmux window named `orchestrator` (deliberately NOT `lane-*`, so it stays out of the
+/// lane overlay/reaper and never pollutes the fleet `lane.list`). `agent`/`model` record what it
+/// was launched with. `autonomy` is the autonomy level it was started with
+/// (`REPOMON_MCP_AUTONOMY`); `None` when the session was adopted from a tmux window that survived
+/// a daemon restart, whose actual autonomy is unknown to this process.
 #[derive(Clone)]
 pub struct OrchestratorSession {
     pub agent: Option<String>,
     pub model: Option<String>,
     pub window: String,
     pub autonomy: Option<String>,
+    /// Which agent CLI this session runs — see [`OrchestratorBackend`]. For an adopted window
+    /// this is derived from the current request/config, not from the surviving window itself
+    /// (best-effort, the same caveat as `agent`): a wrong guess degrades to an empty transcript
+    /// or the recency-heuristic fallback, never an error.
+    pub backend: OrchestratorBackend,
     /// The `--session-id` UUID this session's `claude` was launched with (minted at spawn time —
     /// see `rpc::mint_session_id`), so the transcript picker
     /// (`rpc::pick_orchestrator_transcript`) can pin `orchestrator.transcript` and the end-of-turn

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -50,9 +50,17 @@ async fn main() {
         )
         .init();
 
-    let config = Config::load().unwrap_or_default();
+    let mut config = Config::load().unwrap_or_default();
+    // Reflect a `--socket` override into the in-memory config: everything that later derives the
+    // socket from config — most importantly the orchestrator spawn path, which points the fleet
+    // MCP server (`repomond mcp`) back at the daemon via `REPOMON_MCP_SOCKET` — must name the
+    // socket this process actually binds, or repomind's MCP server connects to a socket nobody
+    // is listening on and dies during its initialize handshake.
+    if let Some(sock) = &args.socket {
+        config.socket_path = Some(sock.clone());
+    }
     let db = args.data.unwrap_or_else(config::db_path);
-    let socket = args.socket.unwrap_or_else(|| config::socket_path(&config));
+    let socket = config::socket_path(&config);
 
     let store = match Store::open(&db) {
         Ok(s) => s,

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -290,13 +290,24 @@ async fn check_orchestrator_attention(
         // Pin the transcript scan to the orchestrator's own session id (captured at spawn via
         // `--session-id`) — the `ctx.orchestrator` state `reconcile_orchestrator` just confirmed
         // is alive — so it never picks up some other active Claude session's transcript. See
-        // `rpc::pick_orchestrator_transcript`.
-        let session_id = ctx
-            .orchestrator
-            .lock()
-            .await
-            .as_ref()
-            .and_then(|o| o.session_id.clone());
+        // `rpc::pick_orchestrator_transcript`. `has_transcript` gates the scan entirely: a
+        // backend with no parseable transcript (codex) must NOT reach the picker at all — with
+        // its always-`None` session id the picker would fall back to the "newest `~/.claude`
+        // transcript with content" heuristic and misattribute another live Claude session.
+        let (session_id, has_transcript) = {
+            let orch = ctx.orchestrator.lock().await;
+            let o = orch.as_ref();
+            (
+                o.and_then(|o| o.session_id.clone()),
+                // `None` (stopped between the reconcile above and here) also means "don't scan".
+                o.is_some_and(|o| o.backend.has_transcript()),
+            )
+        };
+        if !has_transcript {
+            // Also drop any cached status a prior Claude-backed session left behind, so it can't
+            // leak an end_of_turn into this one.
+            *transcript_cache = None;
+        }
         let tmux = ctx.tmux.clone();
         let pane = tokio::task::spawn_blocking(move || {
             tmux.capture_named(ORCHESTRATOR_WINDOW, Some(ORCH_CAPTURE_LINES))
@@ -309,7 +320,7 @@ async fn check_orchestrator_attention(
             .and_then(agent::prompt::detect_pending_prompt);
 
         *scan_transcript = !*scan_transcript;
-        if dialog.is_none() && *scan_transcript {
+        if has_transcript && dialog.is_none() && *scan_transcript {
             *transcript_cache = tokio::task::spawn_blocking(move || {
                 rpc::pick_orchestrator_transcript(session_id.as_deref())
             })

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1361,17 +1361,27 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             // Clear a session whose window died externally so a restart actually re-spawns instead
             // of no-op'ing on a corpse.
             reconcile_orchestrator(ctx).await;
+            // Hold the session lock across the ENTIRE check → adopt/spawn → record sequence.
+            // Releasing it between the is-running check and the record (as this handler once did)
+            // let two concurrent starts — a real scenario: the TUI's command-center auto-start and
+            // `repomon orchestrate` both fire at startup on separate connections — both observe
+            // "not running" and race the spawn: the loser then either failed its own `new-session`
+            // outright, spawned a duplicate `orchestrator` window (tmux allows duplicate names),
+            // or took the adopt branch on the winner's fresh window and overwrote its
+            // just-recorded session id/autonomy. Holding a tokio Mutex across the awaits below is
+            // fine — it merely serializes concurrent start/stop/status for the ~tens of ms a tmux
+            // spawn takes. Nothing in this region re-locks `ctx.orchestrator` (the audit:
+            // `reconcile_orchestrator` runs above, before the guard; config is a separate RwLock;
+            // `orchestrator_attention` is only ever taken after — never while holding — it).
+            let mut orch = ctx.orchestrator.lock().await;
             // Already tracking a live session: idempotent no-op (don't spawn a second window).
-            {
-                let orch = ctx.orchestrator.lock().await;
-                if orch.is_some() {
-                    let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
-                    return Ok(orchestrator_status_value(
-                        orch.as_ref(),
-                        &attention,
-                        headline.as_deref(),
-                    ));
-                }
+            if orch.is_some() {
+                let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
+                return Ok(orchestrator_status_value(
+                    orch.as_ref(),
+                    &attention,
+                    headline.as_deref(),
+                ));
             }
             // Resolve agent/model: explicit param wins, then the persisted config default.
             let (cfg_agent, cfg_model, customs) = {
@@ -1405,8 +1415,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                         autonomy: None,
                         session_id: None,
                     };
-                    *ctx.orchestrator.lock().await = Some(session);
-                    let orch = ctx.orchestrator.lock().await;
+                    *orch = Some(session);
                     let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
                     let status =
                         orchestrator_status_value(orch.as_ref(), &attention, headline.as_deref());
@@ -1443,17 +1452,31 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 autonomy: Some(p.autonomy),
                 session_id: Some(session_id),
             };
-            *ctx.orchestrator.lock().await = Some(session);
-            let orch = ctx.orchestrator.lock().await;
+            *orch = Some(session);
             let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
             let status = orchestrator_status_value(orch.as_ref(), &attention, headline.as_deref());
             ctx.broadcast(crate::pubsub::topic::ORCHESTRATOR_STATUS, status.clone());
             Ok(status)
         }
         "orchestrator.stop" => {
+            // Take the session lock BEFORE the kill so a stop can't interleave with a concurrent
+            // `orchestrator.start` (which holds this lock across its spawn): stop either runs
+            // first against nothing, or kills the fully-recorded window — never a window that a
+            // mid-flight start is about to record (which would leave an untracked orphan running).
+            let mut orch = ctx.orchestrator.lock().await;
             let tmux = ctx.tmux.clone();
             let _ = tokio::task::spawn_blocking(move || tmux.kill_named(ORCHESTRATOR_WINDOW)).await;
-            *ctx.orchestrator.lock().await = None;
+            // Unlike `agent.stop` (see `reap::kill_and_forget`), no cache reconciliation is needed
+            // after this kill: `prompt_cache` only ever holds lane-window sniffs (`overlay_agents`
+            // keys it by lane candidates, which the orchestrator window deliberately isn't), and
+            // while `last_good_windows` does carry `orchestrator`, every consumer of the resolved
+            // list filters to `lane-*` and orchestrator liveness is always probed directly via
+            // `has_named`. Dropping the entry anyway is cheap hygiene, not correctness.
+            ctx.last_good_windows
+                .lock()
+                .await
+                .retain(|w| w != ORCHESTRATOR_WINDOW);
+            *orch = None;
             *ctx.orchestrator_attention.lock().await = ("none".to_string(), None);
             let status = orchestrator_status_value(None, "none", None);
             ctx.broadcast(crate::pubsub::topic::ORCHESTRATOR_STATUS, status.clone());

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -352,8 +352,9 @@ struct Browse {
 }
 #[derive(Deserialize, Default)]
 struct OrchestratorStart {
-    /// Override the orchestrator agent (Claude account); falls back to `orchestrator_agent` in
-    /// config, then bare `claude`.
+    /// Override the orchestrator agent — a Claude account (e.g. `claude-work`), a custom agent
+    /// name, or `codex`; falls back to `orchestrator_agent` in config, then bare `claude`.
+    /// Anything else (no MCP client → can't drive the fleet) is rejected with invalid_params.
     #[serde(default)]
     agent: Option<String>,
     /// Override the model (e.g. `opus`); falls back to `orchestrator_model` in config.
@@ -1345,6 +1346,13 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             let Some(session) = orch.as_ref() else {
                 return Ok(json!([]));
             };
+            // A backend without a parseable transcript reads as an empty chat — deliberately NOT
+            // the recency-heuristic fallback below, which would misattribute some other live
+            // Claude session's transcript as this orchestrator's. Clients render the live pane
+            // stream (`event.orchestrator.output`) instead.
+            if !session.backend.has_transcript() {
+                return Ok(json!([]));
+            }
             let session_id = session.session_id.clone();
             drop(orch);
             let items = tokio::task::spawn_blocking(move || {
@@ -1394,6 +1402,10 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             };
             let agent = p.agent.or(cfg_agent);
             let model = p.model.or(cfg_model);
+            // Resolved once here, recorded on the session for BOTH the adopt and spawn paths, and
+            // consulted everywhere a Claude-only capability would otherwise be assumed. Errors out
+            // (guard drops, nothing recorded) on an agent that can't run the orchestrator at all.
+            let backend = resolve_orchestrator_backend(&agent, &customs)?;
             // A window may survive a daemon restart (tmux outlives us). Adopt it instead of
             // spawning a duplicate `orchestrator` window.
             {
@@ -1414,6 +1426,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                         window: ORCHESTRATOR_WINDOW.to_string(),
                         autonomy: None,
                         session_id: None,
+                        backend,
                     };
                     *orch = Some(session);
                     let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
@@ -1423,17 +1436,35 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                     return Ok(status);
                 }
             }
-            // Build the MCP config that points the orchestrator's `claude` at `repomond mcp`. The
-            // server's env is authoritative for the socket + guardrails.
             let socket = repomon_core::config::socket_path(&*ctx.config.read().await);
-            let mcp_path = write_orchestrator_mcp_config(&socket, &p.autonomy, p.max_agents)
-                .map_err(internal)?;
             let base = orchestrator_base_command(&agent, &customs);
-            // Minted fresh for this genuine spawn (never for adopt — see above) so the transcript
-            // picker can pin `orchestrator.transcript`/the end-of-turn check to this exact session.
-            let session_id = mint_session_id();
-            let command =
-                build_orchestrator_command(&base, &mcp_path, &model, &p.prompt, &session_id);
+            let (command, session_id) = match backend {
+                crate::OrchestratorBackend::Claude => {
+                    // Build the MCP config file that points the orchestrator's `claude` at
+                    // `repomond mcp`. The server's env is authoritative for the socket +
+                    // guardrails.
+                    let mcp_path =
+                        write_orchestrator_mcp_config(&socket, &p.autonomy, p.max_agents)
+                            .map_err(internal)?;
+                    // Minted fresh for this genuine spawn (never for adopt — see above) so the
+                    // transcript picker can pin `orchestrator.transcript`/the end-of-turn check
+                    // to this exact session.
+                    let session_id = mint_session_id();
+                    let command = build_claude_orchestrator_command(
+                        &base, &mcp_path, &model, &p.prompt, &session_id,
+                    );
+                    (command, Some(session_id))
+                }
+                // Codex takes its MCP registration inline (`-c` overrides — no config file) and
+                // has no session pinning; the transcript/end-of-turn paths gate on
+                // `backend.has_transcript()` instead of a session id.
+                crate::OrchestratorBackend::Codex => (
+                    build_codex_orchestrator_command(
+                        &base, &socket, &p.autonomy, p.max_agents, &model, &p.prompt,
+                    ),
+                    None,
+                ),
+            };
             // cwd = $HOME, so repomind starts from the user's home rather than the daemon's cwd.
             let home = std::env::var("HOME")
                 .map(PathBuf::from)
@@ -1450,7 +1481,8 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 model,
                 window: ORCHESTRATOR_WINDOW.to_string(),
                 autonomy: Some(p.autonomy),
-                session_id: Some(session_id),
+                session_id,
+                backend,
             };
             *orch = Some(session);
             let (attention, headline) = ctx.orchestrator_attention.lock().await.clone();
@@ -2574,15 +2606,19 @@ async fn commits_in_range(
     Ok(out)
 }
 
-/// The `{running, agent, model, window, autonomy, session_id, attention, headline}` status JSON
-/// for the orchestrator (shared by `orchestrator.status` and the `event.orchestrator.status`
-/// broadcast). `autonomy` is the level the session was started with, or `null` if it was adopted
-/// from a surviving tmux window and is therefore unknown. `session_id` is the `--session-id` UUID
-/// it was launched with (see `mint_session_id`) — same "unknown → null" semantics as `autonomy`
-/// for an adopted window. `attention` is one of `"none"`, `"permission"`, `"decision"`,
-/// `"end_of_turn"` — see [`notify_watch::check_orchestrator_attention`](crate::notify_watch);
-/// `headline` is a short "why" (the pending dialog's question, or a tail of repomind's last
-/// message) or `null`.
+/// The `{running, agent, model, backend, window, autonomy, session_id, attention, headline}`
+/// status JSON for the orchestrator (shared by `orchestrator.status` and the
+/// `event.orchestrator.status` broadcast). `agent` is the raw name the session was started with
+/// (`claude-work`, a custom, `codex`); `backend` is the normalized seam value
+/// (`"claude"`/`"codex"`) clients should switch rendering on — a codex-backed session has no
+/// transcript chat view, never reports `end_of_turn`, and always has a null `session_id`.
+/// `autonomy` is the level the session was started with, or `null` if it was adopted from a
+/// surviving tmux window and is therefore unknown. `session_id` is the `--session-id` UUID it was
+/// launched with (see `mint_session_id`) — same "unknown → null" semantics as `autonomy` for an
+/// adopted window, always null for codex. `attention` is one of `"none"`, `"permission"`,
+/// `"decision"`, `"end_of_turn"` — see
+/// [`notify_watch::check_orchestrator_attention`](crate::notify_watch); `headline` is a short
+/// "why" (the pending dialog's question, or a tail of repomind's last message) or `null`.
 pub(crate) fn orchestrator_status_value(
     orch: Option<&crate::OrchestratorSession>,
     attention: &str,
@@ -2593,6 +2629,7 @@ pub(crate) fn orchestrator_status_value(
             "running": true,
             "agent": s.agent,
             "model": s.model,
+            "backend": s.backend.as_str(),
             "window": s.window,
             "autonomy": s.autonomy,
             "session_id": s.session_id,
@@ -2603,6 +2640,7 @@ pub(crate) fn orchestrator_status_value(
             "running": false,
             "agent": Value::Null,
             "model": Value::Null,
+            "backend": Value::Null,
             "window": Value::Null,
             "autonomy": Value::Null,
             "session_id": Value::Null,
@@ -2690,10 +2728,44 @@ pub(crate) async fn reconcile_orchestrator(ctx: &Ctx) -> bool {
     false
 }
 
+/// Which backend an orchestrator agent name runs on. `None` and Claude account variants are
+/// Claude; a config custom is Claude too — its command line gets the Claude-shaped flags
+/// [`build_claude_orchestrator_command`] appends, exactly as before backends existed (a
+/// codex-shaped custom is future work). `codex` is the one non-Claude backend that can actually
+/// drive the fleet (it has an MCP client). Anything else is a loud `invalid_params` — `aider`
+/// and `cursor-agent` can't speak MCP, and an unknown name has no command — instead of what this
+/// path used to do: silently spawn e.g. `aider --mcp-config …`, a broken window the user had to
+/// diagnose by hand.
+fn resolve_orchestrator_backend(
+    agent: &Option<String>,
+    customs: &HashMap<String, String>,
+) -> Result<crate::OrchestratorBackend, RpcError> {
+    use crate::OrchestratorBackend as B;
+    let Some(name) = agent else {
+        return Ok(B::Claude);
+    };
+    if customs.contains_key(name) {
+        return Ok(B::Claude);
+    }
+    // `claude` itself and account variants (`claude-work`, …) parse as Other but are Claude; the
+    // prefix test matches how the TUI's agent picker has always classified them.
+    if name.starts_with("claude") {
+        return Ok(B::Claude);
+    }
+    match AgentKind::from_kind_str(name) {
+        AgentKind::Codex => Ok(B::Codex),
+        _ => Err(RpcError::invalid_params(format!(
+            "agent '{name}' can't run the orchestrator: repomind needs an MCP-capable CLI \
+             (a claude account, codex, or a custom agent command)"
+        ))),
+    }
+}
+
 /// Resolve the orchestrator's base launch command from its agent name, mirroring `agent.spawn`: a
 /// config custom wins, then an autodetected Claude variant (e.g. `claude-work` →
-/// `CLAUDE_CONFIG_DIR=… claude`), else the kind's default binary. `None` (no agent chosen) is bare
-/// `claude` — the orchestrator is fundamentally a Claude session.
+/// `CLAUDE_CONFIG_DIR=… claude`), else the kind's default binary (`codex` — anything else was
+/// already rejected by [`resolve_orchestrator_backend`]). `None` (no agent chosen) is bare
+/// `claude`.
 fn orchestrator_base_command(agent: &Option<String>, customs: &HashMap<String, String>) -> String {
     match agent {
         Some(name) => {
@@ -2718,8 +2790,9 @@ fn orchestrator_base_command(agent: &Option<String>, customs: &HashMap<String, S
 /// it. The fleet + memory tools are pre-approved so routine orchestration doesn't prompt.
 /// `session_id` pins the launched session's id (`--session-id <uuid>`, verified against `claude
 /// --help` to exist) so the transcript picker can find *this* session's transcript directly
-/// instead of guessing by recency — see [`pick_orchestrator_transcript_in`].
-fn build_orchestrator_command(
+/// instead of guessing by recency — see [`pick_orchestrator_transcript_in`]. The Codex
+/// counterpart is [`build_codex_orchestrator_command`].
+fn build_claude_orchestrator_command(
     base: &str,
     mcp_config_path: &Path,
     model: &Option<String>,
@@ -2742,6 +2815,76 @@ fn build_orchestrator_command(
         command.push(' ');
         command.push_str(&shell_quote(prompt));
     }
+    command
+}
+
+/// Build the full `codex` invocation for the orchestrator, shell-quoted for `sh -c` (tmux runs
+/// the window command through a shell). ALL Codex-CLI flag knowledge lives here (plus its unit
+/// test), so a codex release changing a flag is a one-function fix. Verified against codex-cli
+/// 0.142.3 (`codex --help`); where it diverges from the Claude arm:
+/// - No `--mcp-config` file: the repomon fleet server is registered inline via `-c key=value`
+///   dotted TOML overrides (`mcp_servers.repomon.*`; the value portion is parsed as TOML). The
+///   user's own `~/.codex/config.toml` servers (e.g. basic-memory) still load — not redeclared,
+///   mirroring the Claude arm's treatment.
+/// - No `--append-system-prompt`: the repomind persona is prepended to the initial positional
+///   prompt instead. Weaker than a real system prompt (visible in the chat, can fade over a very
+///   long session) — if codex stabilizes an instructions-file override, swap it in here.
+/// - No `--session-id` and no `--allowedTools`: codex can't pin its session file (and its
+///   on-disk format is unstable anyway — the caller records `session_id: None`, and the
+///   transcript/end-of-turn paths gate on `OrchestratorBackend::has_transcript`); tool
+///   pre-approval is expressed through the approval policy below instead of a per-tool list.
+/// - `autonomy` maps onto codex's approval/sandbox flags so routine MCP-driven orchestration
+///   never stalls on an interactive approval. The REAL guardrail is `REPOMON_MCP_AUTONOMY`,
+///   enforced server-side by `repomon_mcp::policy` from the env this hands the MCP server.
+fn build_codex_orchestrator_command(
+    base: &str,
+    socket: &Path,
+    autonomy: &str,
+    max_agents: Option<usize>,
+    model: &Option<String>,
+    prompt: &Option<String>,
+) -> String {
+    let repomond = repomon_core::service::repomond_path();
+    let mut command = base.to_string();
+    // Interpolated straight into TOML basic strings: the paths this carries (the repomond binary,
+    // the daemon socket) never contain quotes/backslashes on the platforms repomon ships for.
+    let mut env = format!(
+        "REPOMON_MCP_SOCKET = \"{}\", REPOMON_MCP_AUTONOMY = \"{autonomy}\"",
+        socket.to_string_lossy(),
+    );
+    if let Some(n) = max_agents {
+        env.push_str(&format!(", REPOMON_MCP_MAX_AGENTS = \"{n}\""));
+    }
+    for over in [
+        format!(
+            "mcp_servers.repomon.command=\"{}\"",
+            repomond.to_string_lossy()
+        ),
+        "mcp_servers.repomon.args=[\"mcp\"]".to_string(),
+        format!("mcp_servers.repomon.env={{ {env} }}"),
+    ] {
+        command.push_str(" -c ");
+        command.push_str(&shell_quote(&over));
+    }
+    command.push_str(match autonomy {
+        // Never stall on approvals; the sandbox still bounds what shell commands can touch.
+        "autonomous" => " -a never -s workspace-write",
+        // Codex decides when to ask; its dialogs surface through the pane attention sniff.
+        "supervised" => " -a on-request",
+        "read-only" => " -s read-only",
+        // An unknown level gets the middle road rather than full autonomy.
+        _ => " -a on-request",
+    });
+    if let Some(model) = model {
+        command.push_str(" -m ");
+        command.push_str(&shell_quote(model));
+    }
+    let goal = match prompt.as_deref().filter(|p| !p.is_empty()) {
+        Some(p) => format!("{}\n\n{p}", repomon_mcp::PERSONA),
+        None => repomon_mcp::PERSONA.to_string(),
+    };
+    command.push(' ');
+    command.push_str(&shell_quote(&goal));
     command
 }
 
@@ -3049,14 +3192,16 @@ mod tests {
             "claude-yolo".to_string(),
             "claude --dangerously-skip-permissions".to_string(),
         );
-        // No agent chosen -> bare claude (the orchestrator is always a Claude session).
+        // No agent chosen -> bare claude (the default backend).
         assert_eq!(orchestrator_base_command(&None, &customs), "claude");
         // A custom agent resolves to its configured command (flags carried over).
         assert_eq!(
             orchestrator_base_command(&Some("claude-yolo".into()), &customs),
             "claude --dangerously-skip-permissions"
         );
-        // An unknown name falls through to the kind's default binary (mirrors agent.spawn).
+        // A kind name resolves to its default binary (mirrors agent.spawn); for the orchestrator
+        // only `codex` reaches here — anything non-MCP-capable is rejected upstream by
+        // `resolve_orchestrator_backend`.
         assert_eq!(
             orchestrator_base_command(&Some("codex".into()), &customs),
             "codex"
@@ -3064,11 +3209,96 @@ mod tests {
     }
 
     #[test]
+    fn orchestrator_backend_resolution() {
+        use crate::OrchestratorBackend as B;
+        let mut customs = HashMap::new();
+        customs.insert("my-yolo".to_string(), "claude --yolo".to_string());
+        // Default and every claude-ish name → Claude.
+        assert_eq!(resolve_orchestrator_backend(&None, &customs).unwrap(), B::Claude);
+        for name in ["claude", "claude-code", "claude-work"] {
+            assert_eq!(
+                resolve_orchestrator_backend(&Some(name.into()), &customs).unwrap(),
+                B::Claude,
+                "{name}"
+            );
+        }
+        // A config custom is Claude-flag-shaped regardless of its name.
+        assert_eq!(
+            resolve_orchestrator_backend(&Some("my-yolo".into()), &customs).unwrap(),
+            B::Claude
+        );
+        // Codex is the one non-Claude backend.
+        assert_eq!(
+            resolve_orchestrator_backend(&Some("codex".into()), &customs).unwrap(),
+            B::Codex
+        );
+        // MCP-less agents and unknown names are loud errors, not broken spawns.
+        for name in ["aider", "cursor", "gemini"] {
+            let err = resolve_orchestrator_backend(&Some(name.into()), &customs).unwrap_err();
+            assert!(
+                err.message.contains(name) && err.message.contains("orchestrator"),
+                "{name}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn codex_orchestrator_command_wires_mcp_and_persona() {
+        let socket = PathBuf::from("/tmp/repomon-test.sock");
+        // Autonomous: MCP registration inline, approvals off, sandboxed, persona as the prompt.
+        let cmd =
+            build_codex_orchestrator_command("codex", &socket, "autonomous", Some(4), &None, &None);
+        assert!(cmd.starts_with("codex "), "{cmd}");
+        // The three -c overrides registering the fleet MCP server.
+        assert!(cmd.contains("mcp_servers.repomon.command="), "{cmd}");
+        assert!(cmd.contains("mcp_servers.repomon.args=[\"mcp\"]"), "{cmd}");
+        assert!(
+            cmd.contains("REPOMON_MCP_SOCKET = \"/tmp/repomon-test.sock\""),
+            "{cmd}"
+        );
+        assert!(cmd.contains("REPOMON_MCP_AUTONOMY = \"autonomous\""), "{cmd}");
+        assert!(cmd.contains("REPOMON_MCP_MAX_AGENTS = \"4\""), "{cmd}");
+        assert!(cmd.contains(" -a never -s workspace-write"), "{cmd}");
+        // The persona rides in as the initial prompt (codex has no --append-system-prompt).
+        assert!(cmd.contains("repomind"), "{cmd}");
+        // None of the Claude-only flags may leak into a codex invocation.
+        for claude_flag in [
+            "--mcp-config",
+            "--append-system-prompt",
+            "--allowedTools",
+            "--session-id",
+            "--model",
+        ] {
+            assert!(!cmd.contains(claude_flag), "{claude_flag} leaked: {cmd}");
+        }
+
+        // Supervised + model + prompt: on-request approvals, -m, prompt appended to the persona.
+        let cmd = build_codex_orchestrator_command(
+            "codex",
+            &socket,
+            "supervised",
+            None,
+            &Some("gpt-5.2-codex".into()),
+            &Some("what needs me?".into()),
+        );
+        assert!(cmd.contains(" -a on-request"), "{cmd}");
+        assert!(!cmd.contains("REPOMON_MCP_MAX_AGENTS"), "{cmd}");
+        assert!(cmd.contains(" -m 'gpt-5.2-codex'"), "{cmd}");
+        assert!(cmd.contains("what needs me?"), "{cmd}");
+
+        // Read-only maps to codex's read-only sandbox.
+        let cmd =
+            build_codex_orchestrator_command("codex", &socket, "read-only", None, &None, &None);
+        assert!(cmd.contains(" -s read-only"), "{cmd}");
+    }
+
+    #[test]
     fn orchestrator_command_wires_mcp_persona_and_tools() {
         let path = PathBuf::from("/tmp/repomind-mcp.json");
         let sid = "11111111-1111-4111-8111-111111111111";
         // No model, no prompt: the core wiring is always present.
-        let cmd = build_orchestrator_command("claude", &path, &None, &None, sid);
+        let cmd = build_claude_orchestrator_command("claude", &path, &None, &None, sid);
         assert!(cmd.starts_with("claude --mcp-config "));
         assert!(cmd.contains("/tmp/repomind-mcp.json"));
         assert!(cmd.contains("--append-system-prompt"));
@@ -3081,7 +3311,7 @@ mod tests {
         assert!(!cmd.contains("--model"));
 
         // A model + a prompt are appended (shell-quoted).
-        let cmd = build_orchestrator_command(
+        let cmd = build_claude_orchestrator_command(
             "CLAUDE_CONFIG_DIR=/h/.claude-work claude",
             &path,
             &Some("opus".into()),
@@ -3094,7 +3324,8 @@ mod tests {
         assert!(cmd.contains(&format!("--session-id '{sid}'")));
 
         // An empty prompt is dropped (not quoted as an empty arg).
-        let cmd = build_orchestrator_command("claude", &path, &None, &Some(String::new()), sid);
+        let cmd =
+            build_claude_orchestrator_command("claude", &path, &None, &Some(String::new()), sid);
         assert!(!cmd.trim_end().ends_with("''"));
     }
 
@@ -3148,11 +3379,13 @@ mod tests {
             window: "orchestrator".into(),
             autonomy: Some("autonomous".into()),
             session_id: Some("11111111-1111-4111-8111-111111111111".into()),
+            backend: crate::OrchestratorBackend::Claude,
         };
         let v = orchestrator_status_value(Some(&s), "decision", Some("Which auth method?"));
         assert_eq!(v["running"], json!(true));
         assert_eq!(v["agent"], json!("claude-work"));
         assert_eq!(v["model"], json!("opus"));
+        assert_eq!(v["backend"], json!("claude"));
         assert_eq!(v["window"], json!("orchestrator"));
         assert_eq!(v["autonomy"], json!("autonomous"));
         assert_eq!(
@@ -3161,21 +3394,25 @@ mod tests {
         );
         assert_eq!(v["attention"], json!("decision"));
         assert_eq!(v["headline"], json!("Which auth method?"));
-        // An adopted session's autonomy AND session id are both unknown.
+        // An adopted session's autonomy AND session id are both unknown; a codex-backed session
+        // reports its backend so clients switch off the (empty) transcript chat view.
         let adopted = crate::OrchestratorSession {
-            agent: None,
+            agent: Some("codex".into()),
             model: None,
             window: "orchestrator".into(),
             autonomy: None,
             session_id: None,
+            backend: crate::OrchestratorBackend::Codex,
         };
         let v = orchestrator_status_value(Some(&adopted), "none", None);
         assert_eq!(v["autonomy"], Value::Null);
         assert_eq!(v["session_id"], Value::Null);
+        assert_eq!(v["backend"], json!("codex"));
         // No session: running=false with null fields; attention/headline still pass through.
         let v = orchestrator_status_value(None, "none", None);
         assert_eq!(v["running"], json!(false));
         assert_eq!(v["agent"], Value::Null);
+        assert_eq!(v["backend"], Value::Null);
         assert_eq!(v["autonomy"], Value::Null);
         assert_eq!(v["session_id"], Value::Null);
         assert_eq!(v["attention"], json!("none"));

--- a/crates/repomon-daemon/tests/orchestrator_codex.rs
+++ b/crates/repomon-daemon/tests/orchestrator_codex.rs
@@ -1,0 +1,124 @@
+//! The codex orchestrator backend, exercised through the daemon's own RPC surface: a start with
+//! `agent: "codex"` must record the codex backend with no session id (codex can't pin one),
+//! `orchestrator.transcript` must read as an empty chat (codex's on-disk session format is not
+//! parsed — the pane stream is the view), and an MCP-less agent (`aider`) must be rejected
+//! loudly instead of spawning a broken window. Whether a real `codex` binary is installed is
+//! deliberately irrelevant: every assertion is on the daemon's own bookkeeping, mirroring
+//! `orchestrator.rs`'s approach, and the window is stopped at the end either way. Kept in its
+//! own integration binary: like `orchestrator.rs`, it mutates process env (`XDG_CONFIG_HOME`),
+//! which is only safe when no other test shares the process.
+
+use std::process::Command;
+use std::time::Duration;
+
+use repomon_core::protocol::{self, Request, Response};
+use repomon_core::{Config, Store, TmuxRuntime};
+use repomon_daemon::{Ctx, serve};
+use serde_json::json;
+use tokio::net::UnixStream;
+
+async fn call(
+    stream: &mut UnixStream,
+    id: u64,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> Response {
+    let req = Request::new(id, method, params);
+    protocol::write_message(stream, &req).await.unwrap();
+    let frame = tokio::time::timeout(Duration::from_secs(10), protocol::read_frame(stream))
+        .await
+        .expect("timed out waiting for daemon response")
+        .unwrap()
+        .expect("response frame");
+    serde_json::from_slice(&frame).unwrap()
+}
+
+#[tokio::test]
+async fn codex_backend_degrades_and_mcpless_agents_are_rejected() {
+    if !TmuxRuntime::available() {
+        eprintln!("tmux not available; skipping codex orchestrator test");
+        return;
+    }
+    let session = format!("repomon-orch-codex-it-{}", std::process::id());
+    let config = Config {
+        tmux_session: session.clone(),
+        ..Default::default()
+    };
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, config, None);
+    let sock = std::env::temp_dir().join(format!("repomon-orch-codex-it-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&sock);
+
+    let server = {
+        let ctx = ctx.clone();
+        let sock = sock.clone();
+        tokio::spawn(async move { serve(ctx, &sock).await })
+    };
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let cfg_home = tempfile::tempdir().expect("tempdir");
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", cfg_home.path());
+    }
+    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+
+    // An agent with no MCP client can't drive the fleet: loud invalid_params, nothing spawned.
+    let r = call(
+        &mut stream,
+        1,
+        "orchestrator.start",
+        Some(json!({ "agent": "aider" })),
+    )
+    .await;
+    let err = r.error.expect("aider must be rejected as orchestrator");
+    assert!(
+        err.message.contains("aider"),
+        "unexpected message: {}",
+        err.message
+    );
+    let r = call(&mut stream, 2, "orchestrator.status", None).await;
+    assert_eq!(r.result.unwrap()["running"], json!(false));
+
+    // A codex start records the codex backend and — unlike a Claude spawn — no session id.
+    // `read-only` autonomy so that if a real `codex` binary is installed and boots in the
+    // window before the stop below, the MCP policy layer caps what it may do.
+    let r = call(
+        &mut stream,
+        3,
+        "orchestrator.start",
+        Some(json!({ "agent": "codex", "autonomy": "read-only" })),
+    )
+    .await;
+    assert!(r.error.is_none(), "codex start errored: {:?}", r.error);
+    let status = r.result.unwrap();
+    assert_eq!(status["running"], json!(true), "status: {status}");
+    assert_eq!(status["backend"], json!("codex"), "status: {status}");
+    assert_eq!(status["agent"], json!("codex"), "status: {status}");
+    assert_eq!(status["autonomy"], json!("read-only"), "status: {status}");
+    assert!(
+        status["session_id"].is_null(),
+        "codex can't pin a session id — must be null, got: {status}"
+    );
+
+    // The transcript reads as an empty chat for a codex backend — the gate must answer before
+    // any ~/.claude scan happens, so no other live Claude session's transcript can ever be
+    // misattributed as this orchestrator's. ([] also happens to be the answer if the window
+    // already died on a codex-less machine and reconcile cleared the session — both fine.)
+    let r = call(&mut stream, 4, "orchestrator.transcript", Some(json!({}))).await;
+    assert!(r.error.is_none(), "transcript errored: {:?}", r.error);
+    assert_eq!(r.result.unwrap(), json!([]));
+
+    let r = call(&mut stream, 5, "orchestrator.stop", None).await;
+    assert!(r.error.is_none(), "orchestrator.stop errored: {:?}", r.error);
+    assert_eq!(r.result.unwrap()["running"], json!(false));
+
+    server.abort();
+    let _ = std::fs::remove_file(&sock);
+    let _ = Command::new("tmux")
+        .args(["-L", &session, "kill-server"])
+        .output();
+}

--- a/crates/repomon-daemon/tests/orchestrator_concurrent.rs
+++ b/crates/repomon-daemon/tests/orchestrator_concurrent.rs
@@ -1,0 +1,129 @@
+//! Two `orchestrator.start` calls racing on separate connections must resolve to a single
+//! orchestrator: one spawn, both responses describing the same session. Before the handler held
+//! the session lock across its check → spawn → record sequence, the second caller could observe
+//! "not running" mid-spawn and either spawn a duplicate `orchestrator` window (tmux happily
+//! allows duplicate names) or take the adopt branch on the first caller's fresh window and
+//! overwrite its just-recorded session id. Kept in its own integration binary: like
+//! `orchestrator.rs`, it mutates process env (`XDG_CONFIG_HOME`), which is only safe when no
+//! other test shares the process.
+
+use std::process::Command;
+use std::time::Duration;
+
+use repomon_core::protocol::{self, Request, Response};
+use repomon_core::{Config, Store, TmuxRuntime};
+use repomon_daemon::{Ctx, serve};
+use serde_json::json;
+use tokio::net::UnixStream;
+
+async fn call(
+    stream: &mut UnixStream,
+    id: u64,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> Response {
+    let req = Request::new(id, method, params);
+    protocol::write_message(stream, &req).await.unwrap();
+    let frame = tokio::time::timeout(Duration::from_secs(10), protocol::read_frame(stream))
+        .await
+        .expect("timed out waiting for daemon response")
+        .unwrap()
+        .expect("response frame");
+    serde_json::from_slice(&frame).unwrap()
+}
+
+#[tokio::test]
+async fn concurrent_starts_spawn_exactly_one_orchestrator() {
+    if !TmuxRuntime::available() {
+        eprintln!("tmux not available; skipping concurrent orchestrator start test");
+        return;
+    }
+    let session = format!("repomon-orch-concurrent-it-{}", std::process::id());
+    let config = Config {
+        tmux_session: session.clone(),
+        ..Default::default()
+    };
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, config, None);
+    let sock = std::env::temp_dir().join(format!(
+        "repomon-orch-concurrent-it-{}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&sock);
+
+    let server = {
+        let ctx = ctx.clone();
+        let sock = sock.clone();
+        tokio::spawn(async move { serve(ctx, &sock).await })
+    };
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Redirect the `--mcp-config` write away from the developer's real `~/.config/repomon`.
+    let cfg_home = tempfile::tempdir().expect("tempdir");
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", cfg_home.path());
+    }
+    // A harmless long-lived stand-in for `claude`: the window must OUTLIVE both racing starts
+    // (unlike `orchestrator.rs`'s instantly-exiting `true`) or the second caller's adopt/spawn
+    // decision races the first window's death instead of the lock. `sh -c 'sleep 30' repomon-test`
+    // swallows the appended Claude flags as positional params — including the multi-line
+    // `--append-system-prompt` persona, which stays one single-quoted argument.
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.agents.insert(
+            "slowpoke".to_string(),
+            "sh -c 'sleep 30' repomon-test".to_string(),
+        );
+    }
+
+    let mut a = UnixStream::connect(&sock).await.expect("connect a");
+    let mut b = UnixStream::connect(&sock).await.expect("connect b");
+    let params = json!({ "agent": "slowpoke", "autonomy": "supervised" });
+    let (ra, rb) = tokio::join!(
+        call(&mut a, 1, "orchestrator.start", Some(params.clone())),
+        call(&mut b, 1, "orchestrator.start", Some(params.clone())),
+    );
+
+    for (name, r) in [("a", &ra), ("b", &rb)] {
+        assert!(
+            r.error.is_none(),
+            "orchestrator.start on {name} errored: {:?}",
+            r.error
+        );
+    }
+    let sa = ra.result.unwrap();
+    let sb = rb.result.unwrap();
+    assert_eq!(sa["running"], json!(true), "a: {sa}");
+    assert_eq!(sb["running"], json!(true), "b: {sb}");
+    // Both callers must describe the SAME session: a genuine spawn mints a session id, and the
+    // loser of the race must be answered with the winner's session, not a duplicate spawn's
+    // (different id) or an adopt-overwrite's (null id).
+    let ida = sa["session_id"]
+        .as_str()
+        .expect("start a must report the spawned session's id");
+    let idb = sb["session_id"]
+        .as_str()
+        .expect("start b must report the spawned session's id");
+    assert_eq!(ida, idb, "both starts must resolve to one session");
+
+    let windows = ctx.tmux.list_windows().unwrap();
+    let count = windows.iter().filter(|w| *w == "orchestrator").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one orchestrator window, got {windows:?}"
+    );
+
+    let r = call(&mut a, 2, "orchestrator.stop", None).await;
+    assert!(r.error.is_none(), "orchestrator.stop errored: {:?}", r.error);
+
+    server.abort();
+    let _ = std::fs::remove_file(&sock);
+    let _ = Command::new("tmux")
+        .args(["-L", &session, "kill-server"])
+        .output();
+}

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -2418,13 +2418,14 @@ impl App {
         }
     }
 
-    /// The agent names the orchestrator can run under: Claude account variants plus custom agents
-    /// (Codex/Aider are excluded; repomind is fundamentally a Claude session). Built from the
-    /// `agent.detect` list already loaded into `nl_agents`.
+    /// The agent names the orchestrator can run under: Claude account variants, custom agents,
+    /// and `codex` — the MCP-capable CLIs. Aider stays excluded (no MCP client, so it can't
+    /// drive the fleet tools; the daemon would reject it anyway). Built from the `agent.detect`
+    /// list already loaded into `nl_agents`.
     fn orchestrator_agent_choices(&self) -> Vec<String> {
         self.nl_agents
             .iter()
-            .filter(|a| a.custom || a.name.starts_with("claude"))
+            .filter(|a| a.custom || a.name.starts_with("claude") || a.name == "codex")
             .map(|a| a.name.clone())
             .collect()
     }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -394,6 +394,9 @@ pub struct App {
     pub orch_last_output: Option<Instant>,
     /// INSERT mode in the command-center view: keystrokes forward to `orchestrator.send_input`.
     pub orch_insert: bool,
+    /// Two-press confirm for restarting repomind (`r r`) in the command-center — a restart kills
+    /// the live session, so a single stray keypress must not do it. Any other key disarms.
+    pub orch_restart_armed: bool,
     /// The watch flag we last pushed to the daemon (`orchestrator.watch`), mirrored so `sync_viewport`
     /// only toggles streaming on a real enter/leave of the view.
     orch_watched: bool,
@@ -535,6 +538,7 @@ impl App {
             orch_notif_seeded: false,
             orch_last_output: None,
             orch_insert: false,
+            orch_restart_armed: false,
             orch_watched: false,
             orch_click: std::cell::Cell::new(None),
             orch_pane_zone: std::cell::Cell::new(None),
@@ -2955,6 +2959,7 @@ impl App {
     async fn load_orchestrator(&mut self) {
         self.reset_scroll();
         self.orch_insert = false;
+        self.orch_restart_armed = false;
         match self
             .client
             .call("orchestrator.start", Some(json!({})))
@@ -2976,7 +2981,36 @@ impl App {
     async fn leave_orchestrator(&mut self) {
         self.reset_scroll();
         self.orch_insert = false;
+        self.orch_restart_armed = false;
         self.view = View::Fleet;
+    }
+
+    /// Restart repomind with the saved settings: stop the live session, then start fresh — so a
+    /// changed `repomind agent` (backend) / model applies without leaving the TUI. Autonomy
+    /// resets to the default, exactly like the view's idempotent auto-start (`load_orchestrator`)
+    /// — the daemon's `orchestrator.start` re-reads `orchestrator_agent`/`orchestrator_model`
+    /// from config on a genuine spawn.
+    async fn restart_orchestrator(&mut self) {
+        self.orch_restart_armed = false;
+        if let Err(e) = self.client.call("orchestrator.stop", None).await {
+            self.status = format!("repomind stop failed: {e}");
+            return;
+        }
+        match self
+            .client
+            .call("orchestrator.start", Some(json!({})))
+            .await
+        {
+            Ok(v) => {
+                self.apply_orchestrator_status(&v);
+                let agent = v
+                    .get("agent")
+                    .and_then(|a| a.as_str())
+                    .unwrap_or("claude (default)");
+                self.status = format!("repomind restarted · agent: {agent}");
+            }
+            Err(e) => self.status = format!("repomind restart failed: {e}"),
+        }
     }
 
     /// Key handling in the command-center view: INSERT forwards to the orchestrator (mirrors
@@ -3005,6 +3039,9 @@ impl App {
             self.send_orch_key(key).await;
             return;
         }
+        // Any key other than the confirming second `r` disarms a pending restart (mirrors the
+        // Fleet view's `X X` repo-removal confirm).
+        let restart_armed = std::mem::take(&mut self.orch_restart_armed);
         match key.code {
             // ↵ / → "go all the way in" = attach to repomind's real tmux pane.
             KeyCode::Enter | KeyCode::Right => {
@@ -3015,6 +3052,16 @@ impl App {
             KeyCode::Char('i') => {
                 self.reset_scroll();
                 self.orch_insert = true;
+            }
+            // `r r` restarts repomind with the saved settings — how a `repomind agent` (backend)
+            // or model change in Settings gets applied to a live session without leaving the TUI.
+            KeyCode::Char('r') if restart_armed => self.restart_orchestrator().await,
+            KeyCode::Char('r') => {
+                self.orch_restart_armed = true;
+                self.status =
+                    "restart repomind with saved settings? it ends the live session — press r \
+                     again to confirm"
+                        .to_string();
             }
             KeyCode::PageUp | KeyCode::Up => self.scroll = self.scroll.saturating_add(8),
             KeyCode::PageDown | KeyCode::Down => self.scroll = self.scroll.saturating_sub(8),

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -43,9 +43,14 @@ pub enum Command {
         #[command(subcommand)]
         cmd: RemoteCmd,
     },
-    /// Talk to repomind — an orchestrator agent that manages the fleet for you. Launches a
-    /// `claude` session wired to the repomon MCP server (and your mnemind memory, if present).
+    /// Talk to repomind — an orchestrator agent that manages the fleet for you. Launches an
+    /// agent session (`claude` by default, `--agent codex` for Codex) wired to the repomon MCP
+    /// server (and your mnemind memory, if present).
     Orchestrate {
+        /// Which agent powers repomind: a Claude account (e.g. claude-work), a custom agent
+        /// name, or codex. Defaults to the `orchestrator_agent` config, then bare claude.
+        #[arg(long)]
+        agent: Option<String>,
         /// How autonomous repomind is: autonomous (default), supervised, or read-only.
         #[arg(long, default_value = "autonomous")]
         autonomy: String,
@@ -185,11 +190,12 @@ pub async fn handle(cmd: Command, config: &Config, socket: Option<PathBuf>) -> R
         Command::Daemon { cmd } => handle_daemon(cmd, config).await?,
         Command::Remote { cmd } => handle_remote(cmd)?,
         Command::Orchestrate {
+            agent,
             autonomy,
             max_agents,
             model,
             prompt,
-        } => handle_orchestrate(config, socket, autonomy, max_agents, model, prompt).await?,
+        } => handle_orchestrate(config, socket, agent, autonomy, max_agents, model, prompt).await?,
         Command::Completions { shell } => {
             use clap::CommandFactory;
             let mut cmd = crate::Cli::command();
@@ -292,9 +298,11 @@ fn handle_remote(cmd: RemoteCmd) -> Result<()> {
 /// start (or reuse) the single daemon-owned orchestrator session, then `tmux attach` to that
 /// durable window. The session-building (MCP config + `claude` invocation) now lives daemon-side
 /// in `orchestrator.start`, so the CLI and the TUI drive **one** shared orchestrator.
+#[allow(clippy::too_many_arguments)]
 async fn handle_orchestrate(
     config: &Config,
     socket: Option<PathBuf>,
+    agent: Option<String>,
     autonomy: String,
     max_agents: Option<usize>,
     model: Option<String>,
@@ -331,6 +339,9 @@ async fn handle_orchestrate(
     // Start (or adopt) the orchestrator session. Idempotent: a no-op if one is already running.
     let mut start = serde_json::Map::new();
     start.insert("autonomy".into(), json!(autonomy));
+    if let Some(agent) = &agent {
+        start.insert("agent".into(), json!(agent));
+    }
     if let Some(model) = &model {
         start.insert("model".into(), json!(model));
     }

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -268,7 +268,11 @@ fn render_settings(f: &mut Frame, app: &App) {
             onoff(s.expand_agents),
             "per-agent sidebar rows · space toggles",
         ),
-        ("repomind account", orch_agent, "←/→ cycle · Claude account"),
+        (
+            "repomind agent",
+            orch_agent,
+            "←/→ cycle · Claude account or codex",
+        ),
         (
             "repomind model",
             orch_model,

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -895,7 +895,7 @@ fn render_fleet(f: &mut Frame, app: &App) {
     f.render_widget(footer(FLEET_KEYS, app, rows[1].width), rows[1]);
 }
 
-const ORCH_KEYS: &str = "i message repomind · ↵/→ attach (full terminal) · ↑↓/PgUp/wheel scroll · click lane to jump  ·  ←/esc back · q quit";
+const ORCH_KEYS: &str = "i message repomind · ↵/→ attach (full terminal) · r r restart (saved settings) · ↑↓/PgUp/wheel scroll · click lane to jump  ·  ←/esc back · q quit";
 const ORCH_INSERT_KEYS: &str =
     "type to repomind · ↵ send · ^O leave insert · PgUp/PgDn scroll · esc/^C → repomind";
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,19 +68,23 @@ alert still reaches you when you're heads-down in an agent pane.
 **History.** On startup and after `repo.add`, the indexer walks HEAD history into SQLite, so
 `timeline`, `sessions`, and `commit.search` work over history rather than just live HEAD.
 
-**repomind.** The orchestrator is a daemon-owned `claude` session running in its own
-`orchestrator` tmux window (`orchestrator.start`/`.stop`), reachable like any other window
-(`.target`/`.send_input`/`.key`/`.resize`). `repomon-mcp` (invoked as `repomond mcp`) is a
-stdio MCP server the orchestrator's `claude` launches as a subprocess and wires up as a tool
-server; it connects back to the same daemon socket as an ordinary client and keeps a fleet
-snapshot refreshed by poll-and-diff (`lane.list` on a ~1.5s cadence, woken early on a
-structural event — a lane created/deleted). Because that `claude` session pre-approves its own
-fleet tool calls (no permission dialog to intercept, unlike a worker agent), the MCP server's
-own policy layer — autonomy level, a per-session action cap, a send-dedupe window, two-phase
+**repomind.** The orchestrator is a daemon-owned agent session — Claude by default, Codex CLI
+optionally (`orchestrator.start`'s `agent` param, the `orchestrator_agent` config) — running in
+its own `orchestrator` tmux window (`orchestrator.start`/`.stop`), reachable like any other
+window (`.target`/`.send_input`/`.key`/`.resize`). Only MCP-capable CLIs qualify (aider can't
+drive the fleet tools, so it's rejected); a Codex-backed session degrades to pane-only
+monitoring — no parsed transcript chat, no end-of-turn attention, no session pinning.
+`repomon-mcp` (invoked as `repomond mcp`) is a stdio MCP server the orchestrator agent launches
+as a subprocess and wires up as a tool server; it connects back to the same daemon socket as an
+ordinary client and keeps a fleet snapshot refreshed by poll-and-diff (`lane.list` on a ~1.5s
+cadence, woken early on a structural event — a lane created/deleted). Because the orchestrator
+session pre-approves its own fleet tool calls (`--allowedTools` on Claude, the approval policy
+on Codex — no permission dialog to intercept, unlike a worker agent), the MCP server's own
+policy layer — autonomy level, a per-session action cap, a send-dedupe window, two-phase
 confirm tokens for destructive actions — is the *sole* gate on what repomind can do. The
 daemon's `notify_watch` tick, the same one that fires desktop alerts for lane agents, also
-classifies repomind's own attention (a pending dialog, or an idle end-of-turn) each pass and
-broadcasts it as `event.orchestrator.status`.
+classifies repomind's own attention (a pending dialog, or — Claude only — an idle end-of-turn)
+each pass and broadcasts it as `event.orchestrator.status`.
 
 ## Performance posture
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -94,9 +94,9 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `daemon.status` | — | `{ uptime_secs, repos, lanes, db_size_bytes, version }` |
 | `daemon.shutdown` | — | `null` |
 | `usage.get` | — | `[AccountUsage]` (per agent account, scraped from Claude `/usage` and Codex `/status`; empty unless `usage_probe` is enabled and a TUI is attached) |
-| `orchestrator.status` | — | `{ running, agent?, model?, window?, autonomy?, session_id?, attention, headline? }` (the daemon-owned repomind orchestrator; reconciles against tmux, so a window killed externally reports `running:false`) |
-| `orchestrator.transcript` | `{ limit? }` | `[TranscriptItem]` (repomind's conversation, same `{ role, text, at? }` shape as `agent.transcript`, so a client can render it as a chat instead of mirroring the pane; pinned to the orchestrator's own `session_id` when known, else falls back to the newest `$HOME` Claude transcript with real content across accounts) |
-| `orchestrator.start` | `{ agent?, model?, autonomy?, max_agents?, prompt? }` | `{ running, agent?, model?, window?, autonomy?, session_id?, attention, headline? }` (spawn or adopt the singleton `orchestrator` window running `claude` wired to the repomon MCP server; idempotent; re-spawns if the prior window died) |
+| `orchestrator.status` | — | `{ running, agent?, model?, backend?, window?, autonomy?, session_id?, attention, headline? }` (the daemon-owned repomind orchestrator; reconciles against tmux, so a window killed externally reports `running:false`) |
+| `orchestrator.transcript` | `{ limit? }` | `[TranscriptItem]` (repomind's conversation, same `{ role, text, at? }` shape as `agent.transcript`, so a client can render it as a chat instead of mirroring the pane; pinned to the orchestrator's own `session_id` when known, else falls back to the newest `$HOME` Claude transcript with real content across accounts. Always `[]` while `backend` is `"codex"` — codex's on-disk session format is not parsed; treat it as "no chat view for this backend" and render the `event.orchestrator.output` pane stream instead, never as an error/loading state) |
+| `orchestrator.start` | `{ agent?, model?, autonomy?, max_agents?, prompt? }` | `{ running, agent?, model?, backend?, window?, autonomy?, session_id?, attention, headline? }` (spawn or adopt the singleton `orchestrator` window wired to the repomon MCP server; idempotent; re-spawns if the prior window died. `agent` picks the backend: a Claude account / custom agent name / `codex`; an agent with no MCP client — e.g. `aider` — is rejected with `invalid_params` instead of spawning a broken window) |
 | `orchestrator.stop` | — | `{ running:false, attention:"none", headline:null, … }` (kill the orchestrator window) |
 | `orchestrator.target` | — | `{ target, available }` (attach target for the orchestrator window; resets it to follow the attaching client's size) |
 | `orchestrator.send_input` | `{ text, enter=true }` | `null` (type an instruction to repomind, then Enter unless `enter=false`) |
@@ -111,6 +111,12 @@ The `orchestrator` window is deliberately not a `lane-*` name, so it never appea
 `permission`/`decision` (the open dialog's question) or `end_of_turn` (a tail of repomind's
 last message, when cheaply available); always `null` when `attention` is `"none"`.
 
+`backend` is the normalized agent CLI the session runs on — `"claude"` or `"codex"` (`null`
+when not running) — and is what clients should switch rendering on (`agent` is the raw
+launch name, e.g. `claude-work`). A `"codex"` session is monitored best-effort from its pane
+only: `orchestrator.transcript` is always `[]`, `attention` never reports `"end_of_turn"`
+(pane dialogs may still surface `permission`/`decision`), and `session_id` is always `null`.
+
 `autonomy` is the level the running session was actually started with (the value passed to, or
 defaulted by, `orchestrator.start`). It is `null` when the daemon *adopted* a window that
 survived a restart of a previous daemon process — the adopting process has no record of what
@@ -122,7 +128,9 @@ end-of-turn attention check to *this* session's own transcript file — instead 
 newest `$HOME` transcript", which misattributes any other active Claude session on the machine as
 repomind's. Like `autonomy`, it is `null` when the daemon *adopted* a surviving window: the prior
 process's session id lived only in its own memory, so an adopted session falls back to the old
-newest-with-content heuristic.
+newest-with-content heuristic. Always `null` for a `"codex"` backend (codex has no equivalent of
+`--session-id`, and its session files aren't parsed — the fallback heuristic is deliberately NOT
+applied there, since it would misattribute an unrelated Claude session's transcript).
 
 **Remote bridge:** of the orchestrator methods above, `status`/`transcript`/`send_input`/`key`
 are allowed over the WebSocket bridge (read + interact, like their `agent.*` equivalents);
@@ -166,6 +174,6 @@ when readable (a partial parse still returns what it could).
 | `event.agent.changed` | `{ name }` or `{ default }` (a custom agent was added/removed, or the default changed) |
 | `event.notification` | `{ lane_id, session_id?, kind, title, body, prompt? }` — daemon-side agent alert (kinds: `needs_you`, `rate_limited`, `resumed`, `idle`; `prompt` is the agent's pending question verbatim). Emitted only while `[remote]` is enabled; the same alert goes to APNs devices with category `AGENT_PROMPT` (actionable) or `AGENT_ALERT`. |
 | `event.orchestrator.output` | `{ content, cursor? }` — the repomind pane's text (and `[col, row]` cursor) streamed while watched; same shape as `event.agent.output` without `lane_id`. |
-| `event.orchestrator.status` | `{ running, agent?, model?, window?, autonomy?, session_id?, attention, headline? }` — broadcast when the orchestrator starts, stops, is reconciled to stopped after its window died, or its `attention` changes. |
+| `event.orchestrator.status` | `{ running, agent?, model?, backend?, window?, autonomy?, session_id?, attention, headline? }` — broadcast when the orchestrator starts, stops, is reconciled to stopped after its window died, or its `attention` changes. |
 
 Object ids travel as lowercase hex strings; timestamps as RFC3339 UTC.


### PR DESCRIPTION
## Summary

repomind was hardwired as a Claude session. This makes the orchestrator backend switchable — **Claude (default, unchanged) or Codex CLI** — behind a small `OrchestratorBackend` seam, with graceful degradation for Codex and two real bugs fixed along the way.

- **Backend seam** (`OrchestratorBackend` in repomon-daemon): resolution maps `None`/`claude*`/custom agents → Claude, `codex` → Codex, and rejects MCP-less agents (`aider`, `cursor`) with `invalid_params` instead of silently spawning a broken window.
- **Codex command builder** (verified live against codex-cli 0.142.3): fleet MCP server registered inline via `-c` TOML overrides (no config file), persona prepended to the initial prompt (no `--append-system-prompt` equivalent), autonomy mapped to `-a`/`-s` flags; `REPOMON_MCP_AUTONOMY` in the MCP server env remains the real guardrail.
- **Graceful degradation**: Codex sessions never mint a `session_id`, `orchestrator.transcript` answers `[]` before any `~/.claude` scan, and the notify-watch end-of-turn check skips the transcript picker — whose `None`-id fallback would otherwise misattribute an unrelated live Claude session's transcript as repomind's.
- **Codex dialog detection**: `parse_option_line` learns codex's `›` cursor glyph (live fixture from a supervised codex orchestrator), so codex dialogs — including its MCP tool-call approval, now a permission-class marker — surface through the full attention loop (`permission` + question headline). Benefits codex worker agents too.
- **Wire/protocol**: additive `backend` field (`"claude"|"codex"|null`) on orchestrator status payloads; documented in protocol.md. **The iOS companion (RepomonKit) must mirror**: the `backend` field, and empty-transcript-while-running as "no chat view for this backend".
- **Surfaces**: `repomon orchestrate --agent codex`, codex in the TUI settings picker.

## Bug fixes (found in-path)

- **`orchestrator.start` TOCTOU**: the handler dropped the session lock between its "already running?" check and recording the spawn, so two concurrent starts (TUI auto-start + `repomon orchestrate`) could double-spawn or adopt-overwrite each other's session. The lock is now held across check → adopt/spawn → record; regression test drives two racing connections.
- **`repomond --socket X` broke repomind's MCP wiring**: the orchestrator spawn path derived `REPOMON_MCP_SOCKET` from config, not the actually-bound socket, so the MCP server connected to a dead socket and failed its initialize handshake. CLI override is now reflected into the in-memory config.

## Test plan

- [x] Unit: backend resolution table, codex builder (flag presence/absence per autonomy), Claude builder unchanged, status `backend` field
- [x] Integration: concurrent-start race (red before fix), codex degradation contract (`backend:"codex"`, null `session_id`, `[]` transcript), `aider` rejection
- [x] Full workspace: 273+ tests green, clippy clean
- [x] Live e2e (codex-cli 0.142.3, isolated daemon): spawn ✓, MCP handshake + `fleet_status` tool call ✓, supervised approval dialog classified as `permission` with question headline ✓, approval via `orchestrator.key` ✓, adopt-after-daemon-restart records backend ✓, transcript `[]` ✓, stop/reconcile ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)