### PR TITLE
dxkit stop-gate verdicts feed the done-candidate hint

### DIFF
--- a/crates/repomon-core/src/agent/attention.rs
+++ b/crates/repomon-core/src/agent/attention.rs
@@ -74,14 +74,53 @@ pub fn agent_attention(s: &AgentSession) -> Attention {
     }
 }
 
-/// [`agent_attention`] refined with the lane's git state: an end-of-turn whose work looks
-/// shippable — worktree clean and a commit landed with this turn — reads as
-/// [`Attention::DoneCandidate`] ("review?") instead of a bare end-of-turn.
+/// A gate verdict counts as "this turn's" when it ran no earlier than slightly before the
+/// agent's last words — the Stop hook fires right after the turn ends, so a fresh verdict's
+/// timestamp lands at/after `last_activity_at`; anything older belongs to a previous turn.
+const GATE_FRESH_SLACK: chrono::Duration = chrono::Duration::minutes(2);
+
+/// [`agent_attention`] refined with the lane's state: an end-of-turn whose work looks done
+/// reads as [`Attention::DoneCandidate`] ("review?") instead of a bare end-of-turn.
+///
+/// Done-ness comes from the strongest available signal: a fresh dxkit stop-gate verdict when
+/// the worktree runs one (`allowed` grants, a block VETOES — the gate explicitly said the
+/// work isn't done, whatever git looks like), else the git heuristic (clean worktree + a
+/// this-turn commit).
 pub fn agent_attention_in(lane: &Lane, s: &AgentSession) -> Attention {
     match agent_attention(s) {
-        Attention::EndOfTurn if work_ready(lane, s) => Attention::DoneCandidate,
+        Attention::EndOfTurn => match gate_this_turn(s) {
+            Some(g) if g.allowed => Attention::DoneCandidate,
+            Some(_) => Attention::EndOfTurn,
+            None if work_ready(lane, s) => Attention::DoneCandidate,
+            None => Attention::EndOfTurn,
+        },
         a => a,
     }
+}
+
+/// This session's gate verdict for the CURRENT turn, if any: same session (when both sides
+/// know their id) and timestamped within [`GATE_FRESH_SLACK`] of the agent's last words.
+fn gate_this_turn(s: &AgentSession) -> Option<&crate::agent::gate::GateVerdict> {
+    let g = gate_for_session(s)?;
+    (g.at >= s.last_activity_at - GATE_FRESH_SLACK).then_some(g)
+}
+
+/// The latest gate block for this session — however old, since the next gate run replaces
+/// it — as `Some(net_new_findings)`. Feeds the "⛔ gate N" badge while the agent repairs.
+pub fn gate_bounced(s: &AgentSession) -> Option<u32> {
+    let g = gate_for_session(s)?;
+    (!g.allowed).then_some(g.net_new_findings)
+}
+
+/// The session's gate verdict, dropping one that identifiably belongs to another session.
+fn gate_for_session(s: &AgentSession) -> Option<&crate::agent::gate::GateVerdict> {
+    let g = s.gate.as_ref()?;
+    if let (Some(gs), Some(ss)) = (&g.session_id, &s.session_id) {
+        if gs != ss {
+            return None;
+        }
+    }
+    Some(g)
 }
 
 /// The lane's work looks shippable: nothing uncommitted, and the last commit belongs to this
@@ -141,6 +180,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             tmux_window: Some("lane-1".into()),
             last_message: None,
             pending_prompt: pending.map(str::to_string),
@@ -193,6 +233,72 @@ mod tests {
             last_activity_at: Utc::now(),
             pinned: false,
         }
