### PR TITLE
feat: full Linux support — systemd service, notifications, clipboard, /proc probe, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup show # installs the rust-toolchain.toml version
+      - name: Install tmux (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all --check
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - run: cargo test --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,25 +37,32 @@ jobs:
             repomon-*.tar.gz.sha256
 
   build-linux:
-    # x86_64 Linux, built natively on the ubuntu runner.
-    runs-on: ubuntu-latest
+    # Each Linux arch builds natively on its own runner (no cross C toolchain needed).
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - run: rustup show
-      - run: rustup target add x86_64-unknown-linux-gnu
-      - run: cargo build --release --locked --target x86_64-unknown-linux-gnu
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --release --locked --target ${{ matrix.target }}
       - name: Package
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          DIST="repomon-${VERSION}-x86_64-unknown-linux-gnu"
+          DIST="repomon-${VERSION}-${{ matrix.target }}"
           mkdir -p "$DIST"
-          cp "target/x86_64-unknown-linux-gnu/release/repomon" \
-             "target/x86_64-unknown-linux-gnu/release/repomond" "$DIST/"
+          cp "target/${{ matrix.target }}/release/repomon" \
+             "target/${{ matrix.target }}/release/repomond" "$DIST/"
           tar -czf "${DIST}.tar.gz" -C "$DIST" repomon repomond
           sha256sum "${DIST}.tar.gz" | awk '{print $1}' > "${DIST}.tar.gz.sha256"
       - uses: actions/upload-artifact@v4
         with:
-          name: x86_64-unknown-linux-gnu
+          name: ${{ matrix.target }}
           path: |
             repomon-*.tar.gz
             repomon-*.tar.gz.sha256

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ is a thin client. Four crates:
 
 ## Install
 
-**One line, no deps** (macOS & Linux x86_64, incl. WSL2; prebuilt binaries, no Rust or Xcode):
+**One line, no deps** (macOS & Linux, x86_64 / aarch64, incl. WSL2; prebuilt binaries, no Rust or Xcode):
 
 ```sh
 curl -fsSL https://github.com/AliHamzaAzam/repomon/releases/latest/download/install.sh | sh
@@ -111,8 +111,7 @@ Or grab a tarball from the [latest release](https://github.com/AliHamzaAzam/repo
 per-arch (`aarch64`/`x86_64`) or the `universal` build, then extract, and put `repomon` and `repomond`
 on your `PATH`.
 
-**From source**: any platform with the Rust toolchain (e.g. ARM Linux, or anywhere without a
-prebuilt binary):
+**From source**: any platform with the Rust toolchain (anywhere without a prebuilt binary):
 
 ```sh
 cargo install --git https://github.com/AliHamzaAzam/repomon repomon-tui repomon-daemon
@@ -128,6 +127,26 @@ Then enable cd-on-exit by adding to your `~/.zshrc` (or `~/.bashrc`):
 ```sh
 eval "$(repomon shell-init zsh)"
 ```
+
+### Run the daemon as a service (optional)
+
+The TUI auto-starts `repomond` on demand, so a service is never required. To keep the daemon
+(and its notifications) alive across logins:
+
+```sh
+repomon daemon install     # macOS: launchd LaunchAgent · Linux: systemd user unit
+```
+
+On Linux this writes `~/.config/systemd/user/repomon.service`; run
+`loginctl enable-linger` if you want `repomond` to survive logout.
+
+### Linux platform notes
+
+- Desktop notifications use `notify-send` (libnotify); the chime plays through
+  `canberra-gtk-play` or `paplay` when present.
+- Clipboard copy uses `wl-copy` (Wayland) or `xclip` (X11); inside tmux, drag-select falls
+  back to OSC52 when neither is installed. Image paste needs `wl-paste` or `xclip`.
+- Click-to-focus notifications are macOS-only (`terminal-notifier`).
 
 ## Usage
 
@@ -232,9 +251,10 @@ babysit grid, multi-agent lanes), the history dashboard (timeline/sessions/searc
 per-session notifications (pane-sniffed permission-dialog detection, fired as desktop popups
 even when the TUI is closed or parked full-screen in an agent), the remote access layer
 (WebSocket bridge + APNs + pairing), and repomind (the MCP-driven fleet orchestrator —
-`repomon orchestrate` and the TUI command-center) are all in. The iOS companion app is built
-and ships once an Apple Developer account is in place. Deferred: an embedded PTY renderer (vs
-the tmux pivot), a web dashboard, and Windows support.
+`repomon orchestrate` and the TUI command-center) are all in, on macOS and Linux (systemd
+service, notifications, clipboard, and process probing all have native Linux paths). The iOS
+companion app is built and ships once an Apple Developer account is in place. Deferred: an
+embedded PTY renderer (vs the tmux pivot), a web dashboard, and Windows support.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # repomon — Completion Status
 
-_Snapshot: 2026-05-30 · branch `main` · 44 commits · github.com/AliHamzaAzam/repomon (private)_
+_Snapshot: 2026-07-06 · branch `main` · 248 commits · github.com/AliHamzaAzam/repomon (public)_
 
 repomon is a Rust TUI for running a fleet of AI coding agents across many repos,
 branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned milestones
@@ -19,7 +19,8 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
 
 ## Quality bar (verified)
 
-- **65 tests passing** — core unit + rpc unit + daemon integration + TUI snapshots.
+- **288 tests passing** (macOS; the Linux CI leg adds Linux-only ones) — core unit + rpc unit +
+  daemon integration (incl. MCP stdio e2e + orchestrator lifecycle) + TUI snapshots.
 - **clippy `-D warnings` clean**, `cargo fmt` clean.
 - **Perf gates met:**
   - daemon cold start **108 ms** (target < 500)
@@ -56,6 +57,12 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
   per `~/.claude*` account) and Codex `/status` (5h/weekly or Free monthly). Scraped via a hidden
   throwaway session per account (`usage_watch.rs` + fixture-tested `agent/usage.rs`), with a
   rate-limit countdown fallback. See `docs/agents.md`.
+- **repomind** — the MCP-driven fleet orchestrator (`repomon orchestrate` + TUI command-center)
+  with a switchable backend (Claude or Codex). Shipped in v0.3.0.
+- **Full Linux support** — systemd user service (`repomon daemon install`), notify-send
+  notifications with sound, wl-copy/xclip clipboard (OSC52 fallback in tmux), image paste via
+  wl-paste/xclip, and a /proc-based liveness probe. CI runs the suite on macOS + Ubuntu;
+  releases ship x86_64 and aarch64 Linux binaries.
 
 ## Deferred (explicitly out of scope in the plan)
 
@@ -68,8 +75,9 @@ SwiftUI menu-bar app · native repomon-owned PTY mode · web dashboard · Window
   mtime). Claude is the rich path (status, needs-you, multi-account).
 - **cd-on-exit (`c`)** only acts when the `repomon` shell function is installed (it sets
   `$REPOMON_CD_FD`); otherwise it shows a hint instead of quitting.
