### PR TITLE
Plain-shell terminals as Grid tiles

### DIFF
--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -75,6 +75,16 @@ impl TmuxRuntime {
         Self::parse_lane_window(name).map(|(id, _)| id)
     }
 
+    /// Parse a plain-terminal window name (`term-{lane}-{n}`, as `terminal.open` mints them)
+    /// into its lane. `None` for anything else — agent windows, the usage probe, malformed
+    /// names — so terminal scans and agent scans stay mutually blind.
+    pub fn parse_term_window(name: &str) -> Option<LaneId> {
+        let rest = name.strip_prefix("term-")?;
+        let (id, seq) = rest.split_once('-')?;
+        seq.parse::<u32>().ok()?;
+        id.parse::<LaneId>().ok()
+    }
+
     /// The 1-based agent slot a managed window occupies, or `None` if it isn't a lane window.
     pub fn slot_of_window(name: &str) -> Option<usize> {
         Self::parse_lane_window(name).map(|(_, slot)| slot)
@@ -659,6 +669,19 @@ mod tests {
         assert_eq!(TmuxRuntime::slot_of_window("lane-42"), Some(1));
         assert_eq!(TmuxRuntime::slot_of_window("lane-42-3"), Some(3));
         assert_eq!(TmuxRuntime::slot_of_window("term-1"), None);
+    }
+
+    #[test]
+    fn parses_terminal_windows_back_to_lane() {
+        // `terminal.open` mints `term-{lane}-{n}`; the parse is its inverse.
+        assert_eq!(TmuxRuntime::parse_term_window("term-7-1"), Some(7));
+        assert_eq!(TmuxRuntime::parse_term_window("term-81-12"), Some(81));
+        // Agent windows, sequence-less/malformed names, and strangers are not terminals.
+        assert_eq!(TmuxRuntime::parse_term_window("lane-7"), None);
+        assert_eq!(TmuxRuntime::parse_term_window("term-7"), None);
+        assert_eq!(TmuxRuntime::parse_term_window("term-x-1"), None);
+        assert_eq!(TmuxRuntime::parse_term_window("term-7-x"), None);
+        assert_eq!(TmuxRuntime::parse_term_window("orchestrator"), None);
     }
 
     #[test]

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -131,6 +131,9 @@ pub struct Ctx {
     /// Which agent window the focused lane should stream, when the TUI has a specific session
     /// selected (Tab in Focus/Split). Lanes not named here stream their first slot.
     pub viewport_focus: Mutex<Option<(LaneId, String)>>,
+    /// Plain-terminal windows (`term-{lane}-{n}`) the TUI has visible as Grid tiles — streamed
+    /// alongside the lane panes, each tagged with its window in the output event.
+    pub viewport_windows: Mutex<Vec<String>>,
     /// Cache of how many live `claude` processes have each working dir (ps/lsof, 10s TTL), so
     /// `/exit`ed sessions whose transcripts linger aren't counted as running.
     pub live_cwds: Mutex<Option<(Instant, HashMap<PathBuf, usize>)>>,
@@ -249,6 +252,7 @@ impl Ctx {
             events,
             viewport: Mutex::new(Vec::new()),
             viewport_focus: Mutex::new(None),
+            viewport_windows: Mutex::new(Vec::new()),
             live_cwds: Mutex::new(None),
             cwds_sticky: Mutex::new(HashMap::new()),
             overlay_cache: Mutex::new(None),
@@ -301,10 +305,9 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
-    /// Per-lane streaming state: the last pushed window+content, the current poll interval, and
-    /// when this lane was last captured.
+    /// Per-window streaming state: the last pushed content, the current poll interval, and
+    /// when this window was last captured.
     struct St {
-        window: String,
         content: String,
         backoff: Duration,
         last_cap: Instant,
@@ -331,8 +334,8 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
     // serviced round-robin across ticks.
     const MAX_PER_TICK: usize = 3;
 
-    let mut state: HashMap<LaneId, St> = HashMap::new();
-    let mut rr: usize = 0; // round-robin offset so background lanes share the per-tick budget fairly
+    let mut state: HashMap<String, St> = HashMap::new();
+    let mut rr: usize = 0; // round-robin offset so background panes share the per-tick budget fairly
     // The base tick must be at least as fast as the tightest regime (TYPING_FLOOR); per-lane
     // gating below keeps non-typing lanes at their slower cadence, so these extra wakeups are
     // cheap no-ops (no captures) when nothing is being typed.
@@ -349,44 +352,53 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
             m.retain(|_, t| now.saturating_duration_since(*t) < TYPING_WINDOW);
         }
         let lanes: Vec<LaneId> = ctx.viewport.lock().await.clone();
-        if lanes.is_empty() {
+        let extra_windows: Vec<String> = ctx.viewport_windows.lock().await.clone();
+        if lanes.is_empty() && extra_windows.is_empty() {
             state.clear();
             continue;
         }
         let focus = ctx.viewport_focus.lock().await.clone();
-        let focus_lane = focus.as_ref().map(|(l, _)| *l);
-        state.retain(|k, _| lanes.contains(k));
+        // One stream target per visible pane: each lane's resolved window, plus any plain
+        // terminals the Grid is tiling (each with the lane it belongs to for the event payload).
+        let mut targets: Vec<(LaneId, String)> = lanes
+            .iter()
+            .map(|&lane| (lane, stream_window_for(lane, &focus)))
+            .collect();
+        for w in &extra_windows {
+            if let Some(lane) = TmuxRuntime::parse_term_window(w) {
+                if !targets.iter().any(|(_, tw)| tw == w) {
+                    targets.push((lane, w.clone()));
+                }
+            }
+        }
+        state.retain(|w, _| targets.iter().any(|(_, tw)| tw == w));
         // Snapshot which lanes were typed into recently — they capture at frame-rate. The map was
         // just pruned above, so this is the live set of within-TYPING_WINDOW lanes.
         let typing_lanes: HashMap<LaneId, Instant> = ctx.input_seen.lock().await.clone();
 
-        // Service the focused lane first (so the per-tick cap never starves what the user is
+        // Service the focused pane first (so the per-tick cap never starves what the user is
         // watching), then the rest from a rotating offset so every background pane gets a turn.
-        let n = lanes.len();
-        let mut order: Vec<LaneId> = Vec::with_capacity(n);
-        if let Some(fl) = focus_lane {
-            if lanes.contains(&fl) {
-                order.push(fl);
+        let focus_window = focus.as_ref().map(|(_, w)| w.clone());
+        let n = targets.len();
+        let mut order: Vec<(LaneId, String)> = Vec::with_capacity(n);
+        if let Some(fw) = &focus_window {
+            if let Some(t) = targets.iter().find(|(_, w)| w == fw) {
+                order.push(t.clone());
             }
         }
         for i in 0..n {
-            let lane = lanes[(rr + i) % n];
-            if Some(lane) != focus_lane {
-                order.push(lane);
+            let t = &targets[(rr + i) % n];
+            if Some(&t.1) != focus_window.as_ref() {
+                order.push(t.clone());
             }
         }
         rr = (rr + 1) % n;
 
         let mut budget = MAX_PER_TICK;
-        for lane in order {
-            let is_focused = focus_lane == Some(lane);
-            // The focused lane streams its selected agent's window; others their first slot.
-            let window = match &focus {
-                Some((l, w)) if *l == lane => w.clone(),
-                _ => TmuxRuntime::window_name(lane),
-            };
+        for (lane, window) in order {
+            let is_focused = focus_window.as_deref() == Some(window.as_str());
             // Cadence regime: a lane typed into within TYPING_WINDOW captures at frame-rate;
-            // otherwise the focused lane is fast and background/Grid tiles slow.
+            // otherwise the focused pane is fast and background/Grid tiles slow.
             let typing = typing_lanes
                 .get(&lane)
                 .is_some_and(|t| now.saturating_duration_since(*t) < TYPING_WINDOW);
@@ -401,18 +413,18 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
             // starts being typed into, a stale 150ms wait shrinks to <=60ms and it captures on the
             // next tick (prompt first-keystroke echo without coupling to the input handler).
             let interval = state
-                .get(&lane)
+                .get(&window)
                 .map(|s| s.backoff.clamp(floor, cap))
                 .unwrap_or(floor);
-            // Not due yet (and window unchanged) → leave it for a later tick; costs nothing. A
-            // lane absent from the map (freshly spawned / first frame) or whose window switched
-            // (Tab) is always due, so fresh output shows immediately.
-            if let Some(s) = state.get(&lane) {
-                if s.window == window && now < s.last_cap + interval {
+            // Not due yet → leave it for a later tick; costs nothing. A window absent from the
+            // map (freshly spawned / first frame / Tab switch) is always due, so fresh output
+            // shows immediately.
+            if let Some(s) = state.get(&window) {
+                if now < s.last_cap + interval {
                     continue;
                 }
             }
-            // Cap captures per tick; a due lane skipped here is picked up next tick (rr rotates).
+            // Cap captures per tick; a due pane skipped here is picked up next tick (rr rotates).
             if budget == 0 {
                 break;
             }
@@ -437,13 +449,16 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                 None
             };
             let content_changed = state
-                .get(&lane)
-                .map(|s| s.window != window || s.content != content)
+                .get(&window)
+                .map(|s| s.content != content)
                 .unwrap_or(true);
             // The focused pane also re-pushes on a cursor-only move (arrowing within the input box)
             // so the rendered cursor tracks even when the text itself is unchanged.
-            let cursor_changed =
-                is_focused && state.get(&lane).map(|s| s.cursor != cursor).unwrap_or(true);
+            let cursor_changed = is_focused
+                && state
+                    .get(&window)
+                    .map(|s| s.cursor != cursor)
+                    .unwrap_or(true);
             let changed = content_changed || cursor_changed;
             // Reset to the floor on any change; otherwise double the (clamped) interval toward cap.
             let backoff = if changed {
@@ -456,15 +471,15 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                     pubsub::topic::AGENT_OUTPUT,
                     serde_json::json!({
                         "lane_id": lane,
+                        "window": window,
                         "content": content.clone(),
                         "cursor": cursor.map(|(x, y)| [x, y]),
                     }),
                 );
             }
             state.insert(
-                lane,
+                window,
                 St {
-                    window,
                     content,
                     backoff,
                     last_cap: now,
@@ -472,6 +487,17 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                 },
             );
         }
+    }
+}
+
+/// The window a viewport lane streams: the TUI-selected agent window when this lane is the
+/// focus (Tab in Focus/Split), else the lane's first slot. A focused plain terminal never
+/// hijacks its lane's stream — the terminal is its own target via `viewport_windows`, so the
+/// lane's agent tile keeps updating beside it.
+fn stream_window_for(lane: LaneId, focus: &Option<(LaneId, String)>) -> String {
+    match focus {
+        Some((l, w)) if *l == lane && TmuxRuntime::parse_term_window(w).is_none() => w.clone(),
+        _ => TmuxRuntime::window_name(lane),
     }
 }
 
@@ -567,5 +593,31 @@ pub async fn stream_orchestrator(ctx: Arc<Ctx>) {
             last = Some(content);
             last_cursor = cursor;
         }
+    }
+}
+
+#[cfg(test)]
+mod stream_tests {
+    use super::*;
+
+    #[test]
+    fn focused_terminal_never_hijacks_its_lanes_stream() {
+        // No focus / focus on another lane: the lane streams its first slot.
+        assert_eq!(stream_window_for(7, &None), "lane-7");
+        assert_eq!(
+            stream_window_for(7, &Some((3, "lane-3-2".into()))),
+            "lane-7"
+        );
+        // The focused lane streams its selected agent window (Tab in Focus/Split).
+        assert_eq!(
+            stream_window_for(7, &Some((7, "lane-7-2".into()))),
+            "lane-7-2"
+        );
+        // A focused plain terminal is its own stream target (viewport_windows); the lane's
+        // pane must keep streaming its agent, or the agent tile freezes beside the terminal.
+        assert_eq!(
+            stream_window_for(7, &Some((7, "term-7-1".into()))),
+            "lane-7"
+        );
     }
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -323,6 +323,10 @@ struct ViewportSet {
     focus_lane: Option<repomon_core::model::LaneId>,
     #[serde(default)]
     focus_window: Option<String>,
+    /// Plain-terminal windows (`term-{lane}-{n}`) visible as Grid tiles, streamed alongside
+    /// the lane panes. Non-terminal names are ignored.
+    #[serde(default)]
+    windows: Vec<String>,
 }
 #[derive(Deserialize)]
 struct LaneMerge {
@@ -1293,6 +1297,28 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             terms.sort();
             to_value(terms)
         }
+        "terminal.list_all" => {
+            // Every lane's open plain terminals — what the Grid tiles. Fleet-wide (unlike
+            // `terminal.list`) so one call covers every visible lane.
+            let tmux = ctx.tmux.clone();
+            let wins = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
+                .await
+                .map_err(internal)?;
+            let mut terms: Vec<Value> = wins
+                .into_iter()
+                .filter_map(|w| {
+                    TmuxRuntime::parse_term_window(&w)
+                        .map(|lane| json!({ "lane_id": lane, "id": w }))
+                })
+                .collect();
+            terms.sort_by_key(|t| {
+                (
+                    t["lane_id"].as_i64().unwrap_or(0),
+                    t["id"].as_str().unwrap_or("").to_string(),
+                )
+            });
+            Ok(Value::Array(terms))
+        }
         "terminal.close" => {
             let p: TerminalId = parse(params)?;
             let tmux = ctx.tmux.clone();
@@ -1373,9 +1399,14 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             Ok(Value::Null)
         }
         "viewport.set" => {
-            let p: ViewportSet = parse(params)?;
+            let mut p: ViewportSet = parse(params)?;
             *ctx.viewport.lock().await = p.lane_ids;
             *ctx.viewport_focus.lock().await = p.focus_lane.zip(p.focus_window);
+            // Only real terminal windows are streamable extras — anything else is dropped so a
+            // client can't point the capture loop at arbitrary windows.
+            p.windows
+                .retain(|w| TmuxRuntime::parse_term_window(w).is_some());
+            *ctx.viewport_windows.lock().await = p.windows;
             Ok(Value::Null)
         }
 

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -90,14 +90,24 @@ pub struct Pane {
 /// A clickable lane region recorded during render (in `view.rs`) and hit-tested by the mouse
 /// handler. `interactive` = a single-click focuses the lane for typing in place (Grid tiles,
 /// Split panes/rows); otherwise a single-click only selects it (Fleet rows, which show no pane).
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct ClickZone {
     pub rect: Rect,
     pub lane: LaneId,
     /// Which agent within the lane this row targets, when the sidebar is expanded into per-agent
     /// rows; `None` for a normal lane row / lane header.
     pub session: Option<usize>,
+    /// The plain-terminal window this region shows (a Grid shell tile); `None` = an agent pane.
+    pub window: Option<String>,
     pub interactive: bool,
+}
+
+/// One Grid tile: a lane's agent pane, or one of its plain terminals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GridTile {
+    pub lane_id: LaneId,
+    /// `Some("term-{lane}-{n}")` for a plain-terminal tile; `None` = the lane's agent pane.
+    pub window: Option<String>,
 }
 
 /// A row in the fleet sidebar: a lane (header), or — when `expand_agents` is on and the lane runs
@@ -351,6 +361,14 @@ pub struct App {
     /// Plain shell terminals open for the selected lane (tmux window names).
     pub terminals: Vec<String>,
     terminals_lane: Option<LaneId>,
+    /// Every lane's open plain terminals `(lane, window)` — the Grid's shell tiles. Synced
+    /// from `terminal.list_all` while the Grid is open.
+    pub term_windows: Vec<(LaneId, String)>,
+    /// Live pane per terminal window, pushed by `event.agent.output` (window-tagged) — the
+    /// shell-tile counterpart of the lane-keyed `output`.
+    pub term_output: HashMap<String, Pane>,
+    /// When `term_windows` was last fetched (throttles the Grid's list_all poll).
+    term_sync_at: Option<Instant>,
     pub browse_path: String,
     pub browse_parent: Option<String>,
     pub browse_entries: Vec<BrowseEntry>,
@@ -378,6 +396,7 @@ pub struct App {
     agents_return: Option<View>,
     last_viewport: Vec<LaneId>,
     last_viewport_focus: Option<(LaneId, String)>,
+    last_viewport_windows: Vec<String>,
     /// Last terminal title emitted (OSC 2), to skip redundant writes.
     last_title: String,
     attach_request: Option<LaneId>,
@@ -532,6 +551,9 @@ impl App {
             pending_focus_ticks: 0,
             terminals: Vec::new(),
             terminals_lane: None,
+            term_windows: Vec::new(),
+            term_output: HashMap::new(),
+            term_sync_at: None,
             browse_path: String::new(),
             browse_parent: None,
             browse_entries: Vec::new(),
@@ -549,6 +571,7 @@ impl App {
             ag_orig: None,
             agents_return: None,
             last_viewport: Vec::new(),
+            last_viewport_windows: Vec::new(),
             last_viewport_focus: None,
             last_title: String::new(),
             attach_request: None,
@@ -1387,6 +1410,36 @@ impl App {
         lanes.into_iter().take(8).map(|l| l.id).collect()
     }
 
+    /// The Grid's tiles: agent panes first (the most active lanes, as ever), then every open
+    /// plain terminal (`t` shells) of a visible lane — in lane display order — up to 8 tiles.
+    pub fn grid_tiles(&self) -> Vec<GridTile> {
+        let mut tiles: Vec<GridTile> = self
+            .grid_lane_ids()
+            .into_iter()
+            .map(|id| GridTile {
+                lane_id: id,
+                window: None,
+            })
+            .collect();
+        let lane_order: Vec<LaneId> = self.visible_lanes().iter().map(|l| l.id).collect();
+        let mut terms: Vec<&(LaneId, String)> = self
+            .term_windows
+            .iter()
+            .filter(|(l, _)| lane_order.contains(l))
+            .collect();
+        terms.sort_by_key(|(l, w)| (lane_order.iter().position(|x| x == l), w.clone()));
+        for (l, w) in terms {
+            if tiles.len() >= 8 {
+                break;
+            }
+            tiles.push(GridTile {
+                lane_id: *l,
+                window: Some(w.clone()),
+            });
+        }
+        tiles
+    }
+
     fn clamp_selection(&mut self) {
         let n = self.rows_len();
         if n == 0 {
@@ -1423,16 +1476,39 @@ impl App {
     /// either changed.
     pub async fn sync_viewport(&mut self) {
         let live = self.live_lanes();
-        // Name the lane the user is actively watching (Split/Focus, or the highlighted Grid tile)
-        // so the daemon streams it at the fast cadence and lets the other viewport panes back off.
+        // The Grid's shell tiles stream as explicit terminal windows alongside the lane panes.
+        let windows: Vec<String> = if self.view == View::Grid {
+            self.grid_tiles().into_iter().filter_map(|t| t.window).collect()
+        } else {
+            Vec::new()
+        };
+        // Name the pane the user is actively watching (Split/Focus, or the highlighted Grid
+        // tile — its terminal window when it's a shell tile) so the daemon streams it at the
+        // fast cadence and lets the other viewport panes back off.
         let focus = match self.view {
-            View::Split | View::Focus | View::Grid => self
+            View::Grid => {
+                let tiles = self.grid_tiles();
+                match tiles.get(self.grid_active) {
+                    Some(GridTile {
+                        lane_id,
+                        window: Some(w),
+                    }) => Some((*lane_id, w.clone())),
+                    _ => self
+                        .selected_lane()
+                        .map(|l| l.id)
+                        .zip(self.selected_window()),
+                }
+            }
+            View::Split | View::Focus => self
                 .selected_lane()
                 .map(|l| l.id)
                 .zip(self.selected_window()),
             _ => None,
         };
-        if live != self.last_viewport || focus != self.last_viewport_focus {
+        if live != self.last_viewport
+            || focus != self.last_viewport_focus
+            || windows != self.last_viewport_windows
+        {
             let _ = self
                 .client
                 .call(
@@ -1441,11 +1517,13 @@ impl App {
                         "lane_ids": live,
                         "focus_lane": focus.as_ref().map(|(l, _)| l),
                         "focus_window": focus.as_ref().map(|(_, w)| w),
+                        "windows": windows,
                     })),
                 )
                 .await;
             self.last_viewport = live;
             self.last_viewport_focus = focus;
+            self.last_viewport_windows = windows;
         }
         // Stream the orchestrator pane while the command-center view is open, or while the pinned
         // repomind row is selected in Split (its right column previews the live pane). Toggle the
@@ -1684,26 +1762,34 @@ impl App {
 
     /// Point the fleet selection at the grid's active tile (so per-lane actions act on it).
     fn select_grid_active(&mut self) {
-        let ids = self.grid_lane_ids();
-        if let Some(&id) = ids.get(self.grid_active) {
-            self.select_lane_session(id, None);
+        let tiles = self.grid_tiles();
+        if let Some(t) = tiles.get(self.grid_active) {
+            self.select_lane_session(t.lane_id, None);
         }
     }
 
     /// Key handling in the babysit Grid: a linear cursor over the live tiles (arrows move it,
     /// dots show position), `↵` focuses the active tile, and esc/spc/q leave the view.
     async fn grid_key(&mut self, key: KeyEvent) {
-        // Click-focused a tile? Keystrokes go straight to that agent (like Split/Focus insert);
-        // ^O blurs, as does a click on empty space.
+        // Click-focused a tile? Keystrokes go straight to that pane (like Split/Focus insert) —
+        // the active tile's agent, or its plain terminal; ^O blurs, as does a click on empty
+        // space.
         if self.focus_insert {
             if leaves_insert(&key) {
                 self.focus_insert = false;
                 return;
             }
-            self.send_agent_key(key).await;
+            let term = self
+                .grid_tiles()
+                .get(self.grid_active)
+                .and_then(|t| t.window.clone().map(|w| (t.lane_id, w)));
+            match term {
+                Some((lane, window)) => self.send_window_key(lane, window, key).await,
+                None => self.send_agent_key(key).await,
+            }
             return;
         }
-        let n = self.grid_lane_ids().len();
+        let n = self.grid_tiles().len();
         if self.grid_active >= n {
             self.grid_active = n.saturating_sub(1);
         }
@@ -1716,10 +1802,16 @@ impl App {
             {
                 self.grid_active += 1;
             }
-            // ↵ opens the active tile's agent in its real tmux pane (a native terminal).
+            // ↵ opens the active tile's pane in its real tmux window (a native terminal).
             KeyCode::Enter if n > 0 => {
-                self.select_grid_active();
-                self.attach_request = self.selected_lane().map(|l| l.id);
+                let tile = self.grid_tiles().get(self.grid_active).cloned();
+                match tile.as_ref().and_then(|t| t.window.clone()) {
+                    Some(w) => self.attach_terminal_window(&w).await,
+                    None => {
+                        self.select_grid_active();
+                        self.attach_request = self.selected_lane().map(|l| l.id);
+                    }
+                }
             }
             // Per-tile actions act on the active tile.
             KeyCode::Char('e') => {
@@ -1735,17 +1827,20 @@ impl App {
                 self.select_grid_active();
                 self.toggle_pin().await;
             }
-            // Hop to the next tile whose agent needs you, wrapping.
+            // Hop to the next tile whose agent needs you, wrapping. (Shell tiles never need
+            // you — the filter naturally skips them.)
             KeyCode::Char('g') if n > 0 => {
-                let ids = self.grid_lane_ids();
-                let need: Vec<usize> = ids
+                let tiles = self.grid_tiles();
+                let need: Vec<usize> = tiles
                     .iter()
                     .enumerate()
-                    .filter(|(_, id)| {
-                        self.lanes
-                            .iter()
-                            .find(|l| l.id == **id)
-                            .is_some_and(|l| self.lane_needs_attention(l))
+                    .filter(|(_, t)| {
+                        t.window.is_none()
+                            && self
+                                .lanes
+                                .iter()
+                                .find(|l| l.id == t.lane_id)
+                                .is_some_and(|l| self.lane_needs_attention(l))
                     })
                     .map(|(i, _)| i)
                     .collect();
@@ -1854,7 +1949,22 @@ impl App {
                     .get("cursor")
                     .and_then(|v| v.as_array())
                     .and_then(|a| Some((a.first()?.as_u64()? as u16, a.get(1)?.as_u64()? as u16)));
-                self.output.insert(id, Pane { raw, lines, cursor });
+                // A window-tagged terminal stream (a Grid shell tile) has its own store — a
+                // lane's agent pane and its terminals must never overwrite each other.
+                match note
+                    .params
+                    .get("window")
+                    .and_then(|v| v.as_str())
+                    .filter(|w| w.starts_with("term-"))
+                {
+                    Some(w) => {
+                        self.term_output
+                            .insert(w.to_string(), Pane { raw, lines, cursor });
+                    }
+                    None => {
+                        self.output.insert(id, Pane { raw, lines, cursor });
+                    }
+                }
             }
         } else if note.method == "event.orchestrator.output" {
             if let Some(content) = note.params.get("content").and_then(|v| v.as_str()) {
@@ -3078,11 +3188,32 @@ impl App {
             .borrow()
             .iter()
             .find(|z| z.rect.contains(Position { x: col, y: row }))
-            .copied();
+            .cloned();
         // Clicking a lane (or the gutter) leaves any repomind insert mode, since the selection is
         // moving off the pinned row.
         self.orch_insert = false;
         match hit {
+            // A Grid shell tile: move the grid cursor onto it (input routes by active tile);
+            // single-click types in place, double-click attaches into the real terminal.
+            Some(z) if z.window.is_some() => {
+                let window = z.window.clone().unwrap();
+                let now = std::time::Instant::now();
+                let dbl = is_double_click(self.last_click, z.lane, now);
+                self.last_click = Some((now, z.lane));
+                if let Some(i) = self
+                    .grid_tiles()
+                    .iter()
+                    .position(|t| t.window.as_deref() == Some(window.as_str()))
+                {
+                    self.grid_active = i;
+                }
+                if dbl {
+                    self.focus_insert = false;
+                    self.attach_terminal_window(&window).await;
+                } else {
+                    self.focus_insert = true;
+                }
+            }
             Some(z) => {
                 let now = std::time::Instant::now();
                 let dbl = is_double_click(self.last_click, z.lane, now);
@@ -3400,6 +3531,40 @@ impl App {
                 })),
             )
             .await;
+    }
+
+    /// Send one keystroke to an explicit window (a Grid shell tile's plain terminal). Unlike
+    /// `send_agent_key` there's no coalescing buffer: a shell echoes per keystroke anyway, and
+    /// the pending-input buffer flushes to the *agent* window, which would misroute here.
+    async fn send_window_key(&mut self, lane: LaneId, window: String, key: KeyEvent) {
+        let Some((spec, literal)) = translate_key(&key) else {
+            return;
+        };
+        let _ = self
+            .client
+            .call(
+                "agent.key",
+                Some(json!({
+                    "lane_id": lane,
+                    "key": spec,
+                    "literal": literal,
+                    "window": window,
+                })),
+            )
+            .await;
+    }
+
+    /// Attach into a plain-terminal window (a Grid shell tile) by name.
+    async fn attach_terminal_window(&mut self, window: &str) {
+        if let Ok(v) = self
+            .client
+            .call("terminal.target", Some(json!({ "id": window })))
+            .await
+        {
+            if let Some(t) = v.get("target").and_then(|t| t.as_str()) {
+                self.attach_target = Some(t.to_string());
+            }
+        }
     }
 
     /// Send the buffered keystrokes/paste to the agent as one `send_input` (literal, no Enter).
@@ -3806,6 +3971,35 @@ impl App {
                 }
             }
             None => self.open_terminal().await,
+        }
+    }
+
+    /// Refresh the fleet-wide open-terminal list (the Grid's shell tiles) — only while the
+    /// Grid is open, throttled to ~2s. Prunes streamed panes of closed terminals.
+    async fn sync_term_windows(&mut self) {
+        if self.view != View::Grid {
+            return;
+        }
+        if self
+            .term_sync_at
+            .is_some_and(|t| t.elapsed() < Duration::from_secs(2))
+        {
+            return;
+        }
+        self.term_sync_at = Some(Instant::now());
+        #[derive(serde::Deserialize)]
+        struct Term {
+            lane_id: LaneId,
+            id: String,
+        }
+        if let Ok(terms) = self
+            .client
+            .call_typed::<Vec<Term>>("terminal.list_all", None)
+            .await
+        {
+            self.term_windows = terms.into_iter().map(|t| (t.lane_id, t.id)).collect();
+            self.term_output
+                .retain(|w, _| self.term_windows.iter().any(|(_, tw)| tw == w));
         }
     }
 
@@ -4613,6 +4807,7 @@ async fn event_loop(
         app.sync_recent_commits().await;
         let t_commits = sync_t.elapsed();
         app.sync_terminals().await;
+        app.sync_term_windows().await;
         let t_terminals = sync_t.elapsed();
         if t_terminals >= Duration::from_millis(250) {
             tui_log(&format!(

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -1478,7 +1478,10 @@ impl App {
         let live = self.live_lanes();
         // The Grid's shell tiles stream as explicit terminal windows alongside the lane panes.
         let windows: Vec<String> = if self.view == View::Grid {
-            self.grid_tiles().into_iter().filter_map(|t| t.window).collect()
+            self.grid_tiles()
+                .into_iter()
+                .filter_map(|t| t.window)
+                .collect()
         } else {
             Vec::new()
         };

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -42,7 +42,19 @@ fn click_zone(app: &App, rect: Rect, lane: LaneId, session: Option<usize>, inter
         rect,
         lane,
         session,
+        window: None,
         interactive,
+    });
+}
+
+/// Record a clickable Grid shell-tile region: clicks route to the named terminal window.
+fn click_zone_window(app: &App, rect: Rect, lane: LaneId, window: String) {
+    app.click_zones.borrow_mut().push(ClickZone {
+        rect,
+        lane,
+        session: None,
+        window: Some(window),
+        interactive: true,
     });
 }
 
@@ -1589,8 +1601,8 @@ fn render_grid(f: &mut Frame, app: &App) {
     ])
     .split(area);
 
-    let ids = app.grid_lane_ids();
-    let n = ids.len();
+    let tiles = app.grid_tiles();
+    let n = tiles.len();
     let header = format!(
         "REPOMON · GRID — {n} live pane{}",
         if n == 1 { "" } else { "s" }
@@ -1603,15 +1615,17 @@ fn render_grid(f: &mut Frame, app: &App) {
         rows[0],
     );
 
-    if ids.is_empty() {
+    if tiles.is_empty() {
         f.render_widget(
             Paragraph::new(vec![
                 Line::raw(""),
                 Line::raw(
-                    "  Nothing to babysit yet — the grid tiles your most active agents".to_string(),
+                    "  Nothing to babysit yet — the grid tiles your most active agents and open shells"
+                        .to_string(),
                 ),
                 Line::raw(
-                    "  (pin any with p). Spawn one with e, or press esc to go back.".to_string(),
+                    "  (pin any with p). Spawn one with e, open a shell with t, or press esc to go back."
+                        .to_string(),
                 ),
             ]),
             rows[1],
@@ -1636,17 +1650,21 @@ fn render_grid(f: &mut Frame, app: &App) {
                 continue;
             }
             let cell = cells[c * 2];
-            let lane = app.lanes.iter().find(|l| l.id == ids[idx]);
-            click_zone(app, cell, ids[idx], None, true);
+            let tile = &tiles[idx];
+            let lane = app.lanes.iter().find(|l| l.id == tile.lane_id);
+            match &tile.window {
+                Some(w) => click_zone_window(app, cell, tile.lane_id, w.clone()),
+                None => click_zone(app, cell, tile.lane_id, None, true),
+            }
             f.render_widget(
                 Paragraph::new(tile_lines(
                     app,
                     lane,
-                    ids[idx],
+                    tile,
                     cell.height as usize,
                     idx == active,
                     idx == active && app.focus_insert,
-                    app.hover_lane == Some(ids[idx]),
+                    app.hover_lane == Some(tile.lane_id),
                 )),
                 cell,
             );
@@ -1673,8 +1691,11 @@ fn render_grid(f: &mut Frame, app: &App) {
     let label = app
         .lanes
         .iter()
-        .find(|l| l.id == ids[active])
-        .map(|l| format!("{}/{}", l.repo.name, lane_name(l)))
+        .find(|l| l.id == tiles[active].lane_id)
+        .map(|l| match &tiles[active].window {
+            Some(w) => format!("{}/{} · {w}", l.repo.name, lane_name(l)),
+            None => format!("{}/{}", l.repo.name, lane_name(l)),
+        })
         .unwrap_or_default();
     let mut spans = vec![Span::raw("  ")];
     for i in 0..n {
@@ -1703,12 +1724,13 @@ fn render_grid(f: &mut Frame, app: &App) {
 fn tile_lines(
     app: &App,
     lane: Option<&Lane>,
-    id: LaneId,
+    tile: &crate::app::GridTile,
     height: usize,
     active: bool,
     focused: bool,
     hovered: bool,
 ) -> Vec<Line<'static>> {
+    let id = tile.lane_id;
     let marker = if focused {
         "▶"
     } else if active {
@@ -1716,13 +1738,15 @@ fn tile_lines(
     } else {
         " "
     };
-    let (badge, badge_style) = match lane {
-        Some(l) => agent_badge(l, app),
-        None => (String::new(), Style::default()),
+    // A shell tile names its terminal window instead of wearing an agent badge.
+    let (badge, badge_style) = match (&tile.window, lane) {
+        (None, Some(l)) => agent_badge(l, app),
+        _ => (String::new(), Style::default()),
     };
-    let label = match lane {
-        Some(l) => format!("{marker}{}/{}  ", l.repo.name, lane_name(l)),
-        None => format!("{marker}lane {id}"),
+    let label = match (lane, &tile.window) {
+        (Some(l), Some(w)) => format!("{marker}{}/{} · {w}  ", l.repo.name, lane_name(l)),
+        (Some(l), None) => format!("{marker}{}/{}  ", l.repo.name, lane_name(l)),
+        (None, _) => format!("{marker}lane {id}"),
     };
     let base = if focused {
         app.theme.selected()
@@ -1747,7 +1771,20 @@ fn tile_lines(
         ));
     }
     let mut lines = vec![Line::from(spans)];
-    lines.extend(output_tail(app, Some(id), height.saturating_sub(1)));
+    let budget = height.saturating_sub(1);
+    match &tile.window {
+        Some(w) => match app.term_output.get(w) {
+            Some(pane) => {
+                let start = pane.lines.len().saturating_sub(budget);
+                lines.extend(pane.lines[start..].iter().cloned());
+            }
+            None => lines.push(Line::from(Span::styled(
+                "  (no live output yet)".to_string(),
+                app.theme.dim(),
+            ))),
+        },
+        None => lines.extend(output_tail(app, Some(id), budget)),
+    }
     lines
 }
 

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -295,6 +295,83 @@ async fn peek_popup_shows_the_dialog_and_queue() {
 }
 
 #[tokio::test]
+async fn grid_tiles_plain_shell_terminals() {
+    use repomon_core::model::AgentStatus;
+    use repomon_tui::keybinds::View;
+
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let sock = std::env::temp_dir().join(format!("repomon-tui-grid-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&sock);
+    let server = {
+        let ctx = ctx.clone();
+        let sock = sock.clone();
+        tokio::spawn(async move { serve(ctx, &sock).await })
+    };
+    for _ in 0..100 {
+        if sock.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let client = DaemonClient::connect(&sock).await.expect("connect");
+
+    let repo_dir = tempfile::tempdir().unwrap();
+    git(repo_dir.path(), &["init", "-b", "main"]);
+    std::fs::write(repo_dir.path().join("README.md"), "hi\n").unwrap();
+    git(repo_dir.path(), &["add", "."]);
+    git(repo_dir.path(), &["commit", "-m", "feat: initial commit"]);
+    client
+        .call(
+            "repo.add",
+            Some(json!({ "path": repo_dir.path().to_string_lossy() })),
+        )
+        .await
+        .expect("repo.add");
+
+    let mut app = App::new(client);
+    app.refresh().await;
+    let lane_id = app.lanes[0].id;
+
+    // A lane with a running agent AND an open plain terminal: the grid tiles both.
+    app.lanes[0].agent_sessions = vec![fake_session(AgentStatus::Running, None)];
+    let term = format!("term-{lane_id}-1");
+    app.term_windows = vec![(lane_id, term.clone())];
+    let raw = "SHELL_TILE_SENTINEL $ cargo build".to_string();
+    app.term_output.insert(
+        term.clone(),
+        repomon_tui::app::Pane {
+            lines: repomon_tui::view::parse_pane(&raw),
+            raw,
+            cursor: None,
+        },
+    );
+    app.view = View::Grid;
+    let grid = render_to_string(&app, 120, 40).unwrap();
+    assert!(
+        grid.contains("2 live panes"),
+        "grid must count the shell tile:\n{grid}"
+    );
+    assert!(
+        grid.contains(&term),
+        "shell tile header must name its terminal window:\n{grid}"
+    );
+    assert!(
+        grid.contains("SHELL_TILE_SENTINEL"),
+        "shell tile must render the terminal's streamed pane:\n{grid}"
+    );
+
+    // The terminal's pane content must not bleed into the agent tile (separate keying).
+    assert!(
+        grid.contains("no live output"),
+        "the agent tile (no streamed output) keeps its own empty state:\n{grid}"
+    );
+
+    server.abort();
+    let _ = std::fs::remove_file(&sock);
+}
+
+#[tokio::test]
 async fn renders_fleet_with_a_registered_repo() {
     let store = Store::open_in_memory().unwrap();
     let ctx = Ctx::new(store, Config::default(), None);

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -85,10 +85,11 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
+| `terminal.list_all` | — | `[{ lane_id, id }]` (every lane's open terminals, sorted — what the Grid tiles) |
 | `terminal.close` | `{ id }` | `null` |
 | `terminal.target` | `{ id }` | `{ target, available }` |
 | `fs.browse` | `{ path? }` | `BrowseResult` (subdirs, repos, added flags) |
-| `viewport.set` | `{ lane_ids, focus_lane?, focus_window? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot) |
+| `viewport.set` | `{ lane_ids, focus_lane?, focus_window?, windows? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot. `windows` names plain-terminal windows — `term-{lane}-{n}` — to stream as extra panes alongside the lanes, e.g. the Grid's shell tiles; non-terminal names are ignored) |
 | `subscribe` | `{ topics? }` | `null` |
 | `ping` | — | `"pong"` (remote keep-alive / connectivity probe) |
 | `push.register` | `{ device_token }` | `null` (register an APNs device for push; idempotent) |
@@ -172,7 +173,7 @@ when readable (a partial parse still returns what it could).
 | `event.lane.created` | `{ lane }` |
 | `event.lane.deleted` | `{ lane_id }` |
 | `event.agent.status` | `{ lane_id, status }` |
-| `event.agent.output` | `{ lane_id, content, cursor? }` (`cursor` is `[col, row]` — the pane's text-cursor position, 0-based from the pane's top-left — sent only for the focused lane when its cursor is visible; `null`/absent otherwise) |
+| `event.agent.output` | `{ lane_id, window, content, cursor? }` (`window` names the tmux window the capture came from — a `lane-*` agent pane or a `term-*` plain terminal, so one lane can stream both without colliding; `cursor` is `[col, row]` — the pane's text-cursor position, 0-based from the pane's top-left — sent only for the focused pane when its cursor is visible; `null`/absent otherwise) |
 | `event.agent.changed` | `{ name }` or `{ default }` (a custom agent was added/removed, or the default changed) |
 | `event.notification` | `{ lane_id, session_id?, kind, title, body, prompt?, attention, dialog? }` — daemon-side agent alert (kinds: `needs_you`, `rate_limited`, `resumed`, `idle`, `stalled`; `prompt` is the agent's pending question verbatim). `attention` refines `needs_you`: `permission` (routine tool-call ask) / `decision` (a real question) / `done_candidate` (turn finished on a clean lane with a this-turn commit — ready to review) / `end_of_turn` (turn finished, no dialog) / `none`; `dialog` is the full `PendingDialog` when one is on screen, so an actionable client can offer its real options. `stalled` fires once when a managed agent's pane and transcript both freeze mid-work for ~5 min while its process lives (see `AgentSession.stale`/`stalled_since` on `lane.list` — additive overlay fields, with `stalled_since` marking the pane's last change). Emitted only while `[remote]` is enabled; the same alert goes to APNs devices with category `AGENT_PROMPT` (actionable) or `AGENT_ALERT`. |
 | `event.orchestrator.output` | `{ content, cursor? }` — the repomind pane's text (and `[col, row]` cursor) streamed while watched; same shape as `event.agent.output` without `lane_id`. |


### PR DESCRIPTION
## What

Closes the oldest known Grid limitation (STATUS.md: "The Grid tiles agent lanes, not the plain `t` shells"): the babysit Grid now tiles every visible lane's open plain terminals after the agent panes, up to the 8-tile cap — observe several shells at once, exactly as suggested.

The enabling change is making the live-output pipeline window-aware end to end:

- **`viewport.set` gains an additive `windows[]` field** naming `term-{lane}-{n}` windows to stream as extra panes; non-terminal names are ignored so a client can't point the capture loop at arbitrary windows.
- **The daemon's `stream_output` loop is re-keyed by window** (was: one window per lane). Terminal panes get the same cadence regimes (typing burst / focused / background backoff) and per-tick budget, and every `event.agent.output` now carries a `window` tag — so one lane can stream its agent pane and a terminal simultaneously without either clobbering the other. A focused terminal never hijacks its lane's stream (regression-tested): the agent tile keeps updating beside it.
- **New `terminal.list_all` RPC** (fleet-wide `[{lane_id, id}]`) feeds the Grid's shell list, polled at ~2s only while the Grid is open.
- **TUI**: shell tiles are labeled `repo/lane · term-N`, keep their own output store, type-in-place on click (keystrokes route to the terminal window), attach on Enter/double-click via `terminal.target`, and show in the position dots. The `g` needs-you hop skips shell tiles.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` green (new tests: `parse_term_window` round-trip, `stream_window_for` focus rules, Grid snapshot with a streamed shell tile beside an agent tile with separate keying).
- Live against an isolated daemon: a ticking shell window appeared as a second tile within one poll, streamed continuously (ticks 0→12 observed), the position dots named it (`2/2 repo/main · term-1-1`), and killing the window dropped the tile cleanly within ~2s.

## Compatibility

All wire changes additive: `windows` defaults to empty, the `window` field on output events is ignored by old clients, and old daemons simply never send it (new TUIs treat untagged events as lane panes, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)