### PR TITLE
feat: agent.fit — arbitrated remote pane reflow

### DIFF
--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -138,6 +138,10 @@ pub struct Ctx {
     /// Which agent window the focused lane should stream, when the TUI has a specific session
     /// selected (Tab in Focus/Split). Lanes not named here stream their first slot.
     pub viewport_focus: Mutex<Option<(LaneId, String)>>,
+    /// When the viewport was last (re)asserted. The TUI heartbeats `viewport.set` every few
+    /// seconds; `agent.fit` treats the focused window as size-owned only while this is fresh,
+    /// so a closed or crashed TUI frees the pane for remote reflow within seconds.
+    pub viewport_focus_at: Mutex<Option<Instant>>,
     /// Plain-terminal windows (`term-{lane}-{n}`) the TUI has visible as Grid tiles — streamed
     /// alongside the lane panes, each tagged with its window in the output event.
     pub viewport_windows: Mutex<Vec<String>>,
@@ -264,6 +268,7 @@ impl Ctx {
             events,
             viewport: Mutex::new(Vec::new()),
             viewport_focus: Mutex::new(None),
+            viewport_focus_at: Mutex::new(None),
             viewport_windows: Mutex::new(Vec::new()),
             live_cwds: Mutex::new(None),
             cwds_sticky: Mutex::new(HashMap::new()),

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -67,8 +67,12 @@ fn remote_method_allowed(method: &str) -> bool {
         // on-screen dialog); agent.answer is strictly safer than the already-allowed blind
         // agent.key — it re-captures and verifies the dialog before steering; agent.watch_bytes
         // is a read-only byte stream of a pane the client could already agent.capture.
+        // agent.fit is the ONLY remote door to pane sizing: it reflows the shared pane to the
+        // caller's grid only while no live TUI viewport owns the window, and always answers
+        // with the authoritative grid. The blind agent.resize stays local-only — an
+        // unconditional remote resize is exactly what squeezed the TUI's mediated view.
         | "agent.send_input" | "agent.signal" | "agent.key" | "agent.scroll"
-        | "agent.target" | "agent.resize"
+        | "agent.target" | "agent.fit"
         | "agent.prompt" | "agent.answer" | "agent.watch_bytes"
         // repomind orchestrator: read (status/transcript) + interact (send_input/key) are safe like
         // the agent equivalents above. start/stop spawn/kill the orchestrator's claude — a remote
@@ -286,7 +290,7 @@ mod tests {
             "agent.key",
             "agent.scroll",
             "agent.target",
-            "agent.resize",
+            "agent.fit",
             "agent.pin",
             "subscribe",
             "viewport.set",
@@ -307,6 +311,7 @@ mod tests {
             "agent.adopt",
             "agent.spawn",
             "agent.stop",
+            "agent.resize",
             "repo.add",
             "repo.remove",
             "repo.discover",

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1250,6 +1250,41 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 .map_err(internal)?;
             Ok(Value::Null)
         }
+        "agent.fit" => {
+            // The arbitrated resize for remote viewers: reflow the pane to the caller's grid
+            // ONLY while no live mediated viewer (the TUI's viewport focus, kept fresh by its
+            // heartbeat) owns the window's size. Always answers with the authoritative grid,
+            // so a refused caller renders pinned at the shared size instead of fighting.
+            let p: AgentResize = parse(params)?;
+            let window = p
+                .window
+                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+            let owned = {
+                let focus = ctx.viewport_focus.lock().await;
+                let at = *ctx.viewport_focus_at.lock().await;
+                fit_owned(focus.as_ref(), at, &window, std::time::Instant::now())
+            };
+            if owned {
+                let tmux = ctx.tmux.clone();
+                let w = window.clone();
+                let dims = tokio::task::spawn_blocking(move || tmux.size_named(&w))
+                    .await
+                    .map_err(internal)?;
+                return Ok(json!({
+                    "applied": false,
+                    "cols": dims.map(|d| d.0),
+                    "rows": dims.map(|d| d.1),
+                }));
+            }
+            let (cols, rows) = (p.cols.max(20), p.rows.max(4));
+            let tmux = ctx.tmux.clone();
+            let w = window.clone();
+            tokio::task::spawn_blocking(move || tmux.resize_named(&w, cols, rows))
+                .await
+                .map_err(internal)?
+                .map_err(internal)?;
+            Ok(json!({ "applied": true, "cols": cols, "rows": rows }))
+        }
         "agent.scroll" => {
             let p: AgentScroll = parse(params)?;
             let tmux = ctx.tmux.clone();
@@ -1448,6 +1483,10 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             let mut p: ViewportSet = parse(params)?;
             *ctx.viewport.lock().await = p.lane_ids;
             *ctx.viewport_focus.lock().await = p.focus_lane.zip(p.focus_window);
+            // The focus heartbeat: `agent.fit` treats the focused window as size-owned while
+            // this is fresh. The TUI re-asserts its viewport every few seconds, so a crashed
+            // or closed TUI releases ownership when the beat stops.
+            *ctx.viewport_focus_at.lock().await = Some(std::time::Instant::now());
             // Only real terminal windows are streamable extras — anything else is dropped so a
             // client can't point the capture loop at arbitrary windows.
             p.windows
@@ -2266,6 +2305,28 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
         Some(n) => n.max(managed_n).max(fresh).min(total),
         None => total, // probe unavailable: don't filter
     }
+}
+
+/// How long a viewport focus keeps owning its window's size after the last `viewport.set`.
+/// Three missed ~5s TUI heartbeats — generous against a busy tick, short enough that a
+/// closed/crashed TUI frees the pane for remote reflow within seconds.
+const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Whether a live mediated viewer owns `window`'s size (`agent.fit`'s arbitration): the
+/// viewport focus names this window and the viewport beat is fresh.
+fn fit_owned(
+    focus: Option<&(repomon_core::model::LaneId, String)>,
+    focus_at: Option<std::time::Instant>,
+    window: &str,
+    now: std::time::Instant,
+) -> bool {
+    let Some((_, focused)) = focus else {
+        return false;
+    };
+    if focused != window {
+        return false;
+    }
+    focus_at.is_some_and(|at| now.duration_since(at) < FOCUS_OWNED_TTL)
 }
 
 /// How long a managed agent's pane must sit unchanged — with no dialog up and its turn not
@@ -3339,6 +3400,24 @@ fn write_orchestrator_mcp_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fit_ownership_follows_the_live_viewport_focus() {
+        let now = std::time::Instant::now();
+        let fresh = Some(now - std::time::Duration::from_secs(2));
+        let stale = Some(now - std::time::Duration::from_secs(30));
+        let focus = Some((7i64, "lane-7".to_string()));
+
+        // A live focus on the same window owns its size.
+        assert!(fit_owned(focus.as_ref(), fresh, "lane-7", now));
+        // A different window is free.
+        assert!(!fit_owned(focus.as_ref(), fresh, "lane-9", now));
+        // A crashed/closed TUI stops owning once the viewport beat goes stale.
+        assert!(!fit_owned(focus.as_ref(), stale, "lane-7", now));
+        assert!(!fit_owned(focus.as_ref(), None, "lane-7", now));
+        // No focus at all — nothing is owned.
+        assert!(!fit_owned(None, fresh, "lane-7", now));
+    }
 
     #[test]
     fn session_visibility_rules() {

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -407,6 +407,10 @@ pub struct App {
     last_viewport: Vec<LaneId>,
     last_viewport_focus: Option<(LaneId, String)>,
     last_viewport_windows: Vec<String>,
+    /// When the viewport was last sent. Expires after [`VIEWPORT_REASSERT`] so the daemon's
+    /// focus-ownership beat (`agent.fit` arbitration) stays fresh while this TUI is alive —
+    /// an unchanged viewport is re-sent, which is otherwise a no-op.
+    last_viewport_at: Option<std::time::Instant>,
     /// Last terminal title emitted (OSC 2), to skip redundant writes.
     last_title: String,
     attach_request: Option<LaneId>,
@@ -586,6 +590,7 @@ impl App {
             last_viewport: Vec::new(),
             last_viewport_windows: Vec::new(),
             last_viewport_focus: None,
+            last_viewport_at: None,
             last_title: String::new(),
             attach_request: None,
             attach_target: None,
@@ -1521,9 +1526,13 @@ impl App {
                 .zip(self.selected_window()),
             _ => None,
         };
+        let beat_due = self
+            .last_viewport_at
+            .is_none_or(|at| at.elapsed() >= VIEWPORT_REASSERT);
         if live != self.last_viewport
             || focus != self.last_viewport_focus
             || windows != self.last_viewport_windows
+            || beat_due
         {
             let _ = self
                 .client
@@ -1540,6 +1549,7 @@ impl App {
             self.last_viewport = live;
             self.last_viewport_focus = focus;
             self.last_viewport_windows = windows;
+            self.last_viewport_at = Some(std::time::Instant::now());
         }
         // Stream the orchestrator pane while the command-center view is open, or while the pinned
         // repomind row is selected in Split (its right column previews the live pane). Toggle the
@@ -4778,6 +4788,17 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
             .call("orchestrator.watch", Some(json!({ "on": false })))
             .await;
     }
+    // Release the viewport on a clean quit so remote viewers may reflow panes immediately
+    // instead of waiting out the focus-ownership TTL (a crash falls back to that TTL).
+    let _ = app
+        .client
+        .call(
+            "viewport.set",
+            Some(
+                json!({ "lane_ids": [], "focus_lane": null, "focus_window": null, "windows": [] }),
+            ),
+        )
+        .await;
     disable_bracketed_paste();
     disable_mouse();
     ratatui::restore();
@@ -4849,6 +4870,11 @@ enum SessionRef {
 /// How long the TUI trusts its last `agent.resize` before re-asserting the same size. Long
 /// enough not to spam tmux, short enough that an externally squeezed pane heals in seconds.
 const RESIZE_REASSERT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// How often an unchanged viewport is re-sent anyway — the daemon's focus-ownership beat for
+/// `agent.fit` arbitration (its 15s TTL tolerates two missed beats). A re-send is a no-op
+/// beyond stamping the beat.
+const VIEWPORT_REASSERT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Consecutive lane refreshes a focused lane may show no managed session before Focus detaches.
 /// More than one, so a single transient overlay flap (one bad snapshot — a tmux/lsof probe blip)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -31,7 +31,10 @@ with `repomon remote pair`, which renders a `repomon://<host:port>#<token>` QR).
   terminal open/close, filesystem) answers `-32601` `"not permitted over remote bridge"`.
   Since v0.4.1 that includes `agent.prompt`, `agent.answer` (verified dialog steering,
   strictly safer than the blind `agent.key` it complements), `agent.watch_bytes`, and
-  `terminal.list_all`. Events themselves are forwarded unfiltered after `subscribe`. Note
+  `terminal.list_all`; since v0.4.2 `agent.fit` replaces `agent.resize` over the bridge —
+  the unconditional resize is local-only (a blind remote resize is exactly what squeezed
+  the TUI's mediated view), and `agent.fit` reflows the shared pane only while no live
+  TUI viewport owns it. Events themselves are forwarded unfiltered after `subscribe`. Note
   `agent.watch_bytes` is single-watch daemon-wide: a remote client and a local TUI Focus view
   contend for the one byte stream, last writer wins — the loser should fall back to
   capture-based polling.
@@ -84,7 +87,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.send_input` | `{ lane_id, text, enter=true, window? }` | `null` (types text, then Enter unless `enter=false`; `window` targets one agent in a multi-agent lane) |
 | `agent.key` | `{ lane_id, key, literal=false, window? }` | `null` (one keystroke: literal char or key name; `window` targets one agent in a multi-agent lane) |
 | `agent.signal` | `{ lane_id, key, window? }` | `null` |
-| `agent.watch_bytes` | `{ lane_id, window?, on }` | on `on: true`, `{ cols, rows }` — the pane's current grid (`null`s when the window is gone); `null` on `off`. Streams the pane's raw PTY bytes (tmux `pipe-pane`) as `event.agent.bytes`. Single-watch: a new `on` replaces the previous watch. Render your emulator at exactly the acked grid — do NOT `agent.resize` the pane to fit your screen: the pane is shared, and a local TUI (which re-asserts its own size within seconds) would render squeezed in the meantime. The capture-based `viewport.set` streaming is unaffected. |
+| `agent.watch_bytes` | `{ lane_id, window?, on }` | on `on: true`, `{ cols, rows }` — the pane's current grid (`null`s when the window is gone); `null` on `off`. Streams the pane's raw PTY bytes (tmux `pipe-pane`) as `event.agent.bytes`. Single-watch: a new `on` replaces the previous watch. Render your emulator at the authoritative grid — the ack's, or the one `agent.fit` answers with: the pane is shared, and only `agent.fit` may reflow it remotely (a local TUI re-asserts its own size within seconds). The capture-based `viewport.set` streaming is unaffected. |
 | `agent.prompt` | `{ lane_id, window? }` | `{ dialog: PendingDialog\|null }` — fresh pane capture parsed for the interactive dialog actually on screen right now (never the sniff cache). `PendingDialog` = `{ title?, question, body?: [String], options: [{ number?, text }], selected? }`; `lane.list` carries the same object on `AgentSession.pending_dialog` alongside the `pending_prompt` summary. |
 | `agent.answer` | `{ lane_id, choice, window?, expect_summary? }` | `{ answered, sent }` — re-captures the pane, verifies a dialog is still up (and, when `expect_summary` is set, that it still summarizes to that string), then steers to `choice` (0-based) and confirms. On a stale view it does NOT send anything: error `-32010` (`no pending dialog` / `dialog changed`) with `error.data.dialog` carrying what's actually on screen (possibly `null`) so the client re-renders instead of re-fetching. Any input path (`send_input`/`key`/`signal`/`answer`) drops the window's sniff-cache entry, so an answered dialog can't be re-advertised for the rest of its TTL. |
 | `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
@@ -92,6 +95,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `session.rename` | `{ session_id, label? }` | `null` (set/clear a user label for a session, keyed by its durable transcript id; empty/absent `label` clears it; overlaid onto `AgentSession.custom_label`) |
 | `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
 | `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
+| `agent.fit` | `{ lane_id, cols, rows, window? }` | `{ applied, cols, rows }` — the arbitrated resize for remote viewers: reflows the shared pane to the caller's grid ONLY while no live local viewport focus owns the window (the TUI heartbeats its viewport every ~5s; ownership lapses 15s after the last beat, and a clean TUI quit releases it immediately). Refused (`applied: false`) it answers with the pane's current grid so the caller renders pinned at the shared size instead of fighting. Poll it (~10s) to adapt when the TUI starts or stops viewing. |
 | `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |


### PR DESCRIPTION
Restores the phone's reflow UX (repomon-ios will follow) without re-introducing the squeeze that #51 fixed. The pane has one size; `agent.fit` decides who gets it:

- **`agent.fit {lane_id, cols, rows, window?}` → `{applied, cols, rows}`**: reflows the shared pane to the caller's grid **only while no live local viewport focus owns the window**; refused, it returns the authoritative grid so the caller pins to the shared size instead of fighting. Clients poll (~10s) to adapt as the TUI starts/stops viewing.
- **Ownership beat**: the TUI re-sends `viewport.set` every 5s even unchanged; ownership lapses 15s after the last beat (crash-safe) and a clean quit releases it immediately.
- **Allowlist**: `agent.fit` replaces `agent.resize` over the bridge — the unconditional resize is local-only again, since a blind remote resize is exactly what squeezed the mediated view.

New `fit_owned` unit test; 319 workspace tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)