-- In agent views (Focus/Split/Grid) the daemon refreshes ~1 s and runs a cached (2 s)
-  `pgrep`/`lsof` liveness probe — light, but slightly more active than the 0% Fleet idle.
+- In agent views (Focus/Split/Grid) the daemon refreshes ~1 s and runs a cached liveness
+  probe (`ps`+`lsof` on macOS, `/proc` on Linux) — light, but slightly more active than the
+  0% Fleet idle.
 
 ## Suggested next steps
 

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -441,17 +441,24 @@ impl TmuxRuntime {
         let _ = self.run(&["set", "-g", "set-clipboard", "on"]);
         // History deep enough to scroll back through a long plan.
         let _ = self.run(&["set", "-g", "history-limit", "50000"]);
+        // Drag-select pipes into the platform clipboard tool when one exists; otherwise fall
+        // back to tmux's own buffer, which `set-clipboard on` above still forwards to the
+        // terminal's clipboard via OSC52 on modern emulators.
+        let pipe = crate::clipboard::copy_pipe_command();
         for table in ["copy-mode", "copy-mode-vi"] {
-            let _ = self.run(&[
-                "bind",
-                "-T",
-                table,
-                "MouseDragEnd1Pane",
-                "send",
-                "-X",
-                "copy-pipe-and-cancel",
-                "pbcopy",
-            ]);
+            let bind = ["bind", "-T", table, "MouseDragEnd1Pane", "send", "-X"];
+            let _ = match &pipe {
+                Some(cmd) => {
+                    let mut args = bind.to_vec();
+                    args.extend(["copy-pipe-and-cancel", cmd.as_str()]);
+                    self.run(&args)
+                }
+                None => {
+                    let mut args = bind.to_vec();
+                    args.push("copy-selection-and-cancel");
+                    self.run(&args)
+                }
+            };
         }
 
         // A thin status bar that always shows the way back, so detaching is discoverable.

--- a/crates/repomon-core/src/clipboard.rs
+++ b/crates/repomon-core/src/clipboard.rs
@@ -1,0 +1,95 @@
+//! Writing to the system clipboard, shared by the TUI and the tmux copy binding.
+//!
+//! The tool is probed rather than `cfg`-gated: one testable selection path covers pbcopy on
+//! macOS, wl-copy/xclip on Linux, and shims wherever they appear.
+
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+/// The clipboard-write command for this platform, probed once per process. `None` when no
+/// clipboard tool is installed (callers fall back to tmux's OSC52 path or skip the copy).
+pub fn copy_argv() -> Option<&'static [String]> {
+    static ARGV: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    ARGV.get_or_init(|| {
+        let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some_and(|v| !v.is_empty());
+        select_copy_argv(wayland, |bin| crate::exec::find_in_path(bin).is_some())
+    })
+    .as_deref()
+}
+
+/// Preference order: pbcopy (macOS), then the display server's native tool — wl-copy under
+/// Wayland, xclip under X11 — then wl-copy as a last resort (covers Wayland sessions where
+/// `$WAYLAND_DISPLAY` isn't exported to the daemon).
+fn select_copy_argv(wayland: bool, has: impl Fn(&str) -> bool) -> Option<Vec<String>> {
+    let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect();
+    if has("pbcopy") {
+        return Some(owned(&["pbcopy"]));
+    }
+    if wayland && has("wl-copy") {
+        return Some(owned(&["wl-copy"]));
+    }
+    if has("xclip") {
+        return Some(owned(&["xclip", "-selection", "clipboard", "-in"]));
+    }
+    if has("wl-copy") {
+        return Some(owned(&["wl-copy"]));
+    }
+    None
+}
+
+/// The copy command as one string, for tmux's `copy-pipe-and-cancel` (argv parts are bare
+/// tool names and flags, so space-joining is quoting-safe).
+pub fn copy_pipe_command() -> Option<String> {
+    copy_argv().map(|argv| argv.join(" "))
+}
+
+/// Pipe `text` into the platform clipboard tool, best-effort.
+pub fn copy_text(text: &str) {
+    use std::io::Write;
+    let Some(argv) = copy_argv() else { return };
+    if let Ok(mut child) = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+    {
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(text.as_bytes());
+        }
+        let _ = child.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_pbcopy_when_present() {
+        let argv = select_copy_argv(true, |b| b == "pbcopy" || b == "wl-copy").unwrap();
+        assert_eq!(argv, ["pbcopy"]);
+    }
+
+    #[test]
+    fn wayland_picks_wl_copy_over_xclip() {
+        let argv = select_copy_argv(true, |b| b == "wl-copy" || b == "xclip").unwrap();
+        assert_eq!(argv, ["wl-copy"]);
+    }
+
+    #[test]
+    fn x11_picks_xclip_with_clipboard_selection() {
+        let argv = select_copy_argv(false, |b| b == "xclip").unwrap();
+        assert_eq!(argv, ["xclip", "-selection", "clipboard", "-in"]);
+    }
+
+    #[test]
+    fn wl_copy_is_the_last_resort_without_wayland() {
+        let argv = select_copy_argv(false, |b| b == "wl-copy").unwrap();
+        assert_eq!(argv, ["wl-copy"]);
+    }
+
+    #[test]
+    fn none_when_no_tool_exists() {
+        assert_eq!(select_copy_argv(false, |_| false), None);
+    }
+}

--- a/crates/repomon-core/src/exec.rs
+++ b/crates/repomon-core/src/exec.rs
@@ -1,0 +1,74 @@
+//! Locating external tools on `$PATH`.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// First executable hit for `bin` on `$PATH`, or `None` when it isn't installed.
+pub fn find_in_path(bin: &str) -> Option<PathBuf> {
+    find_in(std::env::var_os("PATH")?.as_os_str(), bin)
+}
+
+fn find_in(path_var: &OsStr, bin: &str) -> Option<PathBuf> {
+    std::env::split_paths(path_var)
+        .map(|dir| dir.join(bin))
+        .find(|cand| is_executable(cand))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[test]
+    fn finds_executable_on_synthetic_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = dir.path().join("sometool");
+        std::fs::write(&tool, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        make_executable(&tool);
+        let path_var = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(find_in(&path_var, "sometool"), Some(tool));
+        assert_eq!(find_in(&path_var, "missing"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_non_executable_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("plainfile"), "data").unwrap();
+        let path_var = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(find_in(&path_var, "plainfile"), None);
+    }
+
+    #[test]
+    fn first_path_entry_wins() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        for dir in [&a, &b] {
+            let tool = dir.path().join("dup");
+            std::fs::write(&tool, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            make_executable(&tool);
+        }
+        let path_var = std::env::join_paths([a.path(), b.path()]).unwrap();
+        assert_eq!(find_in(&path_var, "dup"), Some(a.path().join("dup")));
+    }
+}

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -9,8 +9,10 @@
 pub mod agent;
 pub mod analytics;
 pub mod client;
+pub mod clipboard;
 pub mod config;
 pub mod error;
+pub mod exec;
 pub mod git;
 pub mod indexer;
 pub mod lane;

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -353,11 +353,14 @@ pub fn play_chime() {
             .arg(NOTIFY_SOUND_FILE)
             .output();
     });