+    }
+
+    #[test]
+    fn gate_verdict_grants_and_vetoes_done_candidate() {
+        use crate::agent::gate::GateVerdict;
+        let gate = |allowed: bool, mins_after_turn: i64, sid: Option<&str>| GateVerdict {
+            allowed,
+            net_new_findings: if allowed { 0 } else { 2 },
+            // Relative to the sess() helper's last_activity_at (now).
+            at: Utc::now() + chrono::Duration::minutes(mins_after_turn),
+            session_id: sid.map(str::to_string),
+        };
+        let with_gate = |mut s: AgentSession, g: GateVerdict| {
+            s.session_id = Some("abc".into());
+            s.gate = Some(g);
+            s
+        };
+
+        // A fresh ALLOWED verdict grants the review hint even on a dirty lane with no commit —
+        // the gate ran the tests/scanners; that beats the git heuristic.
+        let eot = with_gate(sess(AgentStatus::Waiting, None), gate(true, 0, Some("abc")));
+        assert_eq!(
+            agent_attention_in(&lane(false, None), &eot),
+            Attention::DoneCandidate
+        );
+
+        // A fresh BLOCK vetoes the git heuristic — clean + committed, but the gate said no.
+        let bounced = with_gate(
+            sess(AgentStatus::Waiting, None),
+            gate(false, 0, Some("abc")),
+        );
+        assert_eq!(
+            agent_attention_in(&lane(true, Some(5)), &bounced),
+            Attention::EndOfTurn
+        );
+
+        // A STALE verdict (from a turn long past) is ignored: back to the git heuristic.
+        let old = with_gate(
+            sess(AgentStatus::Waiting, None),
+            gate(true, -60, Some("abc")),
+        );
+        assert_eq!(
+            agent_attention_in(&lane(false, None), &old),
+            Attention::EndOfTurn
+        );
+
+        // Another session's verdict is ignored too.
+        let other = with_gate(sess(AgentStatus::Waiting, None), gate(true, 0, Some("zzz")));
+        assert_eq!(
+            agent_attention_in(&lane(false, None), &other),
+            Attention::EndOfTurn
+        );
+
+        // gate_bounced feeds the badge: the latest block for THIS session, however old.
+        let mut running = with_gate(
+            sess(AgentStatus::Running, None),
+            gate(false, -30, Some("abc")),
+        );
+        assert_eq!(gate_bounced(&running), Some(2));
+        running.gate = Some(gate(true, 0, Some("abc")));
+        assert_eq!(gate_bounced(&running), None);
+        let foreign = with_gate(
+            sess(AgentStatus::Running, None),
+            gate(false, 0, Some("zzz")),
+        );
+        assert_eq!(gate_bounced(&foreign), None);
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/claude.rs
+++ b/crates/repomon-core/src/agent/claude.rs
@@ -74,6 +74,7 @@ impl TranscriptSummary {
             stale: false, // overlaid by the daemon's stall detector
             stalled_since: None,
             ended_turn: self.ended_turn,
+            gate: None,
             config_dir: self.config_dir,
             custom_label: None, // overlay sets this from the session_labels store
         }

--- a/crates/repomon-core/src/agent/gate.rs
+++ b/crates/repomon-core/src/agent/gate.rs
@@ -1,0 +1,132 @@
+//! Reading a dxkit stop-gate verdict from a worktree's loop ledger.
+//!
+//! [dxkit](https://github.com/vyuh-labs/dxkit) is a deterministic Stop-hook for Claude Code:
+//! when an agent tries to declare "done", the gate reruns scanners/tests on the changed files
+//! and blocks the stop on net-new findings. Every gate run appends one JSON line to
+//! `.dxkit/loop/ledger.jsonl` in the worktree (an append-only audit trail dxkit documents as
+//! safe for external tools to read). repomon tails that file: a fresh `allowed` verdict is a
+//! stronger done-signal than the git heuristic, and a fresh block *vetoes* it — the gate
+//! explicitly said the work isn't done. Worktrees without dxkit simply have no ledger, and
+//! everything falls back to the git heuristic.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Relative location of dxkit's loop ledger inside a worktree.
+pub const LEDGER_REL: &str = ".dxkit/loop/ledger.jsonl";
+
+/// How many bytes of the ledger tail to read — events are single lines well under 1 KB, so
+/// this always covers the last event without reading an unbounded audit trail.
+const TAIL_BYTES: u64 = 8 * 1024;
+
+/// The latest stop-gate verdict for a worktree, as read from the dxkit loop ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateVerdict {
+    /// Whether the gate let the agent stop (`false` = bounced on net-new findings).
+    pub allowed: bool,
+    /// Net-new findings that blocked completion (0 when allowed).
+    pub net_new_findings: u32,
+    /// When the gate ran.
+    pub at: DateTime<Utc>,
+    /// The Claude session the verdict belongs to, when the hook payload carried one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+/// Parse the LAST well-formed stop-gate event out of ledger content (later lines win —
+/// the ledger is append-only). Unknown fields, junk lines, and future schema versions are
+/// skipped rather than errors: the ledger is another tool's file.
+pub fn parse_ledger_tail(content: &str) -> Option<GateVerdict> {
+    #[derive(Deserialize)]
+    struct Line {
+        event: String,
+        timestamp: DateTime<Utc>,
+        allowed: bool,
+        #[serde(default)]
+        net_new_findings: u32,
+        #[serde(default)]
+        session_id: Option<String>,
+    }
+    content.lines().rev().find_map(|l| {
+        let line: Line = serde_json::from_str(l.trim()).ok()?;
+        (line.event == "Stop").then_some(GateVerdict {
+            allowed: line.allowed,
+            net_new_findings: line.net_new_findings,
+            at: line.timestamp,
+            session_id: line.session_id,
+        })
+    })
+}
+
+/// Read the latest gate verdict from `worktree`'s dxkit ledger, if one exists. Reads only
+/// the file's tail — the ledger is an unbounded audit trail.
+pub fn read_gate_verdict(worktree: &Path) -> Option<GateVerdict> {
+    use std::io::{Read, Seek, SeekFrom};
+    let path = worktree.join(LEDGER_REL);
+    let mut f = std::fs::File::open(path).ok()?;
+    let len = f.metadata().ok()?.len();
+    let start = len.saturating_sub(TAIL_BYTES);
+    f.seek(SeekFrom::Start(start)).ok()?;
+    let mut tail = String::new();
+    f.read_to_string(&mut tail).ok()?;
+    // A mid-line seek start means the first line is a fragment; the parser skips junk lines.
+    parse_ledger_tail(&tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A real-shaped dxkit ledger line (schema_version 1), trimmed to the fields that matter.
+    const BLOCKED: &str = r#"{"schema_version":1,"timestamp":"2026-07-07T10:15:30Z","event":"Stop","session_id":"abc-123","cwd":"/w","branch":"feat/x","commit":"deadbeef","guardrail_status":"fail","net_new_findings":2,"baseline_findings":14,"files_changed":3,"allowed":false,"stop_hook_active":false,"tests_status":"pass","lint_status":"pass","typecheck_status":"pass","duration_ms":1200}"#;
+    const ALLOWED: &str = r#"{"schema_version":1,"timestamp":"2026-07-07T10:22:05Z","event":"Stop","session_id":"abc-123","cwd":"/w","branch":"feat/x","commit":"deadbeef","guardrail_status":"pass","net_new_findings":0,"baseline_findings":14,"files_changed":3,"allowed":true,"stop_hook_active":true,"tests_status":"pass","lint_status":"pass","typecheck_status":"pass","duration_ms":900}"#;
+
+    #[test]
+    fn last_event_wins_and_junk_is_skipped() {
+        // Blocked then allowed (the repair loop finishing): the tail verdict is the allowed one.
+        let content = format!("{BLOCKED}\n{ALLOWED}\n");
+        let v = parse_ledger_tail(&content).expect("verdict");
+        assert!(v.allowed);
+        assert_eq!(v.net_new_findings, 0);
+        assert_eq!(v.session_id.as_deref(), Some("abc-123"));
+        assert_eq!(
+            v.at,
+            "2026-07-07T10:22:05Z".parse::<DateTime<Utc>>().unwrap()
+        );
+
+        // Allowed then blocked (a later attempt regressed): the block wins.
+        let content = format!("{ALLOWED}\n{BLOCKED}\n");
+        let v = parse_ledger_tail(&content).expect("verdict");
+        assert!(!v.allowed);
+        assert_eq!(v.net_new_findings, 2);
+
+        // A trailing fragment (mid-line tail seek), junk, and blank lines are skipped.
+        let content = format!("gs\":14}}\n\nnot json\n{ALLOWED}\n{{\"half\":");
+        let v = parse_ledger_tail(&content).expect("verdict");
+        assert!(v.allowed);
+    }
+
+    #[test]
+    fn non_stop_events_and_empty_content_yield_none() {
+        assert_eq!(parse_ledger_tail(""), None);
+        assert_eq!(parse_ledger_tail("not json at all\n"), None);
+        // A future non-Stop event kind is not a verdict.
+        let other = r#"{"schema_version":1,"timestamp":"2026-07-07T10:00:00Z","event":"Baseline","allowed":true,"net_new_findings":0}"#;
+        assert_eq!(parse_ledger_tail(other), None);
+    }
+
+    #[test]
+    fn reads_the_tail_of_a_real_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = dir.path().join(LEDGER_REL);
+        std::fs::create_dir_all(ledger.parent().unwrap()).unwrap();
+        std::fs::write(&ledger, format!("{BLOCKED}\n{ALLOWED}\n")).unwrap();
+        let v = read_gate_verdict(dir.path()).expect("verdict");
+        assert!(v.allowed);
+        // No ledger at all → None (the common, dxkit-less case).
+        let bare = tempfile::tempdir().unwrap();
+        assert_eq!(read_gate_verdict(bare.path()), None);
+    }
+}

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod attention;
 pub mod claude;
+pub mod gate;
 pub mod limit;
 pub mod prompt;
 pub mod text;

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -282,6 +282,11 @@ pub struct AgentSession {
     /// Daemon-internal (feeds the stall detector); never serialized.
     #[serde(skip)]
     pub ended_turn: bool,
+    /// The latest dxkit stop-gate verdict from the worktree's `.dxkit/loop/ledger.jsonl`,
+    /// when the lane uses dxkit. Overlaid at list time; not persisted. A fresh `allowed`
+    /// grants done-candidate, a fresh block vetoes it (see `agent_attention_in`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate: Option<crate::agent::gate::GateVerdict>,
     /// The Claude account (config dir) this agent runs under, overlaid at list time from the
     /// transcript. `None` = the default `~/.claude`; `Some` = a variant (`~/.claude-work`). Lets a
     /// client attribute account-level usage (the `/usage` probe) to the focused agent. Not persisted.

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -614,6 +614,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             config_dir: None,
             custom_label: None,
         }

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -702,6 +702,7 @@ fn session_from_row(r: &Row) -> rusqlite::Result<AgentSession> {
         stale: false,
         stalled_since: None,
         ended_turn: false,
+        gate: None,
         config_dir: None,
         custom_label: None,
     })
