### PR TITLE
daemon subcommands honor --socket

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -57,9 +57,9 @@ Agent panes live on the isolated server: `tmux -L rmv capture-pane -t "rmv:=lane
   later captures report "no server running". Track which view you're in.
 - The Notifications view (`5`) swallows most keys; Esc out before pressing
   global keys like `v`.
-- **`repomon daemon stop|status|restart` IGNORE `--socket`** — they resolve the
-  socket from config, so with only env-var isolation they hit the REAL daemon.
-  Stop an isolated daemon by pid (`pgrep -fl repomond`), never via the subcommand.
+- `repomon daemon stop|status|restart` honor `--socket` since fix/daemon-cli-socket
+  (2026-07-07); on OLDER installed binaries they resolve from config and hit the
+  REAL daemon — with an old binary, stop isolated daemons by pid instead.
 - Time-based states (stall = 5 min of frozen pane): set the scenario up, verify
   the negative early, and come back on a background timer; poking the agent pane
   (`tmux send-keys -l "x"` — tty echo changes the content) resets the clock for

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -187,7 +187,7 @@ pub async fn handle(cmd: Command, config: &Config, socket: Option<PathBuf>) -> R
             }
         }
         Command::Lane { cmd } => handle_lane(cmd, config, socket).await?,
-        Command::Daemon { cmd } => handle_daemon(cmd, config).await?,
+        Command::Daemon { cmd } => handle_daemon(cmd, config, socket).await?,
         Command::Remote { cmd } => handle_remote(cmd)?,
         Command::Orchestrate {
             agent,
@@ -498,11 +498,22 @@ async fn handle_lane(cmd: LaneCmd, config: &Config, socket: Option<PathBuf>) -> 
     Ok(())
 }
 
-async fn handle_daemon(cmd: DaemonCmd, config: &Config) -> Result<()> {
-    let socket = config::socket_path(config);
+/// The socket a `daemon` subcommand should target: the CLI `--socket` flag when given, else
+/// the config's. (The same precedence `ensure_daemon` applies for every other subcommand.)
+fn daemon_socket(flag: Option<PathBuf>, config: &Config) -> PathBuf {
+    flag.unwrap_or_else(|| config::socket_path(config))
+}
+
+async fn handle_daemon(
+    cmd: DaemonCmd,
+    config: &Config,
+    socket_flag: Option<PathBuf>,
+) -> Result<()> {
+    let explicit_socket = socket_flag.is_some();
+    let socket = daemon_socket(socket_flag, config);
     match cmd {
         DaemonCmd::Start => {
-            crate::ensure_daemon(config, None).await?;
+            crate::ensure_daemon(config, Some(socket.clone())).await?;
             println!("daemon running (socket: {})", socket.display());
         }
         DaemonCmd::Stop => {
@@ -511,13 +522,17 @@ async fn handle_daemon(cmd: DaemonCmd, config: &Config) -> Result<()> {
             } else {
                 println!("no running daemon at {}", socket.display());
             }
-            // Also stop a service-managed instance (launchd/systemd), if any.
-            let _ = service::stop();
+            // Also stop a service-managed instance (launchd/systemd), if any — but only when
+            // targeting the default socket. An explicit `--socket` means an isolated daemon;
+            // unloading the service would take down the real fleet alongside it.
+            if !explicit_socket {
+                let _ = service::stop();
+            }
         }
         DaemonCmd::Restart => {
             stop_running(&socket).await;
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-            crate::ensure_daemon(config, None).await?;
+            crate::ensure_daemon(config, Some(socket.clone())).await?;
             println!("daemon restarted (socket: {})", socket.display());
         }
         DaemonCmd::Status => match DaemonClient::connect(&socket).await {
@@ -656,5 +671,29 @@ mod tests {
         man.render(&mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("repomon"));
+    }
+
+    #[test]
+    fn daemon_socket_prefers_the_cli_flag() {
+        use repomon_core::Config;
+        use std::path::PathBuf;
+
+        // The regression this guards: `repomon --socket X daemon stop|status|restart` used to
+        // resolve the socket from config alone and hit the DEFAULT daemon — stopping the real
+        // fleet daemon when the caller meant an isolated one.
+        let config = Config {
+            socket_path: Some(PathBuf::from("/tmp/from-config.sock")),
+            ..Default::default()
+        };
+        assert_eq!(
+            super::daemon_socket(Some(PathBuf::from("/tmp/from-flag.sock")), &config),
+            PathBuf::from("/tmp/from-flag.sock"),
+            "an explicit --socket must always win"
+        );
+        assert_eq!(
+            super::daemon_socket(None, &config),
+            PathBuf::from("/tmp/from-config.sock"),
+            "without the flag, the config path applies as before"
+        );
     }
 }


### PR DESCRIPTION
## What

`repomon daemon start|stop|restart|status` resolved their socket from config alone and silently ignored the global `--socket` flag — so `repomon --socket /tmp/x.sock daemon stop` shut down the **default** daemon (the real fleet) instead of the isolated instance the caller named. Found while live-verifying #45: the teardown "stopped" an isolated daemon that kept running, and bounced the real one instead.

- New `daemon_socket(flag, config)` resolution: the CLI flag wins, config otherwise — the same precedence `ensure_daemon` already applies for every other subcommand (regression-tested).
- `daemon start`/`restart` spawn on the flagged socket instead of always the default.
- `daemon stop` only unloads the launchd/systemd login service when targeting the default socket — an explicit `--socket` means an isolated daemon, and taking the service down with it would kill the real fleet anyway.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` green.
- Live, against the real daemon + a fresh isolated one: `daemon start --socket` bound the isolated socket; `daemon status --socket` reported the 0-repo isolated daemon while the flagless form still reported the real fleet; `daemon stop --socket` stopped only the isolated daemon (real daemon uptime uninterrupted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)