### PR TITLE
feat(remote): allow dialog answering and PTY streaming over the bridge

### DIFF
--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -59,11 +59,17 @@ fn remote_method_allowed(method: &str) -> bool {
         | "commit.today" | "commit.range" | "commit.search" | "commit.recent"
         | "agent.capture" | "agent.transcript"
         | "usage.get" | "daemon.status"
+        // terminal-window *names* only ({lane_id, id} pairs) — open/close/target stay blocked
+        | "terminal.list_all"
         // event stream + per-client streaming hint
         | "subscribe" | "viewport.set"
-        // drive an existing agent
+        // drive an existing agent. agent.prompt is a read (fresh pane capture parsed for the
+        // on-screen dialog); agent.answer is strictly safer than the already-allowed blind
+        // agent.key — it re-captures and verifies the dialog before steering; agent.watch_bytes
+        // is a read-only byte stream of a pane the client could already agent.capture.
         | "agent.send_input" | "agent.signal" | "agent.key" | "agent.scroll"
         | "agent.target" | "agent.resize"
+        | "agent.prompt" | "agent.answer" | "agent.watch_bytes"
         // repomind orchestrator: read (status/transcript) + interact (send_input/key) are safe like
         // the agent equivalents above. start/stop spawn/kill the orchestrator's claude — a remote
         // process-spawn with caller-chosen autonomy/max_agents/prompt, so strictly higher privilege
@@ -271,6 +277,10 @@ mod tests {
             "commit.recent",
             "agent.capture",
             "agent.transcript",
+            "agent.prompt",
+            "agent.answer",
+            "agent.watch_bytes",
+            "terminal.list_all",
             "agent.send_input",
             "agent.signal",
             "agent.key",
@@ -308,6 +318,8 @@ mod tests {
             "config.get",
             "config.set",
             "terminal.open",
+            "terminal.close",
+            "terminal.target",
             "fs.browse",
             "daemon.shutdown",
             "agent.add",

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -26,6 +26,15 @@ with `repomon remote pair`, which renders a `repomon://<host:port>#<token>` QR).
   token can read panes and type into agents.
 - `ping` → `"pong"` serves as an application-level keep-alive; events flow after `subscribe`
   exactly as on the Unix socket.
+- **Method allowlist (default-deny):** the bridge only dispatches reads and
+  interaction-with-existing-agents — anything else (host management, spawning, config,
+  terminal open/close, filesystem) answers `-32601` `"not permitted over remote bridge"`.
+  Since v0.4.1 that includes `agent.prompt`, `agent.answer` (verified dialog steering,
+  strictly safer than the blind `agent.key` it complements), `agent.watch_bytes`, and
+  `terminal.list_all`. Events themselves are forwarded unfiltered after `subscribe`. Note
+  `agent.watch_bytes` is single-watch daemon-wide: a remote client and a local TUI Focus view
+  contend for the one byte stream, last writer wins — the loser should fall back to
+  capture-based polling.
 
 ## Envelope
 


### PR DESCRIPTION
Opens the remote WebSocket bridge's default-deny allowlist to the four v0.4.0 RPCs a companion client needs:

- **agent.prompt**: a read (fresh pane capture parsed for the on-screen dialog)
- **agent.answer**: verified dialog steering with `expect_summary`; strictly safer than the already-allowed blind `agent.key Enter` clients send today
- **agent.watch_bytes**: read-only PTY byte stream of a pane the client could already `agent.capture`
- **terminal.list_all**: window-name metadata (`{lane_id, id}` pairs)

`terminal.open/close/target` stay blocked (host mutation), as does everything else not listed. Also documents the default-deny allowlist in protocol.md's Remote transport section, including the `agent.watch_bytes` single-watch caveat (a remote client and a local TUI Focus view contend; last writer wins; the loser should fall back to capture polling).

Unblocks the repomon-ios v0.4.0 sync (structured dialog answering, lock-screen Approve upgrade, embedded PTY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)