@@ -996,6 +997,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             config_dir: None,
             custom_label: None,
         };

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -112,6 +112,12 @@ pub struct OrchestratorSession {
     pub session_id: Option<String>,
 }
 
+/// One `gate_cache` entry: the ledger's mtime when last read, and the verdict parsed then.
+pub type GateCacheEntry = (
+    Option<std::time::SystemTime>,
+    Option<repomon_core::agent::gate::GateVerdict>,
+);
+
 /// Everything a request handler needs. Cheap to share via `Arc`.
 pub struct Ctx {
     pub store: Store,
@@ -156,6 +162,9 @@ pub struct Ctx {
     /// detector's clock. Never TTL-pruned (its point is remembering how long a pane has sat
     /// still); entries drop only when their window vanishes.
     pub pane_seen: Mutex<HashMap<String, (u64, chrono::DateTime<chrono::Utc>)>>,
+    /// Per worktree: the dxkit loop ledger's mtime and the verdict parsed from its tail, so
+    /// the overlay re-reads only when the gate actually ran again. Keyed by worktree path.
+    pub gate_cache: Mutex<HashMap<PathBuf, GateCacheEntry>>,
     /// Lanes currently paused on a usage limit, with their reset time — written by the
     /// auto-continue watcher and read by `overlay_agents` to surface the `RateLimited` status.
     pub rate_limits: Mutex<HashMap<LaneId, auto_continue::RateLimit>>,
@@ -258,6 +267,7 @@ impl Ctx {
             overlay_cache: Mutex::new(None),
             prompt_cache: Mutex::new(HashMap::new()),
             pane_seen: Mutex::new(HashMap::new()),
+            gate_cache: Mutex::new(HashMap::new()),
             rate_limits: Mutex::new(HashMap::new()),
             usage: Mutex::new(HashMap::new()),
             auto_continue_off: Mutex::new(HashSet::new()),

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2010,6 +2010,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     stale: false,
                     stalled_since: None,
                     ended_turn: false,
+                    gate: None,
                     config_dir: None,
                     custom_label: None,
                 });
@@ -2026,6 +2027,38 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 }
             }
         }