+    #[cfg(not(target_os = "macos"))]
+    std::thread::spawn(play_sound_blocking);
 }
 
 /// Fire a native desktop notification, best-effort and without blocking the caller (the actual
 /// `osascript`/`notify-send` invocation runs on a detached thread). `click_focus` makes the popup
-/// click-to-focus the terminal when `terminal-notifier` is installed (plain popup otherwise).
+/// click-to-focus the terminal when `terminal-notifier` is installed (macOS only — on Linux
+/// there is no portable way to focus a terminal from a background process, so it's ignored).
 pub fn send_native(title: &str, body: &str, sound: bool, click_focus: bool) {
     let (title, body) = (title.to_string(), body.to_string());
     std::thread::spawn(move || {
@@ -446,12 +449,70 @@ fn terminal_bundle_id(term_program: &str) -> Option<&'static str> {
     }
 }
 
+/// Deliver via `notify-send` (libnotify/DBus). The `sound-name` hint covers desktops that honor
+/// it; the local player in [`play_sound_blocking`] covers the rest. Both are best-effort no-ops
+/// on headless boxes.
 #[cfg(not(target_os = "macos"))]
-fn run_native(title: &str, body: &str, _sound: bool, _click_focus: bool) {
+fn run_native(title: &str, body: &str, sound: bool, _click_focus: bool) {
     let _ = std::process::Command::new("notify-send")
-        .arg(title)
-        .arg(body)
+        .args(notify_send_args(title, body, sound))
         .output();
+    if sound {
+        play_sound_blocking();
+    }
+}
+
+/// Arguments for `notify-send`: app name, normal urgency, the freedesktop sound hint when
+/// `sound` is on, and title/body last behind `--` so they can never parse as flags. Pure and
+/// compiled everywhere so the shape is tested on every platform.
+pub fn notify_send_args(title: &str, body: &str, sound: bool) -> Vec<String> {
+    let mut args: Vec<String> = ["-a", "repomon", "-u", "normal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    if sound {
+        args.push("-h".into());
+        args.push("string:sound-name:message-new-instant".into());
+    }
+    args.push("--".into());
+    args.push(title.to_string());
+    args.push(body.to_string());
+    args
+}
+
+/// The local chime player, probed once per process: canberra (plays the themed event sound),
+/// else `paplay` with a freedesktop sound file that exists. `None` = no way to play a sound.
+#[cfg(not(target_os = "macos"))]
+fn sound_argv() -> Option<&'static [String]> {
+    fn locate() -> Option<Vec<String>> {
+        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect();
+        if crate::exec::find_in_path("canberra-gtk-play").is_some() {
+            return Some(owned(&["canberra-gtk-play", "-i", "message-new-instant"]));
+        }
+        if crate::exec::find_in_path("paplay").is_some() {
+            for file in [
+                "/usr/share/sounds/freedesktop/stereo/message-new-instant.oga",
+                "/usr/share/sounds/freedesktop/stereo/message.oga",
+            ] {
+                if std::path::Path::new(file).exists() {
+                    return Some(owned(&["paplay", file]));
+                }
+            }
+        }
+        None
+    }
+    static ARGV: std::sync::OnceLock<Option<Vec<String>>> = std::sync::OnceLock::new();
+    ARGV.get_or_init(locate).as_deref()
+}
+
+/// Play the notification chime through whatever player this box has, if any.
+#[cfg(not(target_os = "macos"))]
+fn play_sound_blocking() {
+    if let Some(argv) = sound_argv() {
+        let _ = std::process::Command::new(&argv[0])
+            .args(&argv[1..])
+            .output();
+    }
 }
 
 /// Escape a string for embedding in an AppleScript double-quoted literal.
@@ -466,6 +527,21 @@ mod tests {
     use crate::model::{AgentKind, Repo, Worktree, WorktreeState};
     use chrono::Utc;
     use std::path::PathBuf;
+
+    #[test]
+    fn notify_send_args_carry_app_urgency_and_sound_hint() {
+        let args = notify_send_args("Title", "Body", true);
+        assert_eq!(&args[..4], ["-a", "repomon", "-u", "normal"]);
+        assert!(args.contains(&"string:sound-name:message-new-instant".to_string()));
+        assert_eq!(&args[args.len() - 3..], ["--", "Title", "Body"]);
+    }
+
+    #[test]
+    fn notify_send_args_skip_the_hint_when_silent() {
+        let args = notify_send_args("T", "B", false);
+        assert!(!args.iter().any(|a| a.contains("sound-name")));
+        assert_eq!(&args[args.len() - 3..], ["--", "T", "B"]);
+    }
 
     /// A minimal real-or-inferred session, mirroring the daemon's `overlay_agents` literals.
     fn sess(session_id: Option<&str>, status: AgentStatus, inferred: bool) -> AgentSession {

--- a/crates/repomon-core/src/service.rs
+++ b/crates/repomon-core/src/service.rs
@@ -1,8 +1,9 @@
-//! Daemon service management (macOS launchd).
+//! Daemon service management (launchd on macOS, systemd user units on Linux).
 //!
 //! Lives in `repomon-core` because the `repomon daemon …` subcommands run from the TUI
-//! binary and must drive install/start/stop without depending on the daemon crate. The
-//! systemd-user equivalent can land later; non-macOS targets get a clear error.
+//! binary and must drive install/start/stop without depending on the daemon crate. A
+//! service is optional on every platform — the TUI auto-spawns `repomond` on demand —
+//! so failures here surface as advice, not as a wall.
 
 use std::path::{Path, PathBuf};
 
@@ -10,6 +11,9 @@ use crate::error::{Error, Result};
 
 /// The launchd label / service identifier.
 pub const LABEL: &str = "com.repomon.daemon";
+
+/// The systemd user unit name (Linux twin of [`LABEL`]).
+pub const UNIT_NAME: &str = "repomon.service";
 
 /// Where logs are written (`<data_dir>/logs`).
 pub fn log_dir() -> PathBuf {
@@ -55,12 +59,62 @@ pub fn generate_plist(program: &Path, socket: &Path) -> String {
     )
 }
 
+/// Generate the systemd user unit for running `program --socket <socket>`. `append:` logging
+/// keeps `repomon daemon logs` and the TUI log view reading the same files launchd writes on
+/// macOS (needs systemd ≥ 240; `journalctl --user -u repomon` works regardless).
+pub fn generate_unit(program: &Path, socket: &Path) -> String {
+    let logs = log_dir();
+    let out = logs.join("repomond.out.log");
+    let err = logs.join("repomond.err.log");
+    format!(
+        r#"[Unit]
+Description=repomon daemon (repomond)
+
+[Service]
+ExecStart="{program}" --socket "{socket}"
+Restart=always
+RestartSec=2
+StandardOutput=append:{out}
+StandardError=append:{err}
+
+[Install]
+WantedBy=default.target
+"#,
+        program = program.display(),
+        socket = socket.display(),
+        out = out.display(),
+        err = err.display(),
+    )
+}
+
+/// The operations `repomon daemon …` drives through `systemctl --user`.
+pub enum ServiceOp {
+    DaemonReload,
+    EnableNow,
+    DisableNow,
+    Stop,
+    Restart,
+    IsActive,
+}
+
+/// The `systemctl` argv for an operation — pure, so the shapes are testable on every platform.
+pub fn systemctl_user_args(op: ServiceOp) -> Vec<&'static str> {
+    match op {
+        ServiceOp::DaemonReload => vec!["--user", "daemon-reload"],
+        ServiceOp::EnableNow => vec!["--user", "enable", "--now", UNIT_NAME],
+        ServiceOp::DisableNow => vec!["--user", "disable", "--now", UNIT_NAME],
+        ServiceOp::Stop => vec!["--user", "stop", UNIT_NAME],
+        ServiceOp::Restart => vec!["--user", "restart", UNIT_NAME],
+        ServiceOp::IsActive => vec!["--user", "is-active", UNIT_NAME],
+    }
+}
+
 #[cfg(target_os = "macos")]
 mod platform {
     use super::*;
     use std::process::Command;
 
-    pub fn plist_path() -> PathBuf {
+    pub fn service_file_path() -> PathBuf {
         dirs_home()
             .join("Library/LaunchAgents")
             .join(format!("{LABEL}.plist"))
@@ -94,7 +148,7 @@ mod platform {
 
     pub fn install(program: &Path, socket: &Path) -> Result<()> {
         std::fs::create_dir_all(log_dir())?;
-        let plist = plist_path();
+        let plist = service_file_path();
         if let Some(parent) = plist.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -107,7 +161,7 @@ mod platform {
     }
 
     pub fn uninstall() -> Result<()> {
-        let plist = plist_path();
+        let plist = service_file_path();
         let domain = format!("gui/{}", uid()?);
         let _ = launchctl(&["bootout", &domain, &plist.to_string_lossy()]);
         if plist.exists() {
@@ -134,15 +188,143 @@ mod platform {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+    use std::process::Command;
+
+    /// `$XDG_CONFIG_HOME/systemd/user/repomon.service` (`~/.config/…` by default).
+    pub fn service_file_path() -> PathBuf {
+        let base = match std::env::var("XDG_CONFIG_HOME") {
+            Ok(x) if !x.is_empty() => PathBuf::from(x),
+            _ => dirs_home().join(".config"),
+        };
+        base.join("systemd").join("user").join(UNIT_NAME)
+    }
+
+    fn dirs_home() -> PathBuf {
+        directories::BaseDirs::new()
+            .map(|b| b.home_dir().to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// `Err(reason)` when systemd user services can't work here. The daemon still runs without
+    /// one — the TUI auto-spawns `repomond` — so callers surface this as advice, not a wall.
+    fn systemd_available() -> std::result::Result<(), String> {
+        const HINT: &str = "the TUI auto-starts repomond, so a service is optional";
+        // The documented probe for "is systemd PID 1 here" — absent in containers and on
+        // non-systemd inits.
+        if !Path::new("/run/systemd/system").exists() {
+            return Err(format!(
+                "systemd is not managing this system (e.g. a container); {HINT}"
+            ));
+        }
+        match Command::new("systemctl")
+            .args(["--user", "is-system-running"])
+            .output()
+        {
+            Err(_) => Err(format!("systemctl not found; {HINT}")),
+            Ok(out) => {
+                let state = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                // Any live user manager will do; "offline" or a DBus connection error mean
+                // there is no user session for `--user` units (common over bare SSH).
+                if matches!(
+                    state.as_str(),
+                    "running" | "degraded" | "starting" | "initializing" | "maintenance"
+                ) {
+                    Ok(())
+                } else {
+                    let state = if state.is_empty() {
+                        "unreachable".to_string()
+                    } else {
+                        state
+                    };
+                    Err(format!(
+                        "no systemd user session (state: {state}); try `loginctl enable-linger $USER`; {HINT}"
+                    ))
+                }
+            }
+        }
+    }
+
+    fn systemctl(op: ServiceOp) -> Result<String> {
+        let args = systemctl_user_args(op);
+        let out = Command::new("systemctl")
+            .args(&args)
+            .output()
+            .map_err(Error::Io)?;
+        if !out.status.success() {
+            return Err(Error::Other(format!(
+                "systemctl {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    pub fn install(program: &Path, socket: &Path) -> Result<()> {
+        systemd_available().map_err(Error::Other)?;
+        std::fs::create_dir_all(log_dir())?;
+        let unit = service_file_path();
+        if let Some(parent) = unit.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&unit, generate_unit(program, socket))?;
+        systemctl(ServiceOp::DaemonReload)?;
+        systemctl(ServiceOp::EnableNow)?;
+        Ok(())
+    }
+
+    pub fn uninstall() -> Result<()> {
+        let _ = systemctl(ServiceOp::DisableNow);
+        let unit = service_file_path();
+        if unit.exists() {
+            std::fs::remove_file(&unit)?;
+        }
+        let _ = systemctl(ServiceOp::DaemonReload);
+        Ok(())
+    }
+
+    pub fn start() -> Result<()> {
+        // restart = start-or-restart, the parity of `launchctl kickstart -k`.
+        systemctl(ServiceOp::Restart).map(|_| ())
+    }
+
+    pub fn stop() -> Result<()> {
+        systemctl(ServiceOp::Stop).map(|_| ())
+    }
+
+    pub fn status() -> Result<String> {
+        if !service_file_path().exists() {
+            return Ok("not installed".to_string());
+        }
+        // `is-active` exits non-zero for inactive/failed, but stdout still carries the state.
+        let out = Command::new("systemctl")
+            .args(systemctl_user_args(ServiceOp::IsActive))
+            .output()
+            .map_err(Error::Io)?;
+        let state = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        Ok(if state.is_empty() {
+            "unknown".to_string()
+        } else {
+            state
+        })
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod platform {
     use super::*;
 
     fn unsupported() -> Error {
-        Error::Other("service management is currently macOS-only (launchd)".into())
+        Error::Other(
+            "service management is supported on macOS (launchd) and Linux (systemd user units)"
+                .into(),
+        )
     }
 
-    pub fn plist_path() -> PathBuf {
+    pub fn service_file_path() -> PathBuf {
         PathBuf::new()
     }
     pub fn install(_program: &Path, _socket: &Path) -> Result<()> {
@@ -162,7 +344,7 @@ mod platform {
     }
 }
 
-pub use platform::{install, plist_path, start, status, stop, uninstall};
+pub use platform::{install, service_file_path, start, status, stop, uninstall};
 
 /// Path to the daemon log file (stdout).
 pub fn log_file() -> PathBuf {
@@ -196,5 +378,44 @@ mod tests {
         assert!(xml.contains("/usr/local/bin/repomond"));
         assert!(xml.contains("/tmp/r.sock"));
         assert!(xml.contains("<key>RunAtLoad</key>"));
+    }
+
+    #[test]
+    fn unit_contains_exec_socket_and_logs() {
+        let unit = generate_unit(
+            Path::new("/usr/local/bin/repomond"),
+            Path::new("/tmp/r.sock"),
+        );
+        assert!(unit.contains(r#"ExecStart="/usr/local/bin/repomond" --socket "/tmp/r.sock""#));
+        assert!(unit.contains("Restart=always"));
+        assert!(unit.contains("WantedBy=default.target"));
+        assert!(unit.contains("StandardOutput=append:"));
+        assert!(unit.contains("repomond.err.log"));
+    }
+
+    #[test]
+    fn systemctl_argv_shapes() {
+        assert_eq!(
+            systemctl_user_args(ServiceOp::EnableNow),
+            ["--user", "enable", "--now", "repomon.service"]
+        );
+        assert_eq!(
+            systemctl_user_args(ServiceOp::DaemonReload),
+            ["--user", "daemon-reload"]
+        );
+        assert_eq!(
+            systemctl_user_args(ServiceOp::IsActive),
+            ["--user", "is-active", "repomon.service"]
+        );
+        assert_eq!(
+            systemctl_user_args(ServiceOp::Stop),
+            ["--user", "stop", "repomon.service"]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn service_file_is_the_user_unit() {
+        assert!(service_file_path().ends_with("systemd/user/repomon.service"));
     }
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2441,6 +2441,7 @@ fn reuse_per_path_on_failure<T: Clone>(
 /// transcript open, but its cwd is the worktree it runs in — so the count per worktree bounds
 /// how many of that worktree's sessions are actually running. `None` if the probe couldn't
 /// run (then we don't filter); `Some({})` means no claude is running.
+#[cfg(not(target_os = "linux"))]
 fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
     use std::process::Command;
     // Enumerate `claude` processes via `ps`, matching the executable basename. `pgrep -x claude`
@@ -2481,6 +2482,74 @@ fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
     Some(counts)
 }
 
+/// Linux variant: scan `/proc` directly — always present, no `ps`/`lsof` dependency, and
+/// cheaper than either.
+#[cfg(target_os = "linux")]
+fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
+    live_cwds_by_name("claude")
+}
+
+/// Count processes named `name` per working directory by walking `/proc`. A process matches
+/// when its `comm` equals `name` (the kernel uses the script basename for `#!` launchers,
+/// truncated to 15 bytes — "claude" fits) OR when the basename of its cmdline argv[0] does
+/// (covers exec'd wrappers whose comm differs — the Linux analogue of the pgrep-vs-ps lesson
+/// above). cwd comes from `/proc/<pid>/cwd`; entries we can't read (other users) are skipped.
+#[cfg(target_os = "linux")]
+fn live_cwds_by_name(name: &str) -> Option<HashMap<PathBuf, usize>> {
+    let mut counts: HashMap<PathBuf, usize> = HashMap::new();
+    for entry in std::fs::read_dir("/proc").ok()? {
+        let Ok(entry) = entry else { continue };
+        let file_name = entry.file_name();
+        let Some(pid) = file_name
+            .to_str()
+            .filter(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+        else {
+            continue;
+        };
+        let base = PathBuf::from("/proc").join(pid);
+        let comm_matches = std::fs::read_to_string(base.join("comm"))
+            .map(|c| c.trim() == name)
+            .unwrap_or(false);
+        let argv0_matches = || {
+            std::fs::read(base.join("cmdline"))
+                .ok()
+                .and_then(|raw| {
+                    let argv0 = raw.split(|&b| b == 0).next()?.to_vec();
+                    let argv0 = String::from_utf8_lossy(&argv0).into_owned();
+                    Some(argv0.rsplit('/').next().unwrap_or("") == name)
+                })
+                .unwrap_or(false)
+        };
+        if !comm_matches && !argv0_matches() {
+            continue;
+        }
+        let Ok(cwd) = std::fs::read_link(base.join("cwd")) else {
+            continue;
+        };
+        let key = cwd.canonicalize().unwrap_or(cwd);
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    Some(counts)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod live_cwds_tests {
+    #[test]
+    fn proc_scan_finds_self() {
+        let comm = std::fs::read_to_string("/proc/self/comm")
+            .unwrap()
+            .trim()
+            .to_string();
+        let cwds = super::live_cwds_by_name(&comm).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        let key = cwd.canonicalize().unwrap_or(cwd);
+        assert!(
+            cwds.get(&key).copied().unwrap_or(0) >= 1,
+            "expected {key:?} among {cwds:?}"
+        );
+    }
+}
+
 /// Cached [`live_claude_cwds`] with a 10s TTL (plus a 30s sticky-high grace against undercounts),
 /// so frequent `lane.list` calls don't hammer `lsof`.
 async fn live_cwds_cached(ctx: &Ctx) -> Option<HashMap<PathBuf, usize>> {
@@ -2501,12 +2570,10 @@ async fn live_cwds_cached(ctx: &Ctx) -> Option<HashMap<PathBuf, usize>> {
     {
         Some(m) => m,
         None => {
-            // The probe couldn't run (pgrep/lsof spawn failed, e.g. under load). Returning None
-            // means "don't filter" — callers keep all recent sessions rather than truncating to a
-            // bogus low count — but it was silent; log it so a recurring flap is visible.
-            tracing::warn!(
-                "live claude-process probe (pgrep/lsof) failed; not truncating sessions"
-            );
+            // The probe couldn't run (ps/lsof spawn failed under load, /proc unreadable).
+            // Returning None means "don't filter" — callers keep all recent sessions rather than
+            // truncating to a bogus low count — but it was silent; log it so a flap is visible.
+            tracing::warn!("live claude-process probe failed; not truncating sessions");
             return None;
         }
     };

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1451,7 +1451,11 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                     // to this exact session.
                     let session_id = mint_session_id();
                     let command = build_claude_orchestrator_command(
-                        &base, &mcp_path, &model, &p.prompt, &session_id,
+                        &base,
+                        &mcp_path,
+                        &model,
+                        &p.prompt,
+                        &session_id,
                     );
                     (command, Some(session_id))
                 }
@@ -1460,7 +1464,12 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 // `backend.has_transcript()` instead of a session id.
                 crate::OrchestratorBackend::Codex => (
                     build_codex_orchestrator_command(
-                        &base, &socket, &p.autonomy, p.max_agents, &model, &p.prompt,
+                        &base,
+                        &socket,
+                        &p.autonomy,
+                        p.max_agents,
+                        &model,
+                        &p.prompt,
                     ),
                     None,
                 ),
@@ -3214,7 +3223,10 @@ mod tests {
         let mut customs = HashMap::new();
         customs.insert("my-yolo".to_string(), "claude --yolo".to_string());
         // Default and every claude-ish name → Claude.
-        assert_eq!(resolve_orchestrator_backend(&None, &customs).unwrap(), B::Claude);
+        assert_eq!(
+            resolve_orchestrator_backend(&None, &customs).unwrap(),
+            B::Claude
+        );
         for name in ["claude", "claude-code", "claude-work"] {
             assert_eq!(
                 resolve_orchestrator_backend(&Some(name.into()), &customs).unwrap(),
@@ -3257,7 +3269,10 @@ mod tests {
             cmd.contains("REPOMON_MCP_SOCKET = \"/tmp/repomon-test.sock\""),
             "{cmd}"
         );
-        assert!(cmd.contains("REPOMON_MCP_AUTONOMY = \"autonomous\""), "{cmd}");
+        assert!(
+            cmd.contains("REPOMON_MCP_AUTONOMY = \"autonomous\""),
+            "{cmd}"
+        );
         assert!(cmd.contains("REPOMON_MCP_MAX_AGENTS = \"4\""), "{cmd}");
         assert!(cmd.contains(" -a never -s workspace-write"), "{cmd}");
         // The persona rides in as the initial prompt (codex has no --append-system-prompt).

--- a/crates/repomon-daemon/tests/orchestrator_codex.rs
+++ b/crates/repomon-daemon/tests/orchestrator_codex.rs
@@ -46,7 +46,8 @@ async fn codex_backend_degrades_and_mcpless_agents_are_rejected() {
     };
     let store = Store::open_in_memory().unwrap();
     let ctx = Ctx::new(store, config, None);
-    let sock = std::env::temp_dir().join(format!("repomon-orch-codex-it-{}.sock", std::process::id()));
+    let sock =
+        std::env::temp_dir().join(format!("repomon-orch-codex-it-{}.sock", std::process::id()));
     let _ = std::fs::remove_file(&sock);
 
     let server = {
@@ -113,7 +114,11 @@ async fn codex_backend_degrades_and_mcpless_agents_are_rejected() {
     assert_eq!(r.result.unwrap(), json!([]));
 
     let r = call(&mut stream, 5, "orchestrator.stop", None).await;
-    assert!(r.error.is_none(), "orchestrator.stop errored: {:?}", r.error);
+    assert!(
+        r.error.is_none(),
+        "orchestrator.stop errored: {:?}",
+        r.error
+    );
     assert_eq!(r.result.unwrap()["running"], json!(false));
 
     server.abort();

--- a/crates/repomon-daemon/tests/orchestrator_concurrent.rs
+++ b/crates/repomon-daemon/tests/orchestrator_concurrent.rs
@@ -119,7 +119,11 @@ async fn concurrent_starts_spawn_exactly_one_orchestrator() {
     );
 
     let r = call(&mut a, 2, "orchestrator.stop", None).await;
-    assert!(r.error.is_none(), "orchestrator.stop errored: {:?}", r.error);
+    assert!(
+        r.error.is_none(),
+        "orchestrator.stop errored: {:?}",
+        r.error
+    );
 
     server.abort();
     let _ = std::fs::remove_file(&sock);

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -4695,23 +4695,9 @@ fn strip_ansi(s: &str) -> String {
     out
 }
 
-/// Copy `text` to the system clipboard (macOS `pbcopy`, falling back to Linux tools).
+/// Copy `text` to the system clipboard (pbcopy / wl-copy / xclip, probed in core).
 fn copy_to_clipboard(text: &str) {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-    for prog in ["pbcopy", "wl-copy", "xclip"] {
-        let mut cmd = Command::new(prog);
-        if prog == "xclip" {
-            cmd.args(["-selection", "clipboard"]);
-        }
-        if let Ok(mut child) = cmd.stdin(Stdio::piped()).stdout(Stdio::null()).spawn() {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(text.as_bytes());
-            }
-            let _ = child.wait();
-            return;
-        }
-    }
+    repomon_core::clipboard::copy_text(text);
 }
 
 /// Save a clipboard image to a temp PNG and return its path (macOS), so it can be referenced

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -4700,24 +4700,45 @@ fn copy_to_clipboard(text: &str) {
     repomon_core::clipboard::copy_text(text);
 }
 
-/// Save a clipboard image to a temp PNG and return its path (macOS), so it can be referenced
-/// to an agent. Tries `pngpaste`, then AppleScript. `None` if the clipboard has no image.
+/// Save a clipboard image to a temp PNG and return its path, so it can be referenced to an
+/// agent. `None` if the clipboard has no image (or no tool exists to read one).
 fn clipboard_image_to_file() -> Option<String> {
-    use std::process::Command;
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let path = format!("/tmp/repomon-paste-{}-{nanos}.png", std::process::id());
+    let path =
+        std::env::temp_dir().join(format!("repomon-paste-{}-{nanos}.png", std::process::id()));
+    if write_clipboard_png(&path) && png_nonempty(&path) {
+        Some(path.to_string_lossy().into_owned())
+    } else {
+        let _ = std::fs::remove_file(&path);
+        None
+    }
+}
+
+/// The written file genuinely holds a PNG (starts with the 8-byte PNG signature) — guards
+/// against a tool that "succeeds" with empty or non-image output.
+fn png_nonempty(path: &std::path::Path) -> bool {
+    std::fs::read(path)
+        .map(|b| b.starts_with(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]))
+        .unwrap_or(false)
+}
+
+/// Write the clipboard's image to `path` as PNG. Tries `pngpaste`, then AppleScript.
+#[cfg(target_os = "macos")]
+fn write_clipboard_png(path: &std::path::Path) -> bool {
+    use std::process::Command;
+    let path = path.to_string_lossy();
 
     if Command::new("pngpaste")
-        .arg(&path)
+        .arg(path.as_ref())
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-        && std::path::Path::new(&path).exists()
+        && std::path::Path::new(path.as_ref()).exists()
     {
-        return Some(path);
+        return true;
     }
 
     let set_f = format!("set f to open for access POSIX file \"{path}\" with write permission");
@@ -4737,13 +4758,35 @@ fn clipboard_image_to_file() -> Option<String> {
     for l in &lines {
         cmd.arg("-e").arg(l);
     }
-    let out = cmd.output().ok()?;
-    if String::from_utf8_lossy(&out.stdout).trim() == "ok" && std::path::Path::new(&path).exists() {
-        Some(path)
-    } else {
-        let _ = std::fs::remove_file(&path);
-        None
+    let Ok(out) = cmd.output() else { return false };
+    String::from_utf8_lossy(&out.stdout).trim() == "ok"
+}
+
+/// Write the clipboard's image to `path` as PNG. Tries `wl-paste`, then `xclip`; both exit
+/// non-zero when the clipboard holds no image target.
+#[cfg(not(target_os = "macos"))]
+fn write_clipboard_png(path: &std::path::Path) -> bool {
+    use std::process::{Command, Stdio};
+    let candidates: [&[&str]; 2] = [
+        &["wl-paste", "--type", "image/png"],
+        &["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
+    ];
+    for argv in candidates {
+        let Ok(file) = std::fs::File::create(path) else {
+            return false;
+        };
+        let ok = Command::new(argv[0])
+            .args(&argv[1..])
+            .stdout(Stdio::from(file))
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return true;
+        }
     }
+    false
 }
 
 /// The keystroke that leaves insert mode. It's `Ctrl-O` (not `Esc`) because the agent itself

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -1,7 +1,7 @@
 //! Headless CLI subcommands: `repomon add|remove|discover|lane …|daemon …`.
 //!
 //! Repo/lane commands talk to the running daemon (the single SQLite writer); daemon
-//! commands drive the launchd service in `repomon_core::service`.
+//! commands drive the login service (launchd or systemd) in `repomon_core::service`.
 
 use std::path::PathBuf;
 
@@ -132,9 +132,9 @@ pub enum DaemonCmd {
     Status,
     /// Print the daemon log (tail).
     Logs,
-    /// Install + load a launchd-managed service (macOS).
+    /// Install + load the login service (launchd on macOS, systemd user unit on Linux).
     Install,
-    /// Unload + remove the launchd service.
+    /// Unload + remove the login service.
     Uninstall,
 }
 
@@ -511,7 +511,7 @@ async fn handle_daemon(cmd: DaemonCmd, config: &Config) -> Result<()> {
             } else {
                 println!("no running daemon at {}", socket.display());
             }
-            // Also bootout a launchd-managed instance, if any.
+            // Also stop a service-managed instance (launchd/systemd), if any.
             let _ = service::stop();
         }
         DaemonCmd::Restart => {
@@ -542,7 +542,12 @@ async fn handle_daemon(cmd: DaemonCmd, config: &Config) -> Result<()> {
         }
         DaemonCmd::Install => {
             service::install(&service::repomond_path(), &socket)?;
-            println!("installed and loaded {}", service::plist_path().display());
+            println!(
+                "installed and loaded {}",
+                service::service_file_path().display()
+            );
+            #[cfg(target_os = "linux")]
+            println!("tip: run `loginctl enable-linger` so repomond survives logout");
         }
         DaemonCmd::Uninstall => {
             stop_running(&socket).await;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ forwards input. That split is what keeps the UI instant and lets agents outlive 
       ┌───────────────────────── repomon-core ────────────────────────┐
       │ model · store(SQLite) · git(gix + worktree shellout) · watch  │
       │ registry · lane · agent(tmux runtime + Claude/Aider monitors) │
-      │ analytics · session · indexer · service(launchd) · protocol   │
+      │ analytics · session · indexer · service(launchd/systemd) · protocol │
       └──────────────▲──────────────────────────────▲─────────────────┘
                      │                              │
                      │ (lib)                        │ (lib)
@@ -29,7 +29,8 @@ forwards input. That split is what keeps the UI instant and lets agents outlive 
   store (a dedicated writer thread; never blocks the runtime), the gix-backed git reader and
   `git worktree` shellout, the notify watcher, the repo registry and lane manager, the
   tmux-backed agent runtime and the agent monitors, the Phase-3 analytics/sessions/indexer,
-  launchd service management, and the shared JSON-RPC protocol + framing.
+  service management (launchd on macOS, systemd user units on Linux), and the shared
+  JSON-RPC protocol + framing.
 - **repomon-daemon** (`repomond`) — hosts core behind a length-prefixed JSON-RPC Unix socket.
   Owns the `Ctx` (store, registry, lanes, tmux runtime, event bus, viewport + focus, and the
   overlay/status caches), the per-connection socket handling, RPC dispatch, the output streamer,

--- a/docs/superpowers/specs/2026-07-06-linux-support-design.md
+++ b/docs/superpowers/specs/2026-07-06-linux-support-design.md
@@ -1,0 +1,149 @@
+# Full Linux support
+
+**Status:** Approved
+**Date:** 2026-07-06
+**Branch:** `feat/linux-support`
+
+## Problem
+
+repomon is macOS-first. Everything already compiles on Linux and the core loop
+(daemon auto-spawn, tmux agents, git worktrees, XDG paths, inotify watching,
+APNs push) works, but the edges do not:
+
+- `repomon daemon install` hard-errors: the non-macOS arm of
+  `repomon-core/src/service.rs` is a stub ("service management is currently
+  macOS-only (launchd)").
+- Desktop notifications reach `notify-send` but ignore the sound and
+  click-to-focus settings; the settings chime preview is a no-op.
+- The tmux drag-select copy binding hardcodes `pbcopy`, so copy silently fails.
+- Clipboard image paste is pngpaste/AppleScript only and returns nothing.
+- Session liveness probing shells to `lsof`, which may be absent on Linux.
+
+Releases already ship a Linux x86_64 binary and `install.sh` handles Linux, so
+users can hit all of these today. The goal is real parity, not just
+compilation, verified in a genuine Linux environment via Apple containers
+(aarch64 VMs) since development happens on macOS.
+
+## Design
+
+Style rules, matching the existing codebase: shell out to platform tools
+rather than adding integration crates (no zbus/notify-rust); keep pure
+"builder" functions (unit text, argv vectors) compiled and tested on every
+platform, with thin `cfg`-gated `Command` wrappers; every Linux path is
+best-effort or probe-gated so headless environments (no DBus, no display, no
+systemd) never fail.
+
+### Shared helpers (repomon-core)
+
+- `exec.rs`: `find_in_path(bin)` over `$PATH`, with a pure `find_in(path_var,
+  bin)` core testable against a synthetic PATH.
+- `clipboard.rs`: `copy_argv()` probed once (OnceLock). macOS: `pbcopy`.
+  Linux: `wl-copy` when `$WAYLAND_DISPLAY` is set and the tool exists, else
+  `xclip -selection clipboard -in`. Pure `select_copy_argv(wayland, has)` for
+  tests, plus `copy_pipe_command()` (space-joined, for tmux) and
+  `copy_text(text)`.
+- Consumers: the tmux copy binding uses `copy_pipe_command()`; when no tool is
+  present it binds `copy-selection-and-cancel` instead, and the existing
+  `set-clipboard on` keeps copy working via OSC52. The TUI's
+  `copy_to_clipboard` delegates to `clipboard::copy_text`.
+
+### Notifications (repomon-core/src/notify.rs)
+
+- Pure `notify_send_args(title, body, sound)`: `-a repomon -u normal`, plus
+  `-h string:sound-name:message-new-instant` when sound is on; title and body
+  come last.
+- `sound_argv()` probe: `canberra-gtk-play -i message-new-instant`, else
+  `paplay` with the freedesktop `message.oga` when that file exists. Runs
+  alongside notify-send so the chime works even where the hint is ignored.
+- `play_chime()` gains a Linux arm so the settings sound preview works.
+- `click_focus` is documented macOS-only; there is no portable way to focus a
+  terminal from a daemon on Linux.
+
+### systemd user service (repomon-core/src/service.rs)
+
+- Cross-platform pure parts, unit-tested everywhere: `UNIT_NAME =
+  "repomon.service"`, `generate_unit(program, socket)` producing
+  `ExecStart`, `Restart=always`, `RestartSec=2`,
+  `StandardOutput/StandardError=append:<data_dir>/logs/repomond.{out,err}.log`
+  (so `repomon daemon logs` and the TUI log view keep working unchanged), and
+  `WantedBy=default.target`; `systemctl_user_args(ServiceOp)` builds each
+  `systemctl --user ...` argv.
+- `#[cfg(target_os = "linux")] mod platform`: `service_file_path()` under
+  `$XDG_CONFIG_HOME/systemd/user/`; `systemd_available()` checks
+  `/run/systemd/system` and `systemctl --user is-system-running`,
+  distinguishing "no systemd (e.g. containers)" from "no user session, try
+  `loginctl enable-linger`", and always mentions that the TUI auto-starts
+  `repomond` so a service is optional; install writes the unit then
+  `daemon-reload` + `enable --now`; uninstall/start/stop/status mirror the
+  launchctl shapes.
+- The old `not(macos)` stub narrows to `not(any(macos, linux))`.
+  `plist_path` is renamed `service_file_path` across all platform mods.
+- CLI doc strings become platform-neutral; successful install on Linux prints
+  a `loginctl enable-linger` hint.
+- Tests assert unit text and argv shapes only; nothing invokes live systemctl.
+
+### Clipboard image paste (repomon-tui/src/app.rs)
+
+Shared wrapper plus per-platform `write_clipboard_png(path)`: macOS keeps the
+pngpaste/AppleScript body; Linux tries `wl-paste --type image/png` then
+`xclip -selection clipboard -t image/png -o`. The temp file moves off
+hardcoded `/tmp` to `std::env::temp_dir()` and the result is validated
+against the PNG magic bytes.
+
+### Process probe (repomon-daemon/src/rpc.rs)
+
+Linux `live_claude_cwds` scans `/proc` instead of `ps` + `lsof`: a process
+matches when its `comm` or the basename of cmdline argv[0] equals `claude`;
+cwd comes from `read_link("/proc/<pid>/cwd")`; unreadable entries are skipped.
+This drops the lsof dependency entirely. An inline test asserts
+`/proc/self` resolves to the current process and cwd.
+
+### CI, release, install.sh
+
+- New `.github/workflows/ci.yml` on PR and push-to-main: matrix `macos-14` and
+  `ubuntu-latest`; pinned toolchain via `rustup show`; tmux installed on
+  Linux so the daemon integration tests actually run; `cargo fmt --check`,
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`,
+  `cargo test --workspace --locked`.
+- `release.yml` adds a `build-linux-arm` job (`ubuntu-24.04-arm`,
+  `aarch64-unknown-linux-gnu`), matching the Apple-container test
+  architecture.
+- `install.sh` learns the Linux `aarch64|arm64` arch case.
+
+### Docs
+
+README platforms line (macOS and Linux, x86_64/aarch64, WSL2), a "run the
+daemon as a service" subsection (launchd vs systemd user unit, linger note,
+service is optional), platform-notes bullets (libnotify, sound players,
+wl-clipboard/xclip, OSC52 fallback, click-to-focus macOS-only);
+architecture.md launchd mentions become launchd/systemd; STATUS.md header
+refresh (stale commit/test counts) plus a Linux milestone.
+
+## Verification
+
+macOS: full workspace gate (fmt, clippy -D warnings, test), reinstall,
+daemon restart, live smoke of notifications and copy.
+
+Linux, inside an Apple container (aarch64):
+1. Build + test with tmux and git installed; proves the suite is headless-safe.
+2. Runtime smoke: foreground `repomond`, then daemon status, repo add, lane
+   list, daemon logs.
+3. Graceful degrade: `daemon install` fails with the systemd-absent message
+   naming the auto-start fallback; `daemon stop` does not error.
+4. Probe fidelity: a fake `claude` shebang script running from a known dir is
+   counted by the `/proc` probe.
+5. tmux binding: `copy-selection-and-cancel` without tools; switches to
+   `copy-pipe-and-cancel "xclip ..."` once xclip is installed.
+
+Ongoing guard: the ubuntu-latest CI leg runs the same suite on every PR.
+
+## Risks
+
+- `XDG_RUNTIME_DIR` absent (containers, some SSH): socket path already falls
+  back to the temp dir; systemd install is gated by the availability probe.
+- `systemctl --user` needs a live user manager: the probe's error text points
+  at `loginctl enable-linger`.
+- `Restart=always` vs the socket-shutdown race in `daemon stop`: the trailing
+  `service::stop()` settles it, the same shape launchd KeepAlive has today.
+- claude comm-name mismatch on exotic launchers: dual comm/argv0 match plus
+  the existing 30s sticky grace bounds the damage.

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ case "$os" in
   Linux)
     case "$arch" in
       x86_64) target="x86_64-unknown-linux-gnu" ;;
+      arm64 | aarch64) target="aarch64-unknown-linux-gnu" ;;
       *) echo "no prebuilt binary for Linux $arch. Install from source:" >&2
          echo "  cargo install --git https://github.com/$REPO repomon-tui repomon-daemon" >&2
          exit 1 ;;


### PR DESCRIPTION
## What

Linux goes from "compiles, mostly works" to a fully supported platform, and the repo finally gets a PR/push CI gate.

- **systemd user service**: \`repomon daemon install\` writes \`~/.config/systemd/user/repomon.service\` and drives it via \`systemctl --user\`, mirroring the launchd flow (append: logging keeps \`daemon logs\` working identically). An availability probe distinguishes no-systemd (containers) from no-user-session (bare SSH; suggests \`loginctl enable-linger\`) and always names the TUI auto-start fallback.
- **Notifications**: \`notify-send\` now carries app name, urgency, and a freedesktop sound hint, backed by a probed local player (\`canberra-gtk-play\`/\`paplay\`); the Settings chime preview works on Linux.
- **Clipboard**: one probed selection path (pbcopy / wl-copy / xclip) shared by the TUI and the tmux drag-select binding, with an OSC52 fallback when no tool is installed. Image paste gains wl-paste/xclip with PNG-signature validation.
- **Process probe**: Linux reads \`/proc\` directly (comm or argv0 basename match), dropping the \`lsof\` dependency.
- **CI**: new \`ci.yml\` runs fmt / clippy -D warnings / full test suite on macos-14 + ubuntu-latest (with tmux, so daemon integration tests really run). Release adds an aarch64 Linux artifact; install.sh learns the arch.
- Docs: README service + platform-notes sections, architecture.md, STATUS.md refreshed (was 6 weeks stale).

## Verification

- macOS: fmt clean, clippy -D warnings clean, 288 tests pass.
- Linux (aarch64, Apple container): full build + test suite, runtime smoke (daemon, repo add, lane list), graceful daemon-install degrade without systemd, kernel comm-name check for the /proc probe. Results posted below when the run completes.

Design doc: docs/superpowers/specs/2026-07-06-linux-support-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)