+    }
+
+    // dxkit stop-gate verdicts: worktrees running dxkit's loop pack leave an append-only
+    // ledger (`.dxkit/loop/ledger.jsonl`); its tail verdict is overlaid onto the lane's real
+    // sessions so a fresh `allowed` grants (and a block vetoes) the done-candidate hint.
+    // Cached by the ledger's mtime — one cheap stat per lane per overlay, a re-read only when
+    // the gate actually ran again. Session matching happens client-side in `attention`.
+    {
+        let mut cache = ctx.gate_cache.lock().await;
+        for lane in lanes.iter_mut() {
+            let wt = lane.worktree.path.clone();
+            let mtime = std::fs::metadata(wt.join(agent::gate::LEDGER_REL))
+                .and_then(|m| m.modified())
+                .ok();
+            let verdict = match cache.get(&wt) {
+                Some((m, v)) if *m == mtime => v.clone(),
+                _ => {
+                    let v = mtime.and_then(|_| agent::gate::read_gate_verdict(&wt));
+                    cache.insert(wt.clone(), (mtime, v.clone()));
+                    v
+                }
+            };
+            if let Some(v) = verdict {
+                for s in lane.agent_sessions.iter_mut().filter(|s| !s.inferred) {
+                    s.gate = Some(v.clone());
+                }
+            }
+        }
+        // Bounded by the live lane set: drop worktrees no longer listed.
+        let live: std::collections::HashSet<&PathBuf> =
+            lanes.iter().map(|l| &l.worktree.path).collect();
+        cache.retain(|wt, _| live.contains(wt));
     }
 
     // Interactive dialogs: a transcript that ends in a tool call reads **Running**, but the
@@ -2570,6 +2603,7 @@ fn window_placeholder_session(lane: &Lane, kind: AgentKind, window: String) -> A
         stale: false,
         stalled_since: None,
         ended_turn: false,
+        gate: None,
         config_dir: None,
         custom_label: None,
     }

--- a/crates/repomon-mcp/src/fleet.rs
+++ b/crates/repomon-mcp/src/fleet.rs
@@ -43,6 +43,10 @@ pub struct AgentDigest {
     /// `AgentSession.stale`). A watchdog flag alongside `status`, not a status of its own.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stalled: bool,
+    /// The worktree's latest dxkit stop-gate verdict, when it runs one — the orchestrator's
+    /// strongest done/not-done evidence (see `AgentSession.gate`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate: Option<repomon_core::agent::gate::GateVerdict>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<String>,
     /// The open dialog's summary, when one is present. Skipped from fleet digests (it lives in
@@ -206,6 +210,7 @@ fn project_agent(lane: &Lane, s: &AgentSession, now: DateTime<Utc>) -> AgentDige
         external: s.external,
         inferred: s.inferred,
         stalled: s.stale,
+        gate: s.gate.clone(),
         window: s.tmux_window.clone(),
         pending_prompt: s.pending_prompt.clone(),
     }
@@ -246,6 +251,13 @@ fn fingerprint(lanes: &[LaneDigest]) -> u64 {
                 a.status.hash(&mut h);
                 a.attention.as_str().hash(&mut h);
                 a.stalled.hash(&mut h);
+                match &a.gate {
+                    Some(g) => {
+                        g.allowed.hash(&mut h);
+                        g.net_new_findings.hash(&mut h);
+                    }
+                    None => 2u8.hash(&mut h),
+                }
                 a.pending_prompt.as_deref().unwrap_or("").hash(&mut h);
             }
             None => 0u8.hash(&mut h),
@@ -353,6 +365,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             config_dir: None,
             custom_label: None,
         }

--- a/crates/repomon-mcp/src/server.rs
+++ b/crates/repomon-mcp/src/server.rs
@@ -1146,6 +1146,7 @@ mod tests {
                 external: false,
                 inferred: false,
                 stalled: false,
+                gate: None,
                 window: Some("lane-1".into()),
                 pending_prompt: None,
             }),
@@ -1178,6 +1179,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             config_dir: None,
             custom_label: None,
         }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -5338,6 +5338,7 @@ mod tests {
             stale: false,
             stalled_since: None,
             ended_turn: false,
+            gate: None,
             config_dir: None,
             custom_label: None,
         }

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -1819,6 +1819,14 @@ fn agent_badge(lane: &Lane, app: &App) -> (String, Style) {
         .iter()
         .find(|s| s.status == AgentStatus::RateLimited);
     let stalled = sessions.iter().find(|s| !s.inferred && s.stale);
+    // The latest dxkit gate block for any session — worn while the loop repairs, cleared by
+    // the next gate run that passes.
+    let gate_tag = sessions
+        .iter()
+        .filter(|s| !s.inferred)
+        .find_map(repomon_core::agent::attention::gate_bounced)
+        .map(|n| format!(" · ⛔ gate {n}"))
+        .unwrap_or_default();
     if let Some(rl) = rate_limited {
         (
             format!("⏳ rate-limited · {}{count}{tag}", fmt_resume(rl.resume_at)),
@@ -1834,14 +1842,20 @@ fn agent_badge(lane: &Lane, app: &App) -> (String, Style) {
             Attention::DoneCandidate => ("✓", "review?"),
             _ => ("⏸", "done"),
         };
-        (format!("{glyph} {word}{count}{tag}"), app.theme.needs_you())
+        (
+            format!("{glyph} {word}{count}{tag}{gate_tag}"),
+            app.theme.needs_you(),
+        )
     } else if let Some(st) = stalled {
         (
             format!("⚠ stalled {}{count}{tag}", fmt_stall(st.stalled_since)),
             app.theme.needs_you(),
         )
     } else if running > 0 {
-        (format!("▶ running{count}{tag}"), app.theme.running())
+        (
+            format!("▶ running{count}{tag}{gate_tag}"),
+            app.theme.running(),
+        )
     } else {
         (format!("idle{count}{tag}"), app.theme.idle())
     }

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -57,6 +57,7 @@ fn fake_session(
         stale: false,
         stalled_since: None,
         ended_turn: false,
+        gate: None,
         config_dir: None,
         custom_label: None,
     }
@@ -173,6 +174,45 @@ async fn waiting_badges_distinguish_attention() {
     let jump = render_to_string(&app, 100, 40).unwrap();
     assert!(jump.contains("✓ review?"), "review badge missing:\n{jump}");
     app.view = View::Fleet;
+
+    // A running agent bounced by the dxkit gate: the badge wears the block while it repairs.
+    let mut bounced = fake_session(AgentStatus::Running, None);
+    bounced.gate = Some(repomon_core::agent::gate::GateVerdict {
+        allowed: false,
+        net_new_findings: 2,
+        at: chrono::Utc::now(),
+        session_id: None,
+    });
+    app.lanes[0].agent_sessions = vec![bounced];
+    app.view = View::LaneJump;
+    let jump = render_to_string(&app, 100, 40).unwrap();
+    // (⛔ is double-width: the test backend dumps a filler cell after it, so match in parts.)
+    assert!(
+        jump.contains("▶ running · ⛔") && jump.contains("gate 2"),
+        "gate-bounce badge missing:\n{jump}"
+    );
+    app.view = View::Fleet;
+
+    // A fresh ALLOWED gate verdict grants the review hint even on a dirty lane — the gate ran
+    // the tests/scanners, which beats the git heuristic.
+    let mut passed = fake_session(AgentStatus::Waiting, None);
+    passed.gate = Some(repomon_core::agent::gate::GateVerdict {
+        allowed: true,
+        net_new_findings: 0,
+        at: chrono::Utc::now(),
+        session_id: None,
+    });
+    app.lanes[0].agent_sessions = vec![passed];
+    app.lanes[0].state.dirty.unstaged = 1;
+    app.lanes[0].state.last_commit_at = None;
+    app.view = View::LaneJump;
+    let jump = render_to_string(&app, 100, 40).unwrap();
+    assert!(
+        jump.contains("✓ review?"),
+        "gate-verified review badge missing:\n{jump}"
+    );
+    app.view = View::Fleet;
+    app.lanes[0].state.dirty.unstaged = 0;
 
     // A stalled agent (alive but frozen mid-work): ⚠ on the row, duration in the badge.
     let mut stuck = fake_session(AgentStatus::Running, None);

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -51,7 +51,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `repo.add` | `{ path }` | `Repo` |
 | `repo.remove` | `{ repo_id }` | `null` |
 | `repo.discover` | `{ root, max_depth=4 }` | `[String]` (repo paths) |
-| `lane.list` | — | `[Lane]` (agent sessions overlaid) |
+| `lane.list` | — | `[Lane]` (agent sessions overlaid; each session may carry `pending_dialog`, `stale`/`stalled_since`, and `gate` — the worktree's latest dxkit stop-gate verdict `{ allowed, net_new_findings, at, session_id? }`, tailed from `.dxkit/loop/ledger.jsonl` when the lane runs dxkit's loop pack. A fresh `allowed` grants the done-candidate attention; a fresh block vetoes it) |
 | `lane.get` | `{ lane_id }` | `Lane` |
 | `lane.create` | `CreateLaneParams` | `Lane` |
 | `lane.delete` | `{ lane_id, also_delete_branch=false }` | `null` |


### PR DESCRIPTION
## What

[dxkit](https://github.com/vyuh-labs/dxkit) is a deterministic Stop-hook for Claude Code: when an agent tries to declare done, it reruns scanners/tests on the changed files and blocks the stop on net-new findings, appending each verdict to an append-only ledger (`.dxkit/loop/ledger.jsonl`) that its docs describe as safe for external tools to read. This PR reads that ledger, giving repomon's done-detection deterministic gate evidence instead of only the git heuristic — the two-layer story the dxkit author proposed at launch.

- **Ledger reader in core** (`agent/gate.rs`): tail-parse (last well-formed `Stop` event wins; junk/fragments/future event kinds skipped; only the last 8 KB read — it's an unbounded audit trail). Fixture-tested against real-shaped schema-v1 lines.
- **Daemon overlay**: one mtime `stat` per lane per overlay pass, re-read only when the gate actually ran; the verdict lands on `AgentSession.gate` (additive wire field).
- **Attention refinement**: at end-of-turn, a fresh `allowed` verdict grants `✓ review?` even on an uncommitted tree (the gate ran the tests/scanners — stronger than the git heuristic); a fresh block **vetoes** done-candidate outright, whatever git looks like. Stale verdicts (previous turns) and other sessions' verdicts are ignored; worktrees without dxkit fall back to the git heuristic unchanged.
- **Bounce visibility**: while the latest verdict is a block, lane badges wear `· ⛔ gate N` (running and waiting states) — you can see a repair loop happening. No new notification kind; bounces are the loop working.
- **MCP**: fleet digests carry the verdict and it participates in the change fingerprint, so repomind's `wait_for_change` wakes on gate transitions and can adjudicate done-vs-keep-going from deterministic evidence.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` green — new fixture tests for ledger tail-parsing (last-event-wins, junk-skipping, tail-of-file reads) and attention grant/veto/staleness/session-matching, plus TUI snapshot tests for both badges.
- Live against an isolated daemon: wrote a blocked schema-v1 event into a lane's ledger → switcher badge showed `▶ running · ⛔ gate 3` within one refresh; appended an allowed event → badge cleared on the next pass (the mtime cache re-read working end to end).

## Compatibility

`AgentSession.gate` and `AgentDigest.gate` are additive/skip-if-absent; nothing changes for worktrees (or clients) that never see a ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)