### PR TITLE
fix: usage tracker and agent names follow the agent, not its sidebar slot

### DIFF
--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -24,7 +24,7 @@ use crate::model::{AgentKind, AgentStatus};
 
 pub use claude::TranscriptSummary;
 pub use limit::{LimitMenu, UsageLimit, detect_usage_limit, menu_select_keys};
-pub use tmux::{TmuxRuntime, shell_quote};
+pub use tmux::{TmuxRuntime, WindowMeta, shell_quote};
 pub use usage::{AccountUsage, UsageReport, UsageWindow, parse_codex_status, parse_usage};
 
 /// How recently a file must have changed for its agent to count as "running".

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -18,6 +18,20 @@ pub struct TmuxRuntime {
     session: String,
 }
 
+/// One window as the overlay probes it ([`TmuxRuntime::list_windows_meta`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowMeta {
+    pub name: String,
+    /// Parsed from `#{window_id}` (`@12` → 12). tmux never reuses window ids within a server,
+    /// so ordering by id is true creation order even when slot NAMES are recycled after an
+    /// exit (`spawn` fills the first free slot). `u64::MAX` when unparsable (sorts last).
+    pub wid: u64,
+    /// The transcript session id bound to this window via the `@repomon_session` window
+    /// option ([`TmuxRuntime::set_window_session`]), if any. tmux destroys window options
+    /// with the window, so a binding can never outlive its agent.
+    pub session: Option<String>,
+}
+
 impl TmuxRuntime {
     pub fn new(session: impl Into<String>) -> Self {
         Self {
@@ -256,6 +270,70 @@ impl TmuxRuntime {
                 Some((name, path, activity))
             })
             .collect())
+    }
+
+    /// One window as the overlay probes it: name, tmux's window id, and the transcript
+    /// session id stuck to it via the `@repomon_session` window option, if bound.
+    pub fn list_windows_meta(&self) -> Result<Vec<WindowMeta>> {
+        // Same single fork the overlay already pays for `list_windows`, richer format string.
+        let out = self.run_allow_absent(&[
+            "list-windows",
+            "-t",
+            &self.session,
+            "-F",
+            "#{window_name}\t#{window_id}\t#{@repomon_session}",
+        ])?;
+        Ok(Self::parse_windows_meta(&out))
+    }
+
+    /// Parse `list_windows_meta` probe lines (`name\t@id\tsession?`).
+    fn parse_windows_meta(out: &str) -> Vec<WindowMeta> {
+        out.lines()
+            .filter_map(|l| {
+                let mut it = l.splitn(3, '\t');
+                let name = it.next()?.to_string();
+                let wid = it
+                    .next()
+                    .and_then(|w| w.strip_prefix('@'))
+                    .and_then(|n| n.parse().ok())
+                    .unwrap_or(u64::MAX);
+                let session = it
+                    .next()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(String::from);
+                Some(WindowMeta { name, wid, session })
+            })
+            .collect()
+    }
+
+    /// Stamp `@repomon_session` on `window` — the overlay binder's write-back, done once per
+    /// agent lifetime. tmux destroys window options with the window, so the binding can never
+    /// outlive its agent (slot-name recycling included). A vanished window is a benign no-op.
+    pub fn set_window_session(&self, window: &str, session_id: &str) -> Result<()> {
+        let target = self.exact_target(window);
+        self.run_allow_absent(&[
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "@repomon_session",
+            session_id,
+        ])?;
+        Ok(())
+    }
+
+    /// [`lane_windows_in`] for metas: `lane`'s agent windows, in slot order.
+    pub fn lane_windows_meta(metas: &[WindowMeta], lane: LaneId) -> Vec<WindowMeta> {
+        let mut slots: Vec<(usize, WindowMeta)> = metas
+            .iter()
+            .filter_map(|m| {
+                let (id, slot) = Self::parse_lane_window(&m.name)?;
+                (id == lane).then(|| (slot, m.clone()))
+            })
+            .collect();
+        slots.sort_by_key(|(s, _)| *s);
+        slots.into_iter().map(|(_, m)| m).collect()
     }
 
     pub fn has_window(&self, lane: LaneId) -> bool {
@@ -685,6 +763,68 @@ mod tests {
         );
         assert_eq!(TmuxRuntime::lane_windows_in(&names, 12), vec!["lane-12"]);
         assert!(TmuxRuntime::lane_windows_in(&names, 3).is_empty());
+    }
+
+    #[test]
+    fn parses_windows_meta_lines() {
+        // `name\t@id\tsession?` — the third field is empty when `@repomon_session` is unset.
+        let out = "lane-1\t@3\tabc-123\nlane-1-2\t@7\t\norchestrator\t@1\t\n";
+        assert_eq!(
+            TmuxRuntime::parse_windows_meta(out),
+            vec![
+                WindowMeta {
+                    name: "lane-1".into(),
+                    wid: 3,
+                    session: Some("abc-123".into()),
+                },
+                WindowMeta {
+                    name: "lane-1-2".into(),
+                    wid: 7,
+                    session: None,
+                },
+                WindowMeta {
+                    name: "orchestrator".into(),
+                    wid: 1,
+                    session: None,
+                },
+            ]
+        );
+        // A malformed window id sorts last (u64::MAX), never panics.
+        assert_eq!(
+            TmuxRuntime::parse_windows_meta("w\tbogus\t\n")[0].wid,
+            u64::MAX
+        );
+        // Empty probe (no server) → no windows.
+        assert!(TmuxRuntime::parse_windows_meta("").is_empty());
+    }
+
+    #[test]
+    fn lane_windows_meta_filters_and_slot_orders() {
+        let wm = |name: &str, wid: u64| WindowMeta {
+            name: name.into(),
+            wid,
+            session: None,
+        };
+        // Exact lane matching (`lane-1` never claims `lane-12`), slot order regardless of
+        // probe order or window id.
+        let metas = vec![
+            wm("lane-1-2", 9),
+            wm("lane-12", 4),
+            wm("lane-1", 2),
+            wm("term-1-1", 5),
+            wm("orchestrator", 1),
+        ];
+        let lane1 = TmuxRuntime::lane_windows_meta(&metas, 1);
+        let names: Vec<&str> = lane1.iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, vec!["lane-1", "lane-1-2"]);
+        assert_eq!(
+            TmuxRuntime::lane_windows_meta(&metas, 12)
+                .iter()
+                .map(|w| w.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["lane-12"]
+        );
+        assert!(TmuxRuntime::lane_windows_meta(&metas, 3).is_empty());
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -178,10 +178,14 @@ impl TmuxRuntime {
         }
         let stderr = String::from_utf8_lossy(&out.stderr);
         // tmux: "can't find window/session/pane: …", "no server running on …",
-        // "error connecting to …" — the target simply isn't there.
+        // "error connecting to …" — the target simply isn't there. `set-option` phrases the
+        // same absence as "no such window/session: …" (tmux ≥ 3.x), unlike the capture/list
+        // commands.
         let absent = stderr.contains("can't find ")
             || stderr.contains("no server running")
-            || stderr.contains("error connecting");
+            || stderr.contains("error connecting")
+            || stderr.contains("no such window")
+            || stderr.contains("no such session");
         if absent {
             Ok(String::new())
         } else {
@@ -307,11 +311,29 @@ impl TmuxRuntime {
             .collect()
     }
 
-    /// Stamp `@repomon_session` on `window` — the overlay binder's write-back, done once per
-    /// agent lifetime. tmux destroys window options with the window, so the binding can never
-    /// outlive its agent (slot-name recycling included). A vanished window is a benign no-op.
+    /// Stamp `@repomon_session` on `window` by NAME — for callers that just created the
+    /// window and know exactly which transcript runs in it (`agent.adopt`). tmux destroys
+    /// window options with the window, so the binding can never outlive its agent (slot-name
+    /// recycling included). A vanished window is a benign no-op.
     pub fn set_window_session(&self, window: &str, session_id: &str) -> Result<()> {
         let target = self.exact_target(window);
+        self.run_allow_absent(&[
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "@repomon_session",
+            session_id,
+        ])?;
+        Ok(())
+    }
+
+    /// Stamp `@repomon_session` by window ID (`@N`) — the overlay binder's write-back. The id
+    /// pins the exact window the pairing was computed against: ids are never reused within a
+    /// server, so a slot NAME recycled between the probe and the stamp can't inherit the old
+    /// transcript's binding. A vanished window is a benign no-op.
+    pub fn set_window_session_by_id(&self, wid: u64, session_id: &str) -> Result<()> {
+        let target = format!("@{wid}");
         self.run_allow_absent(&[
             "set-option",
             "-w",

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -198,10 +198,11 @@ pub struct Ctx {
     /// count immediately so the vanished agent drops from the `×N` count without waiting out the
     /// `live_cwds` cache TTL.
     pub last_managed_windows: Mutex<HashSet<String>>,
-    /// Last tmux window list a probe returned successfully. Reused for one overlay tick when
-    /// `list_windows` fails transiently (fork/connection fault under load), so a single bad
-    /// snapshot doesn't drop every managed agent — see `rpc::resolve_windows`.
-    pub last_good_windows: Mutex<Vec<String>>,
+    /// Last tmux window list a probe returned successfully (names + window ids +
+    /// `@repomon_session` bindings). Reused for one overlay tick when `list_windows_meta`
+    /// fails transiently (fork/connection fault under load), so a single bad snapshot doesn't
+    /// drop every managed agent — see `rpc::resolve_windows`.
+    pub last_good_windows: Mutex<Vec<repomon_core::agent::WindowMeta>>,
     /// Consecutive empty `list_windows` results. A sudden total-empty is usually a tmux server
     /// bounce, not every agent exiting at once — `resolve_windows` reuses last-good until this
     /// reaches the confirm threshold, so a server restart doesn't mass-fire Idle.

--- a/crates/repomon-daemon/src/reap.rs
+++ b/crates/repomon-daemon/src/reap.rs
@@ -93,7 +93,10 @@ pub(crate) async fn kill_and_forget(ctx: &Ctx, window: &str) {
     let tmux = ctx.tmux.clone();
     let w = window.to_string();
     let _ = tokio::task::spawn_blocking(move || tmux.kill_named(&w)).await;
-    ctx.last_good_windows.lock().await.retain(|w| w != window);
+    ctx.last_good_windows
+        .lock()
+        .await
+        .retain(|w| w.name != window);
     ctx.prompt_cache.lock().await.remove(window);
     ctx.invalidate_overlay().await;
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -983,6 +983,21 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
+            // The one moment the daemon KNOWS which transcript runs in this window: stamp
+            // the sticky binding deterministically instead of leaving it to first-contact
+            // guessing — `--resume` doesn't touch the resumed .jsonl until the first
+            // exchange, so the binder could otherwise pair a newer external transcript onto
+            // the adopted window and the stamp would wedge it there.
+            if let Some(sid) = p.session_id.clone() {
+                let tmux = ctx.tmux.clone();
+                let w = window.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Err(e) = tmux.set_window_session(&w, &sid) {
+                        tracing::warn!("failed to stamp adopted session on {w}: {e}");
+                    }
+                })
+                .await;
+            }
             let _ = ctx
                 .store
                 .set_lane_tmux_window(p.lane_id, Some(window.clone()))
@@ -1953,6 +1968,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     if let Err(ref e) = fresh {
         tracing::warn!("tmux list-windows failed; reusing last-good window set this overlay: {e}");
     }
+    // A tick that ran on the last-good snapshot pairs against binding info that lags any
+    // stamps by a generation — good enough to display, but never persist first-contact
+    // bindings computed from it (they could overwrite fresh stamps with crossed pairs).
+    let probe_ok = fresh.is_ok();
     let windows = {
         let mut last_good = ctx.last_good_windows.lock().await;
         let mut empty_misses = ctx.window_empty_misses.lock().await;
@@ -1990,7 +2009,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let global_auto = ctx.config.read().await.auto_continue;
 
     // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
-    let mut new_bindings: Vec<(String, String)> = Vec::new();
+    let mut new_bindings: Vec<(u64, String, String)> = Vec::new();
     for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
         // The lane's managed agent windows, in slot order. A window only exists while its
         // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
@@ -2024,14 +2043,14 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             .iter()
             .filter_map(|w| w.session.clone())
             .collect();
-        let summaries = select_kept_summaries(summaries, &bound, keep);
+        let summaries = select_kept_summaries(summaries, &bound, keep, now);
         if !summaries.is_empty() {
             // Pair transcripts with windows by sticky identity (`@repomon_session`), falling
             // back to the oldest-with-oldest heuristic only on first contact — see
             // `pair_transcripts_to_windows`. The old purely positional zip re-bound windows
             // whenever two agents swapped activity rank, which moved names, panes, and usage
             // accounts between rows.
-            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows);
+            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows, now);
             new_bindings.extend(pairing.new_bindings);
             for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
@@ -2125,13 +2144,17 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
 
     // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
     // window so the pairing survives daemon restarts and activity-order flips. Rare — once
-    // per agent lifetime — so this adds no forks to a steady-state overlay.
-    if !new_bindings.is_empty() {
+    // per agent lifetime — so this adds no forks to a steady-state overlay. Stamped by
+    // window ID (never reused), and only on fresh-probe ticks (see `probe_ok`). Concurrent
+    // overlay ticks can still cross-stamp in a sub-second window; a wrong winner is caught
+    // by the supersession rule in `pair_transcripts_to_windows` once the real transcript
+    // starts writing.
+    if probe_ok && !new_bindings.is_empty() {
         let tmux = ctx.tmux.clone();
         let _ = tokio::task::spawn_blocking(move || {
-            for (w, sid) in new_bindings {
-                if let Err(e) = tmux.set_window_session(&w, &sid) {
-                    tracing::warn!("failed to stamp @repomon_session on {w}: {e}");
+            for (wid, name, sid) in new_bindings {
+                if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
+                    tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
                 }
             }
         })
@@ -2335,9 +2358,11 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
 struct Pairing {
     /// Per input summary (order preserved): the managed window it runs in; `None` = external.
     assignment: Vec<Option<String>>,
-    /// Sticky bindings established this tick — `(window_name, session_id)` to stamp as
-    /// `@repomon_session` so they survive daemon restarts and activity-order flips.
-    new_bindings: Vec<(String, String)>,
+    /// Sticky bindings established this tick — `(window_id, window_name, session_id)` to
+    /// stamp as `@repomon_session` so they survive daemon restarts and activity-order flips.
+    /// Stamped by window ID: a slot NAME recycled between the probe and the stamp must not
+    /// inherit the old transcript's binding.
+    new_bindings: Vec<(u64, String, String)>,
     /// Live managed windows no transcript claimed, newest (highest window id) first. The
     /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
     /// appeared yet (at most one, per the `SessKey::Fallback` model).
@@ -2361,38 +2386,88 @@ struct Pairing {
 fn pair_transcripts_to_windows(
     summaries: &[agent::TranscriptSummary],
     windows: &[agent::WindowMeta],
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Pairing {
-    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
-    let mut taken = vec![false; windows.len()];
-    // Pass 1 — sticky identity.
+    let is_fresh =
+        |s: &agent::TranscriptSummary| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS;
+    // Pass 1 — sticky identity, tentatively: each window claims the kept transcript its
+    // `@repomon_session` names.
+    let mut claim: Vec<Option<usize>> = vec![None; windows.len()];
+    let mut claimed = vec![false; summaries.len()];
     for (wi, w) in windows.iter().enumerate() {
         let Some(sid) = &w.session else { continue };
         if let Some(si) = summaries
             .iter()
             .position(|s| s.session_id.as_deref() == Some(sid.as_str()))
         {
-            if assignment[si].is_none() {
-                assignment[si] = Some(w.name.clone());
-                taken[wi] = true;
+            if !claimed[si] {
+                claim[wi] = Some(si);
+                claimed[si] = true;
             }
         }
     }
-    // Pass 2 — first contact. Never-bound windows are offered before stale-bound ones, both
-    // oldest (lowest window id) first.
+    // Supersession: a claude process rotates its transcript id in place (`/clear`, a
+    // fork-on-resume), leaving its window bound to a dead transcript while the live
+    // continuation has no window. When more FRESH unclaimed transcripts exist than free
+    // windows to receive them, release claims whose transcript has gone quiet — coldest
+    // first — so pass 2 can re-bind those windows to the transcripts actually writing. A
+    // claim on a fresh transcript is never released, so an idle fleet can't be shuffled.
+    let fresh_unclaimed = summaries
+        .iter()
+        .enumerate()
+        .filter(|(i, s)| !claimed[*i] && is_fresh(s))
+        .count();
+    let mut free_n = claim.iter().filter(|c| c.is_none()).count();
+    if fresh_unclaimed > free_n {
+        let mut stale_wis: Vec<usize> = (0..windows.len())
+            .filter(|&wi| claim[wi].is_some_and(|si| !is_fresh(&summaries[si])))
+            .collect();
+        stale_wis.sort_by_key(|&wi| summaries[claim[wi].unwrap()].last_activity);
+        for wi in stale_wis {
+            if fresh_unclaimed <= free_n {
+                break;
+            }
+            claimed[claim[wi].unwrap()] = false;
+            claim[wi] = None;
+            free_n += 1;
+        }
+    }
+    // Honor the surviving claims.
+    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
+    let mut taken = vec![false; windows.len()];
+    for (wi, c) in claim.iter().enumerate() {
+        if let Some(si) = c {
+            assignment[*si] = Some(windows[wi].name.clone());
+            taken[wi] = true;
+        }
+    }
+    // Pass 2 — first contact. Never-bound windows are offered before stale/released-bound
+    // ones; among the windows actually used, oldest (lowest window id) pairs with the oldest
+    // chosen transcript, like the legacy positional zip.
     let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
     free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
-    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest;
-    // pair that subset oldest-with-oldest (hence `.rev()`), like the legacy positional zip.
+    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest.
     let chosen: Vec<usize> = (0..summaries.len())
         .filter(|&i| assignment[i].is_none())
         .take(free.len())
         .collect();
+    let mut used: Vec<usize> = free.into_iter().take(chosen.len()).collect();
+    used.sort_by_key(|&i| windows[i].wid);
     let mut new_bindings = Vec::new();
-    for (&si, &wi) in chosen.iter().rev().zip(&free) {
+    for (&si, &wi) in chosen.iter().rev().zip(&used) {
         assignment[si] = Some(windows[wi].name.clone());
         taken[wi] = true;
-        if let Some(sid) = &summaries[si].session_id {
-            new_bindings.push((windows[wi].name.clone(), sid.clone()));
+        // Persist only pairs we're confident in: an actively-writing transcript IS the agent
+        // in this window. A quiet one is a stand-in guess (e.g. a fresh spawn whose .jsonl
+        // hasn't appeared yet, with an old transcript filling the display) — show it, but
+        // leave the window unbound so first contact re-runs once the real transcript starts
+        // writing, instead of wedging the guess for hours.
+        if is_fresh(&summaries[si]) {
+            if let Some(sid) = &summaries[si].session_id {
+                if windows[wi].session.as_deref() != Some(sid.as_str()) {
+                    new_bindings.push((windows[wi].wid, windows[wi].name.clone(), sid.clone()));
+                }
+            }
         }
     }
     let mut unpaired: Vec<&agent::WindowMeta> = windows
@@ -2419,15 +2494,21 @@ fn select_kept_summaries(
     summaries: Vec<agent::TranscriptSummary>,
     bound: &std::collections::HashSet<String>,
     keep: usize,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<agent::TranscriptSummary> {
     if summaries.len() <= keep {
         return summaries;
     }
-    let (bound_s, rest): (Vec<_>, Vec<_>) = summaries
+    let is_fresh =
+        |s: &agent::TranscriptSummary| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS;
+    // Protected: bound to a live window (the window proves its agent alive) OR actively
+    // writing right now — `sessions_to_keep`'s "never drop a session that is working"
+    // contract must survive bound-protection, or a stale binding could make the one live
+    // transcript invisible.
+    let (mut out, rest): (Vec<_>, Vec<_>) = summaries
         .into_iter()
-        .partition(|s| s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
-    let take_rest = keep.saturating_sub(bound_s.len());
-    let mut out = bound_s;
+        .partition(|s| is_fresh(s) || s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
+    let take_rest = keep.saturating_sub(out.len());
     out.extend(rest.into_iter().take(take_rest));
     out.sort_by_key(|s| std::cmp::Reverse(s.last_activity));
     out
@@ -3680,9 +3761,10 @@ mod tests {
         }
     }
 
-    /// Activity times t(0) < t(1) < …, so `t(2)` is newer than `t(1)`.
+    /// Activity times t(0) < t(1) < … in 10s steps, so several consecutive stamps all count
+    /// as "fresh" (within `RECENTLY_ACTIVE_SECS`) relative to a nearby `now`.
     fn t(n: i64) -> chrono::DateTime<chrono::Utc> {
-        chrono::DateTime::from_timestamp(1_700_000_000 + n * 60, 0).unwrap()
+        chrono::DateTime::from_timestamp(1_700_000_000 + n * 10, 0).unwrap()
     }
 
     #[test]
@@ -3691,19 +3773,19 @@ mod tests {
         // slot 1, the overflow transcript external — exactly what the positional zip did.
         let summaries = vec![tsum("c", t(3)), tsum("b", t(2)), tsum("a", t(1))];
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
-        let p = pair_transcripts_to_windows(&summaries, &windows);
+        let p = pair_transcripts_to_windows(&summaries, &windows, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
         );
-        // Both pairs become sticky bindings.
+        // Both paired transcripts are actively fresh → both pairs become sticky bindings.
         let mut nb = p.new_bindings.clone();
         nb.sort();
         assert_eq!(
             nb,
             vec![
-                ("lane-5".to_string(), "b".to_string()),
-                ("lane-5-2".to_string(), "c".to_string())
+                (1, "lane-5".to_string(), "b".to_string()),
+                (2, "lane-5-2".to_string(), "c".to_string())
             ]
         );
         assert!(p.unpaired.is_empty());
@@ -3714,14 +3796,14 @@ mod tests {
         // The reported bug: two bound agents swap activity rank; the pairing must not move.
         let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
         // b most recently active…
-        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows, t(2));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
         assert!(p.new_bindings.is_empty());
         // …then a takes a turn and the order flips: same windows per session id.
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
@@ -3736,13 +3818,13 @@ mod tests {
         // its result is emitted as bindings; re-running with those bindings and flipped
         // activity keeps the original assignment.
         let unbound = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
-        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound);
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound, t(2));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
         let bound = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
@@ -3756,14 +3838,14 @@ mod tests {
         // The surviving agent b keeps its bound `lane-7-2`; the newcomer c gets the recycled
         // window — even though slot-name order would have handed c the older agent's window.
         let windows = vec![wm("lane-7", 7, None), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows, t(9));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
         );
         assert_eq!(
             p.new_bindings,
-            vec![("lane-7".to_string(), "c".to_string())]
+            vec![(7, "lane-7".to_string(), "c".to_string())]
         );
     }
 
@@ -3772,7 +3854,7 @@ mod tests {
         // b's transcript flaps out for one tick: its window merely goes unpaired (placeholder
         // target); it is NOT rebound to the surviving transcript and no binding is written.
         let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows, t(3));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
         assert!(p.new_bindings.is_empty());
         assert_eq!(p.unpaired, vec!["lane-7-2".to_string()]);
@@ -3780,14 +3862,14 @@ mod tests {
 
     #[test]
     fn stale_binding_released_to_a_genuinely_new_transcript() {
-        // The bound transcript is gone AND a new one needs a window: the stale binding is
-        // released and rewritten to the newcomer.
+        // The bound transcript is gone AND a new (actively writing) one needs a window: the
+        // stale binding is released and rewritten to the newcomer.
         let windows = vec![wm("lane-7", 1, Some("x"))];
-        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows, t(5));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
         assert_eq!(
             p.new_bindings,
-            vec![("lane-7".to_string(), "y".to_string())]
+            vec![(1, "lane-7".to_string(), "y".to_string())]
         );
         assert!(p.unpaired.is_empty());
     }
@@ -3797,26 +3879,104 @@ mod tests {
         // One transcript, two windows (second freshly spawned, no `.jsonl` yet): the leftover
         // is the NEWEST window (highest id) so the placeholder lands on the fresh spawn.
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows, t(1));
         assert_eq!(p.assignment, vec![Some("lane-5".into())]);
         assert_eq!(p.unpaired, vec!["lane-5-2".to_string()]);
         // All windows transcript-backed → nothing unpaired.
         let p = pair_transcripts_to_windows(
             &[tsum("b", t(2)), tsum("a", t(1))],
             &[wm("lane-5", 1, None), wm("lane-5-2", 2, None)],
+            t(2),
         );
         assert!(p.unpaired.is_empty());
     }
 
     #[test]
+    fn spawn_race_displays_but_does_not_stamp_a_stale_transcript() {
+        // agent.spawn created the window but claude hasn't written its .jsonl yet; the only
+        // transcript around is a stale leftover (an /exited session, or the user's own
+        // external one). It may stand in for DISPLAY, but the binding must not be stamped —
+        // otherwise the guess wedges for hours (pass 1 would re-claim it every tick).
+        let windows = vec![wm("lane-7", 5, None)];
+        let stale = tsum("e", t(0));
+        let p = pair_transcripts_to_windows(std::slice::from_ref(&stale), &windows, t(100));
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert!(
+            p.new_bindings.is_empty(),
+            "a quiet transcript is a guess, not a binding"
+        );
+        // The real transcript appears (actively writing): IT gets the window and the stamp;
+        // the stale one falls back to external.
+        let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
+        assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
+        assert_eq!(
+            p.new_bindings,
+            vec![(5, "lane-7".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn clear_rotation_rebinds_window_to_the_live_transcript() {
+        // `/clear` (or a fork-on-resume) rotates the session id in place: the window stays
+        // bound to the dead transcript e while the live continuation x has no window. The
+        // stale binding must be superseded — released and re-stamped to the transcript that
+        // is actually writing.
+        let windows = vec![wm("lane-7", 1, Some("e"))];
+        let p =
+            pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), None],
+            "the live transcript takes the window; the dead one goes external"
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![(1, "lane-7".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn fresh_external_does_not_steal_a_bound_window_when_a_free_one_exists() {
+        // An idle bound agent e plus a fresh unpaired transcript x: with a free window
+        // available, x takes the free window and e's binding is left alone — supersession
+        // only fires when the fresh transcript would otherwise have no home.
+        let windows = vec![wm("lane-7", 1, Some("e")), wm("lane-7-2", 9, None)];
+        let p =
+            pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![(9, "lane-7-2".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn idle_bound_pairing_holds_without_fresh_claimants() {
+        // Nothing fresh in the lane (everyone idle): stale-bound windows keep their agents —
+        // supersession must never shuffle a merely-idle fleet.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("b", t(1)), tsum("a", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+    }
+
+    #[test]
     fn select_kept_summaries_protects_bound_sessions() {
         // A bound-but-quiet agent (its window is alive — that IS liveness) must survive
-        // truncation ahead of newer unbound transcripts; output stays newest-first.
+        // truncation ahead of newer unbound transcripts; output stays newest-first. `now` is
+        // far past every activity time so freshness plays no part here.
         let bound: std::collections::HashSet<String> = ["a".to_string()].into();
         let kept = select_kept_summaries(
             vec![tsum("e1", t(3)), tsum("e2", t(2)), tsum("a", t(1))],
             &bound,
             2,
+            t(1000),
         );
         let ids: Vec<&str> = kept
             .iter()
@@ -3824,12 +3984,29 @@ mod tests {
             .collect();
         assert_eq!(ids, vec!["e1", "a"]);
         // Under the cap nothing is dropped.
-        let kept = select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5);
+        let kept =
+            select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5, t(1000));
         assert_eq!(kept.len(), 2);
         // More bound sessions than `keep` says: the windows win (each proves a live agent).
         let bound: std::collections::HashSet<String> = ["a".to_string(), "b".to_string()].into();
-        let kept = select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1);
+        let kept =
+            select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1, t(1000));
         assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn select_kept_summaries_never_drops_a_fresh_transcript() {
+        // The fresh backstop must survive bound-protection: with keep=1 and the budget
+        // filled by a bound-but-stale transcript, the actively-writing one is kept too —
+        // truncating the only session doing work would make the live agent invisible.
+        let bound: std::collections::HashSet<String> = ["e".to_string()].into();
+        let kept =
+            select_kept_summaries(vec![tsum("x", t(100)), tsum("e", t(0))], &bound, 1, t(100));
+        let ids: Vec<&str> = kept
+            .iter()
+            .filter_map(|s| s.session_id.as_deref())
+            .collect();
+        assert_eq!(ids, vec!["x", "e"]);
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2008,8 +2008,9 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let auto_off = ctx.auto_continue_off.lock().await.clone();
     let global_auto = ctx.config.read().await.auto_continue;
 
-    // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
-    let mut new_bindings: Vec<(u64, String, String)> = Vec::new();
+    // Per-lane binding candidates + their probe-window pools, resolved against pane
+    // evidence and stamped as `@repomon_session` after the loop.
+    let mut stamp_batches: Vec<StampBatch> = Vec::new();
     for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
         // The lane's managed agent windows, in slot order. A window only exists while its
         // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
@@ -2051,7 +2052,9 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             // whenever two agents swapped activity rank, which moved names, panes, and usage
             // accounts between rows.
             let pairing = pair_transcripts_to_windows(&summaries, &lane_windows, now);
-            new_bindings.extend(pairing.new_bindings);
+            if !pairing.new_bindings.is_empty() {
+                stamp_batches.push((pairing.new_bindings, pairing.probe));
+            }
             for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
                     lane.last_activity_at = s.last_activity;
@@ -2142,19 +2145,33 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         }
     }
 
-    // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
-    // window so the pairing survives daemon restarts and activity-order flips. Rare — once
-    // per agent lifetime — so this adds no forks to a steady-state overlay. Stamped by
-    // window ID (never reused), and only on fresh-probe ticks (see `probe_ok`). Concurrent
-    // overlay ticks can still cross-stamp in a sub-second window; a wrong winner is caught
-    // by the supersession rule in `pair_transcripts_to_windows` once the real transcript
-    // starts writing.
-    if probe_ok && !new_bindings.is_empty() {
+    // Persist the sticky bindings established this tick — but only where the pane PROVES
+    // the pairing: each candidate transcript's last-message fingerprint must be visible in
+    // exactly one of its lane's unclaimed panes (`confirmed_stamps`). Activity rank alone
+    // mis-stamped when several transcripts were fresh at once (live incident: two agents'
+    // names swapped and stayed swapped), and a wrong sticky stamp wedges until superseded.
+    // An unconfirmed candidate simply returns next tick — the pairing stamps itself once
+    // the agent's turn is visible on screen. Rare (once per agent lifetime), so the capture
+    // forks don't touch steady-state ticks. Skipped when the window probe failed
+    // (`probe_ok`): a last-good snapshot lags the stamps by a generation.
+    if probe_ok && !stamp_batches.is_empty() {
         let tmux = ctx.tmux.clone();
         let _ = tokio::task::spawn_blocking(move || {
-            for (wid, name, sid) in new_bindings {
-                if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
-                    tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
+            for (cands, probe) in stamp_batches {
+                if cands.iter().all(|c| c.needle.is_none()) {
+                    continue;
+                }
+                let panes: Vec<(u64, String, String)> = probe
+                    .into_iter()
+                    .map(|(wid, name)| {
+                        let text = tmux.capture_named(&name, Some(60)).unwrap_or_default();
+                        (wid, name, normalize_fingerprint(&text))
+                    })
+                    .collect();
+                for (wid, name, sid) in confirmed_stamps(&cands, &panes) {
+                    if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
+                        tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
+                    }
                 }
             }
         })
@@ -2354,19 +2371,95 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
     }
 }
 
+/// A transcript that should get a sticky binding this tick, pending pane evidence: the
+/// fingerprint of its last message must be visible in exactly one of the lane's unclaimed
+/// panes before anything is stamped. Activity rank proved able to guess wrong when several
+/// transcripts were fresh at once, and a wrong sticky stamp wedges until superseded — so the
+/// pane, not the rank, picks the window.
+struct BindingCandidate {
+    sid: String,
+    /// Normalized fingerprint of the transcript's last message ([`message_fingerprint`]);
+    /// `None` (no message yet / too short) means no evidence — the candidate simply returns
+    /// next tick.
+    needle: Option<String>,
+}
+
+/// One lane's binding candidates plus the probe-window pool they may stamp onto.
+type StampBatch = (Vec<BindingCandidate>, Vec<(u64, String)>);
+
 /// A lane's transcript↔window pairing for one overlay tick ([`pair_transcripts_to_windows`]).
 struct Pairing {
     /// Per input summary (order preserved): the managed window it runs in; `None` = external.
     assignment: Vec<Option<String>>,
-    /// Sticky bindings established this tick — `(window_id, window_name, session_id)` to
-    /// stamp as `@repomon_session` so they survive daemon restarts and activity-order flips.
-    /// Stamped by window ID: a slot NAME recycled between the probe and the stamp must not
-    /// inherit the old transcript's binding.
-    new_bindings: Vec<(u64, String, String)>,
+    /// Transcripts to bind this tick, pending pane confirmation ([`confirmed_stamps`]).
+    new_bindings: Vec<BindingCandidate>,
+    /// The windows a new binding may land on — everything pass 1 didn't claim, `(window_id,
+    /// name)`. Stamps target the window ID: a slot NAME recycled between the probe and the
+    /// stamp must not inherit the old transcript's binding.
+    probe: Vec<(u64, String)>,
     /// Live managed windows no transcript claimed, newest (highest window id) first. The
     /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
     /// appeared yet (at most one, per the `SessKey::Fallback` model).
     unpaired: Vec<String>,
+}
+
+/// Collapse text to lowercase ASCII alphanumerics. Makes fingerprint matching immune to
+/// tmux line wrapping, markdown styling (the pane renderer strips `**`/`_` markers), ANSI
+/// spacing, and case.
+fn normalize_fingerprint(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// Minimum normalized length before a fingerprint is distinctive enough to act on.
+const FINGERPRINT_MIN: usize = 24;
+/// How much of the normalized TAIL to keep — after a long reply scrolls, its tail is what
+/// stays visible above the input box.
+const FINGERPRINT_LEN: usize = 64;
+
+/// The pane fingerprint of a transcript's last message, or `None` when there is no message
+/// or it is too short to be distinctive.
+fn message_fingerprint(last_message: Option<&str>) -> Option<String> {
+    let n = normalize_fingerprint(last_message?);
+    if n.len() < FINGERPRINT_MIN {
+        return None;
+    }
+    // Byte slicing is safe: the normalized form is pure ASCII.
+    Some(n[n.len().saturating_sub(FINGERPRINT_LEN)..].to_string())
+}
+
+/// Which stamps the pane evidence supports: each candidate with a fingerprint is stamped on
+/// the single probe window whose (normalized) pane contains it. No match, several matching
+/// panes, or several candidates matching the same pane → no stamp for those involved; the
+/// candidates return next tick once the screens disambiguate. Returns `(wid, name, sid)`.
+fn confirmed_stamps(
+    cands: &[BindingCandidate],
+    panes: &[(u64, String, String)],
+) -> Vec<(u64, String, String)> {
+    // Every needle↔pane hit, as (candidate index, pane index).
+    let mut hits: Vec<(usize, usize)> = Vec::new();
+    for (ci, c) in cands.iter().enumerate() {
+        let Some(needle) = &c.needle else { continue };
+        for (pi, (_, _, text)) in panes.iter().enumerate() {
+            if text.contains(needle.as_str()) {
+                hits.push((ci, pi));
+            }
+        }
+    }
+    // Keep only 1:1 matches — a candidate seen in several panes, or a pane claimed by
+    // several candidates, proves nothing yet.
+    hits.iter()
+        .filter(|&&(ci, pi)| {
+            hits.iter().filter(|(c, _)| *c == ci).count() == 1
+                && hits.iter().filter(|(_, p)| *p == pi).count() == 1
+        })
+        .map(|&(ci, pi)| {
+            let (wid, name, _) = &panes[pi];
+            (*wid, name.clone(), cands[ci].sid.clone())
+        })
+        .collect()
 }
 
 /// Pair a lane's kept transcripts (newest-first) with its live managed windows by STICKY
@@ -2445,9 +2538,15 @@ fn pair_transcripts_to_windows(
     }
     // Pass 2 — first contact. Never-bound windows are offered before stale/released-bound
     // ones; among the windows actually used, oldest (lowest window id) pairs with the oldest
-    // chosen transcript, like the legacy positional zip.
+    // chosen transcript, like the legacy positional zip. This ordering is only the DISPLAY
+    // hint — the durable stamp is decided by pane evidence (`confirmed_stamps`), for which
+    // every pass-1-unclaimed window is a legal target.
     let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
     free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
+    let probe: Vec<(u64, String)> = free
+        .iter()
+        .map(|&i| (windows[i].wid, windows[i].name.clone()))
+        .collect();
     // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest.
     let chosen: Vec<usize> = (0..summaries.len())
         .filter(|&i| assignment[i].is_none())
@@ -2459,15 +2558,17 @@ fn pair_transcripts_to_windows(
     for (&si, &wi) in chosen.iter().rev().zip(&used) {
         assignment[si] = Some(windows[wi].name.clone());
         taken[wi] = true;
-        // Persist only pairs we're confident in: an actively-writing transcript IS the agent
-        // in this window. A quiet one is a stand-in guess (e.g. a fresh spawn whose .jsonl
-        // hasn't appeared yet, with an old transcript filling the display) — show it, but
-        // leave the window unbound so first contact re-runs once the real transcript starts
-        // writing, instead of wedging the guess for hours.
+        // Nominate only transcripts we could ever be confident in: an actively-writing one
+        // IS some window's agent. A quiet one is a stand-in guess (e.g. a fresh spawn whose
+        // .jsonl hasn't appeared yet, with an old transcript filling the display) — show
+        // it, but never nominate it for a binding.
         if is_fresh(&summaries[si]) {
             if let Some(sid) = &summaries[si].session_id {
                 if windows[wi].session.as_deref() != Some(sid.as_str()) {
-                    new_bindings.push((windows[wi].wid, windows[wi].name.clone(), sid.clone()));
+                    new_bindings.push(BindingCandidate {
+                        sid: sid.clone(),
+                        needle: message_fingerprint(summaries[si].last_message.as_deref()),
+                    });
                 }
             }
         }
@@ -2482,6 +2583,7 @@ fn pair_transcripts_to_windows(
     Pairing {
         assignment,
         new_bindings,
+        probe,
         unpaired: unpaired.into_iter().map(|w| w.name.clone()).collect(),
     }
 }
@@ -3755,6 +3857,10 @@ mod tests {
         }
     }
 
+    fn candidate_sids(p: &Pairing) -> Vec<&str> {
+        p.new_bindings.iter().map(|b| b.sid.as_str()).collect()
+    }
+
     fn wm(name: &str, wid: u64, sid: Option<&str>) -> agent::WindowMeta {
         agent::WindowMeta {
             name: name.into(),
@@ -3780,15 +3886,14 @@ mod tests {
             p.assignment,
             vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
         );
-        // Both paired transcripts are actively fresh → both pairs become sticky bindings.
-        let mut nb = p.new_bindings.clone();
-        nb.sort();
+        // Both paired transcripts are actively fresh → both are nominated for bindings,
+        // with every unclaimed window as a legal stamp target for the evidence pass.
+        let mut sids = candidate_sids(&p);
+        sids.sort();
+        assert_eq!(sids, vec!["b", "c"]);
         assert_eq!(
-            nb,
-            vec![
-                (1, "lane-5".to_string(), "b".to_string()),
-                (2, "lane-5-2".to_string(), "c".to_string())
-            ]
+            p.probe,
+            vec![(1, "lane-5".to_string()), (2, "lane-5-2".to_string())]
         );
         assert!(p.unpaired.is_empty());
     }
@@ -3845,10 +3950,8 @@ mod tests {
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(7, "lane-7".to_string(), "c".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["c"]);
+        assert_eq!(p.probe, vec![(7, "lane-7".to_string())]);
     }
 
     #[test]
@@ -3869,10 +3972,8 @@ mod tests {
         let windows = vec![wm("lane-7", 1, Some("x"))];
         let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows, t(5));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
-        assert_eq!(
-            p.new_bindings,
-            vec![(1, "lane-7".to_string(), "y".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["y"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
         assert!(p.unpaired.is_empty());
     }
 
@@ -3911,10 +4012,7 @@ mod tests {
         // the stale one falls back to external.
         let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
         assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
-        assert_eq!(
-            p.new_bindings,
-            vec![(5, "lane-7".to_string(), "x".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["x"]);
     }
 
     #[test]
@@ -3931,10 +4029,8 @@ mod tests {
             vec![Some("lane-7".into()), None],
             "the live transcript takes the window; the dead one goes external"
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(1, "lane-7".to_string(), "x".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["x"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
     }
 
     #[test]
@@ -3954,10 +4050,8 @@ mod tests {
             vec![Some("lane-7".into()), None, Some("lane-7-2".into())],
             "c inherits a's window; b keeps its own; dead a goes external"
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(1, "lane-7".to_string(), "c".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["c"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
     }
 
     #[test]
@@ -3972,10 +4066,8 @@ mod tests {
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(9, "lane-7-2".to_string(), "x".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["x"]);
+        assert_eq!(p.probe, vec![(9, "lane-7-2".to_string())]);
     }
 
     #[test]
@@ -4017,6 +4109,111 @@ mod tests {
         let kept =
             select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1, t(1000));
         assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn message_fingerprint_normalizes_and_gates() {
+        // Markdown styling and line wrapping vanish under normalization.
+        let m = "**Done!** The deploy isn't blocked on the invite anymore.";
+        let f = message_fingerprint(Some(m)).unwrap();
+        assert!(pane_text_contains(
+            "✻ Done! The deploy isn't\nblocked on the invite anymore.\n❯",
+            &f
+        ));
+        // A different conversation's pane does not match.
+        assert!(!pane_text_contains(
+            "recap: building Store Listen landing page",
+            &f
+        ));
+        // Long messages fingerprint their TAIL (what stays visible above the input box).
+        let long = format!(
+            "{} tail marker alpha beta gamma delta epsilon",
+            "x".repeat(500)
+        );
+        let f = message_fingerprint(Some(&long)).unwrap();
+        assert!(f.len() <= FINGERPRINT_LEN);
+        let pane = format!(
+            "{} tail marker alpha beta gamma delta epsilon",
+            "x".repeat(60)
+        );
+        assert!(pane_text_contains(&pane, &f));
+        // Absent or indistinct messages give no fingerprint: no evidence, no stamp.
+        assert_eq!(message_fingerprint(Some("ok")), None);
+        assert_eq!(message_fingerprint(None), None);
+    }
+
+    /// Test-side helper mirroring the stamp task's pane check.
+    fn pane_text_contains(pane: &str, needle: &str) -> bool {
+        normalize_fingerprint(pane).contains(needle)
+    }
+
+    #[test]
+    fn stamps_follow_pane_evidence_not_the_hint() {
+        let cand = |sid: &str, msg: &str| BindingCandidate {
+            sid: sid.into(),
+            needle: message_fingerprint(Some(msg)),
+        };
+        let a = cand("a", "fingerprint marker for agent alpha pane evidence");
+        let b = cand("b", "fingerprint marker for agent bravo pane evidence");
+        // Panes are CROSSED relative to candidate order: evidence must decide, so a lands
+        // on @2 and b on @1 regardless of any heuristic hint.
+        let panes = vec![
+            (
+                1,
+                "lane-7".to_string(),
+                normalize_fingerprint("✻ fingerprint marker for agent bravo pane evidence\n❯"),
+            ),
+            (
+                2,
+                "lane-7-2".to_string(),
+                normalize_fingerprint("✻ fingerprint marker for agent alpha pane evidence\n❯"),
+            ),
+        ];
+        let mut got = confirmed_stamps(&[a, b], &panes);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                (1, "lane-7".to_string(), "b".to_string()),
+                (2, "lane-7-2".to_string(), "a".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn ambiguous_or_absent_pane_evidence_stamps_nothing() {
+        let cand = |sid: &str, msg: Option<&str>| BindingCandidate {
+            sid: sid.into(),
+            needle: message_fingerprint(msg),
+        };
+        let marker = "identical rotation continuation marker text";
+        // Two panes showing the same text: ambiguous for a matching candidate.
+        let twin_panes = vec![
+            (1, "lane-7".to_string(), normalize_fingerprint(marker)),
+            (2, "lane-7-2".to_string(), normalize_fingerprint(marker)),
+        ];
+        assert!(confirmed_stamps(&[cand("a", Some(marker))], &twin_panes).is_empty());
+        // Two candidates whose needles both match one pane: mutual ambiguity, skip both.
+        let one_pane = vec![(1, "lane-7".to_string(), normalize_fingerprint(marker))];
+        assert!(
+            confirmed_stamps(
+                &[cand("a", Some(marker)), cand("b", Some(marker))],
+                &one_pane
+            )
+            .is_empty()
+        );
+        // No fingerprint (agent mid-first-turn) or no matching pane: nothing stamped.
+        assert!(confirmed_stamps(&[cand("a", None)], &one_pane).is_empty());
+        assert!(
+            confirmed_stamps(
+                &[cand(
+                    "a",
+                    Some("completely unrelated conversation text here")
+                )],
+                &one_pane
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1749,7 +1749,7 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             ctx.last_good_windows
                 .lock()
                 .await
-                .retain(|w| w != ORCHESTRATOR_WINDOW);
+                .retain(|w| w.name != ORCHESTRATOR_WINDOW);
             *orch = None;
             *ctx.orchestrator_attention.lock().await = ("none".to_string(), None);
             let status = orchestrator_status_value(None, "none", None);
@@ -1944,8 +1944,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // window set for this tick (a transient tmux fork/connection fault must not momentarily drop
     // every managed agent — that flips sessions to `external`, detaches the focused TUI, and fires
     // stale notifications). A real empty result still clears.
-    let fresh: Result<Vec<String>, String> =
-        match tokio::task::spawn_blocking(move || tmux.list_windows()).await {
+    let fresh: Result<Vec<agent::WindowMeta>, String> =
+        match tokio::task::spawn_blocking(move || tmux.list_windows_meta()).await {
             Ok(Ok(w)) => Ok(w),
             Ok(Err(e)) => Err(e.to_string()),
             Err(e) => Err(e.to_string()),
@@ -1964,8 +1964,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // fresh on the very next line, and the gone agent disappears within one refresh.
     let managed_now: std::collections::HashSet<String> = windows
         .iter()
-        .filter(|w| w.starts_with("lane-"))
-        .cloned()
+        .filter(|w| w.name.starts_with("lane-"))
+        .map(|w| w.name.clone())
         .collect();
     {
         let mut prev = ctx.last_managed_windows.lock().await;
@@ -1989,11 +1989,13 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let auto_off = ctx.auto_continue_off.lock().await.clone();
     let global_auto = ctx.config.read().await.auto_continue;
 
-    for (lane, mut summaries) in lanes.iter_mut().zip(per_lane) {
-        // The lane's managed agent windows, in slot order (= spawn order). A window only exists
-        // while its agent's process lives (tmux closes it on exit), so it doubles as proof of
-        // liveness and as the routing target for keys/captures.
-        let lane_windows = TmuxRuntime::lane_windows_in(&windows, lane.id);
+    // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
+    let mut new_bindings: Vec<(String, String)> = Vec::new();
+    for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
+        // The lane's managed agent windows, in slot order. A window only exists while its
+        // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
+        // and as the routing target for keys/captures.
+        let lane_windows = TmuxRuntime::lane_windows_meta(&windows, lane.id);
         let managed_n = lane_windows.len();
         // Live `claude` processes whose cwd is this worktree bound how many of its sessions are
         // running (a `/exit`ed one leaves a recent transcript but no process). But never drop a
@@ -2016,13 +2018,22 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             .filter(|s| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS)
             .count();
         let keep = sessions_to_keep(summaries.len(), alive, managed_n, fresh);
-        summaries.truncate(keep);
+        // A transcript bound to a live window IS a live agent regardless of what the process
+        // count says — never truncate it away in favor of a newer unbound one.
+        let bound: std::collections::HashSet<String> = lane_windows
+            .iter()
+            .filter_map(|w| w.session.clone())
+            .collect();
+        let summaries = select_kept_summaries(summaries, &bound, keep);
         if !summaries.is_empty() {
-            // Pair the newest `k` transcripts with the `k` windows, oldest with oldest (slot order
-            // tracks spawn order, transcripts arrive newest-first). A heuristic, but it routes
-            // keys/captures to the right pane in practice.
-            let paired = summaries.len().min(managed_n);
-            for (idx, s) in summaries.into_iter().enumerate() {
+            // Pair transcripts with windows by sticky identity (`@repomon_session`), falling
+            // back to the oldest-with-oldest heuristic only on first contact — see
+            // `pair_transcripts_to_windows`. The old purely positional zip re-bound windows
+            // whenever two agents swapped activity rank, which moved names, panes, and usage
+            // accounts between rows.
+            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows);
+            new_bindings.extend(pairing.new_bindings);
+            for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
                     lane.last_activity_at = s.last_activity;
                 }
@@ -2031,11 +2042,12 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     .session_id
                     .as_ref()
                     .and_then(|id| labels.get(id).cloned());
-                if idx < paired {
-                    session.external = false;
-                    session.tmux_window = Some(lane_windows[paired - 1 - idx].clone());
-                } else {
-                    session.external = true;
+                match win {
+                    Some(w) => {
+                        session.external = false;
+                        session.tmux_window = Some(w);
+                    }
+                    None => session.external = true,
                 }
                 lane.agent_sessions.push(session);
             }
@@ -2044,13 +2056,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             // away as a window-only placeholder so it isn't invisible until then. At most one
             // (the `SessKey::Fallback` model allows a single no-transcript session per lane): the
             // newest unpaired window, which is the slot the latest spawn took.
-            if let Some(w) = placeholder_window_index(paired, managed_n) {
+            if let Some(w) = pairing.unpaired.first() {
                 let kind = lane_meta_kind(&metas, lane.id);
-                lane.agent_sessions.push(window_placeholder_session(
-                    lane,
-                    kind,
-                    lane_windows[w].clone(),
-                ));
+                lane.agent_sessions
+                    .push(window_placeholder_session(lane, kind, w.clone()));
             }
         } else if managed_n > 0 {
             // No parseable transcript: surface a repomon-spawned agent if its window is alive.
@@ -2058,7 +2067,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             lane.agent_sessions.push(window_placeholder_session(
                 lane,
                 kind,
-                lane_windows[0].clone(),
+                lane_windows[0].name.clone(),
             ));
         } else if let Some(changed) = lane.state.last_change_at {
             // No identified agent, but a *non-main* worktree's files changed very recently — infer
@@ -2112,6 +2121,21 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 }
             }
         }
+    }
+
+    // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
+    // window so the pairing survives daemon restarts and activity-order flips. Rare — once
+    // per agent lifetime — so this adds no forks to a steady-state overlay.
+    if !new_bindings.is_empty() {
+        let tmux = ctx.tmux.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            for (w, sid) in new_bindings {
+                if let Err(e) = tmux.set_window_session(&w, &sid) {
+                    tracing::warn!("failed to stamp @repomon_session on {w}: {e}");
+                }
+            }
+        })
+        .await;
     }
 
     // dxkit stop-gate verdicts: worktrees running dxkit's loop pack leave an append-only
@@ -2255,7 +2279,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         // liveness ONLY — its old timestamps are the stall clock.
         {
             let live: std::collections::HashSet<&str> =
-                windows.iter().map(String::as_str).collect();
+                windows.iter().map(|w| w.name.as_str()).collect();
             let mut cache = ctx.prompt_cache.lock().await;
             cache.retain(|w, (t, _)| live.contains(w.as_str()) && t.elapsed() < SNIFF_TTL);
             let mut seen = ctx.pane_seen.lock().await;
@@ -2305,6 +2329,108 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
         Some(n) => n.max(managed_n).max(fresh).min(total),
         None => total, // probe unavailable: don't filter
     }
+}
+
+/// A lane's transcript↔window pairing for one overlay tick ([`pair_transcripts_to_windows`]).
+struct Pairing {
+    /// Per input summary (order preserved): the managed window it runs in; `None` = external.
+    assignment: Vec<Option<String>>,
+    /// Sticky bindings established this tick — `(window_name, session_id)` to stamp as
+    /// `@repomon_session` so they survive daemon restarts and activity-order flips.
+    new_bindings: Vec<(String, String)>,
+    /// Live managed windows no transcript claimed, newest (highest window id) first. The
+    /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
+    /// appeared yet (at most one, per the `SessKey::Fallback` model).
+    unpaired: Vec<String>,
+}
+
+/// Pair a lane's kept transcripts (newest-first) with its live managed windows by STICKY
+/// IDENTITY first, position last.
+///
+/// Pass 1: a window whose `@repomon_session` names a kept transcript keeps it. This is what
+/// makes the pairing immune to two agents swapping activity rank — which used to re-bind
+/// their windows every poll, moving names, panes, and usage accounts between rows — and to
+/// daemon restarts (the binding lives in tmux, not daemon memory).
+///
+/// Pass 2 (first contact only): the newest still-unassigned transcripts meet the still-free
+/// windows, oldest-with-oldest — the same heuristic the overlay always used, but run ONCE
+/// per agent: each pair is emitted in `new_bindings` and pass 1 owns it from the next tick.
+/// Never-bound windows are offered before stale-bound ones (whose transcript vanished this
+/// tick), so a one-tick transcript flap can't hand a live agent's window to a newcomer; and
+/// window age is the window id — slot NAMES are recycled after an exit, ids never are.
+fn pair_transcripts_to_windows(
+    summaries: &[agent::TranscriptSummary],
+    windows: &[agent::WindowMeta],
+) -> Pairing {
+    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
+    let mut taken = vec![false; windows.len()];
+    // Pass 1 — sticky identity.
+    for (wi, w) in windows.iter().enumerate() {
+        let Some(sid) = &w.session else { continue };
+        if let Some(si) = summaries
+            .iter()
+            .position(|s| s.session_id.as_deref() == Some(sid.as_str()))
+        {
+            if assignment[si].is_none() {
+                assignment[si] = Some(w.name.clone());
+                taken[wi] = true;
+            }
+        }
+    }
+    // Pass 2 — first contact. Never-bound windows are offered before stale-bound ones, both
+    // oldest (lowest window id) first.
+    let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
+    free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
+    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest;
+    // pair that subset oldest-with-oldest (hence `.rev()`), like the legacy positional zip.
+    let chosen: Vec<usize> = (0..summaries.len())
+        .filter(|&i| assignment[i].is_none())
+        .take(free.len())
+        .collect();
+    let mut new_bindings = Vec::new();
+    for (&si, &wi) in chosen.iter().rev().zip(&free) {
+        assignment[si] = Some(windows[wi].name.clone());
+        taken[wi] = true;
+        if let Some(sid) = &summaries[si].session_id {
+            new_bindings.push((windows[wi].name.clone(), sid.clone()));
+        }
+    }
+    let mut unpaired: Vec<&agent::WindowMeta> = windows
+        .iter()
+        .zip(&taken)
+        .filter(|(_, t)| !**t)
+        .map(|(w, _)| w)
+        .collect();
+    unpaired.sort_by_key(|w| std::cmp::Reverse(w.wid));
+    Pairing {
+        assignment,
+        new_bindings,
+        unpaired: unpaired.into_iter().map(|w| w.name.clone()).collect(),
+    }
+}
+
+/// Which of a lane's newest-first transcripts to keep, honoring bindings: every summary bound
+/// to a live managed window is kept regardless of rank (the window only exists while its
+/// agent's process lives, so it outranks the process-count probe), then newest-first from the
+/// rest up to `keep` total. Output is re-sorted newest-first so the wire order is unchanged.
+/// Without this, a bound-but-quiet agent could be truncated in favor of a newer external
+/// transcript, dropping a live agent from the lane.
+fn select_kept_summaries(
+    summaries: Vec<agent::TranscriptSummary>,
+    bound: &std::collections::HashSet<String>,
+    keep: usize,
+) -> Vec<agent::TranscriptSummary> {
+    if summaries.len() <= keep {
+        return summaries;
+    }
+    let (bound_s, rest): (Vec<_>, Vec<_>) = summaries
+        .into_iter()
+        .partition(|s| s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
+    let take_rest = keep.saturating_sub(bound_s.len());
+    let mut out = bound_s;
+    out.extend(rest.into_iter().take(take_rest));
+    out.sort_by_key(|s| std::cmp::Reverse(s.last_activity));
+    out
 }
 
 /// How long a viewport focus keeps owning its window's size after the last `viewport.set`.
@@ -2716,16 +2842,6 @@ fn window_placeholder_session(lane: &Lane, kind: AgentKind, window: String) -> A
     }
 }
 
-/// Whether a lane needs a window-only placeholder for a just-spawned agent whose transcript
-/// hasn't appeared yet, and which managed-window index it maps to. `shown` = transcript-backed
-/// sessions already emitted; `managed_n` = live managed windows. A managed window exists only
-/// while its agent's process lives (tmux closes it on exit), so an unpaired window is a real
-/// agent that simply hasn't written its `.jsonl` yet. Returns the newest unpaired window's index
-/// (at most one, per the `SessKey::Fallback` single-no-transcript-session model), or `None`.
-fn placeholder_window_index(shown: usize, managed_n: usize) -> Option<usize> {
-    (managed_n > shown).then(|| managed_n - 1)
-}
-
 /// A Claude session id is safe to interpolate into a resume command (`claude --resume <id>`).
 /// Transcript ids are UUIDs / `[A-Za-z0-9_-]`; anything else (whitespace, `;`, `$`, quotes, `|`,
 /// backticks…) is rejected so `agent.adopt` can't be turned into shell injection — the command is
@@ -2741,11 +2857,11 @@ fn valid_session_id(s: &str) -> bool {
 /// `tmux` failing to spawn under load — distinct from a genuinely empty server), reuse the
 /// last-good list so a single bad snapshot doesn't momentarily drop every managed agent — which
 /// would flip sessions to `external`, detach the focused TUI, and fire stale notifications.
-fn resolve_windows(
-    fresh: Result<Vec<String>, String>,
-    last_good: &mut Vec<String>,
+fn resolve_windows<T: Clone>(
+    fresh: Result<Vec<T>, String>,
+    last_good: &mut Vec<T>,
     empty_misses: &mut u8,
-) -> Vec<String> {
+) -> Vec<T> {
     match fresh {
         // Transient probe fault (fork/connection): reuse last-good; don't touch the empty counter.
         Err(_) => last_good.clone(),
@@ -3539,19 +3655,181 @@ mod tests {
         assert_eq!(misses, 0);
     }
 
+    /// A minimal transcript summary for pairing tests: `sid` + activity time.
+    fn tsum(sid: &str, last_activity: chrono::DateTime<chrono::Utc>) -> agent::TranscriptSummary {
+        agent::TranscriptSummary {
+            kind: repomon_core::model::AgentKind::ClaudeCode,
+            manifest_path: PathBuf::from(format!("/tmp/{sid}.jsonl")),
+            cwd: None,
+            last_activity,
+            tool_call_count: 0,
+            status: repomon_core::model::AgentStatus::Idle,
+            title: None,
+            last_message: None,
+            config_dir: None,
+            session_id: Some(sid.to_string()),
+            ended_turn: false,
+        }
+    }
+
+    fn wm(name: &str, wid: u64, sid: Option<&str>) -> agent::WindowMeta {
+        agent::WindowMeta {
+            name: name.into(),
+            wid,
+            session: sid.map(str::to_string),
+        }
+    }
+
+    /// Activity times t(0) < t(1) < …, so `t(2)` is newer than `t(1)`.
+    fn t(n: i64) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::from_timestamp(1_700_000_000 + n * 60, 0).unwrap()
+    }
+
     #[test]
-    fn placeholder_for_the_newest_unpaired_window() {
-        // One existing agent (transcript) + a freshly-spawned second window: surface the new
-        // window immediately, mapped to the newest slot, so it isn't invisible until its
-        // transcript lands.
-        assert_eq!(placeholder_window_index(1, 2), Some(1));
-        // Every managed window already transcript-backed → no placeholder.
-        assert_eq!(placeholder_window_index(2, 2), None);
-        assert_eq!(placeholder_window_index(1, 1), None);
-        assert_eq!(placeholder_window_index(0, 0), None);
-        // Three windows, one transcript: still a single placeholder (the Fallback invariant),
-        // mapped to the newest window.
-        assert_eq!(placeholder_window_index(1, 3), Some(2));
+    fn pairing_without_bindings_matches_legacy_heuristic() {
+        // First contact (nothing bound yet): newest transcript ↔ newest slot, oldest paired ↔
+        // slot 1, the overflow transcript external — exactly what the positional zip did.
+        let summaries = vec![tsum("c", t(3)), tsum("b", t(2)), tsum("a", t(1))];
+        let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
+        let p = pair_transcripts_to_windows(&summaries, &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
+        );
+        // Both pairs become sticky bindings.
+        let mut nb = p.new_bindings.clone();
+        nb.sort();
+        assert_eq!(
+            nb,
+            vec![
+                ("lane-5".to_string(), "b".to_string()),
+                ("lane-5-2".to_string(), "c".to_string())
+            ]
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn pairing_sticks_across_activity_flip() {
+        // The reported bug: two bound agents swap activity rank; the pairing must not move.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        // b most recently active…
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+        // …then a takes a turn and the order flips: same windows per session id.
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn first_contact_binds_then_holds_through_flip() {
+        // Unbound windows (daemon restart / pre-upgrade agents): the heuristic runs once and
+        // its result is emitted as bindings; re-running with those bindings and flipped
+        // activity keeps the original assignment.
+        let unbound = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        let bound = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+    }
+
+    #[test]
+    fn slot_recycling_pairs_new_transcript_to_new_window() {
+        // Slot 1 (`lane-7`) died and was respawned: same NAME, higher window id, no binding.
+        // The surviving agent b keeps its bound `lane-7-2`; the newcomer c gets the recycled
+        // window — even though slot-name order would have handed c the older agent's window.
+        let windows = vec![wm("lane-7", 7, None), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![("lane-7".to_string(), "c".to_string())]
+        );
+    }
+
+    #[test]
+    fn one_tick_transcript_flap_does_not_rebind() {
+        // b's transcript flaps out for one tick: its window merely goes unpaired (placeholder
+        // target); it is NOT rebound to the surviving transcript and no binding is written.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert!(p.new_bindings.is_empty());
+        assert_eq!(p.unpaired, vec!["lane-7-2".to_string()]);
+    }
+
+    #[test]
+    fn stale_binding_released_to_a_genuinely_new_transcript() {
+        // The bound transcript is gone AND a new one needs a window: the stale binding is
+        // released and rewritten to the newcomer.
+        let windows = vec![wm("lane-7", 1, Some("x"))];
+        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(
+            p.new_bindings,
+            vec![("lane-7".to_string(), "y".to_string())]
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn placeholder_target_is_the_newest_unpaired_window() {
+        // One transcript, two windows (second freshly spawned, no `.jsonl` yet): the leftover
+        // is the NEWEST window (highest id) so the placeholder lands on the fresh spawn.
+        let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-5".into())]);
+        assert_eq!(p.unpaired, vec!["lane-5-2".to_string()]);
+        // All windows transcript-backed → nothing unpaired.
+        let p = pair_transcripts_to_windows(
+            &[tsum("b", t(2)), tsum("a", t(1))],
+            &[wm("lane-5", 1, None), wm("lane-5-2", 2, None)],
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn select_kept_summaries_protects_bound_sessions() {
+        // A bound-but-quiet agent (its window is alive — that IS liveness) must survive
+        // truncation ahead of newer unbound transcripts; output stays newest-first.
+        let bound: std::collections::HashSet<String> = ["a".to_string()].into();
+        let kept = select_kept_summaries(
+            vec![tsum("e1", t(3)), tsum("e2", t(2)), tsum("a", t(1))],
+            &bound,
+            2,
+        );
+        let ids: Vec<&str> = kept
+            .iter()
+            .filter_map(|s| s.session_id.as_deref())
+            .collect();
+        assert_eq!(ids, vec!["e1", "a"]);
+        // Under the cap nothing is dropped.
+        let kept = select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5);
+        assert_eq!(kept.len(), 2);
+        // More bound sessions than `keep` says: the windows win (each proves a live agent).
+        let bound: std::collections::HashSet<String> = ["a".to_string(), "b".to_string()].into();
+        let kept = select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1);
+        assert_eq!(kept.len(), 2);
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2409,9 +2409,11 @@ fn pair_transcripts_to_windows(
     // Supersession: a claude process rotates its transcript id in place (`/clear`, a
     // fork-on-resume), leaving its window bound to a dead transcript while the live
     // continuation has no window. When more FRESH unclaimed transcripts exist than free
-    // windows to receive them, release claims whose transcript has gone quiet — coldest
-    // first — so pass 2 can re-bind those windows to the transcripts actually writing. A
-    // claim on a fresh transcript is never released, so an idle fleet can't be shuffled.
+    // windows to receive them, release claims whose transcript has gone quiet — WARMEST
+    // first: the transcript that stopped writing most recently is the one that just rotated
+    // into the newcomer, while a long-cold one is simply an idle agent whose window must not
+    // be given away. A claim on a fresh transcript is never released, so an idle fleet
+    // can't be shuffled.
     let fresh_unclaimed = summaries
         .iter()
         .enumerate()
@@ -2422,7 +2424,7 @@ fn pair_transcripts_to_windows(
         let mut stale_wis: Vec<usize> = (0..windows.len())
             .filter(|&wi| claim[wi].is_some_and(|si| !is_fresh(&summaries[si])))
             .collect();
-        stale_wis.sort_by_key(|&wi| summaries[claim[wi].unwrap()].last_activity);
+        stale_wis.sort_by_key(|&wi| std::cmp::Reverse(summaries[claim[wi].unwrap()].last_activity));
         for wi in stale_wis {
             if fresh_unclaimed <= free_n {
                 break;
@@ -3932,6 +3934,29 @@ mod tests {
         assert_eq!(
             p.new_bindings,
             vec![(1, "lane-7".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn clear_rotation_releases_the_rotated_window_not_the_coldest() {
+        // Two bound agents, both currently quiet: a rotated its session id a moment ago
+        // (`/clear` → continuation c), b has been idle for much longer. The window released
+        // for c must be a's — the transcript that went quiet MOST recently is the one that
+        // just rotated; sacrificing the long-idle b would route c's keys into b's pane.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(
+            &[tsum("c", t(100)), tsum("a", t(50)), tsum("b", t(0))],
+            &windows,
+            t(100),
+        );
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), None, Some("lane-7-2".into())],
+            "c inherits a's window; b keeps its own; dead a goes external"
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![(1, "lane-7".to_string(), "c".to_string())]
         );
     }
 

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -4991,11 +4991,14 @@ fn stable_session_order(sessions: &[AgentSession]) -> Vec<usize> {
 }
 
 /// The stable identity of a session, or `None` for an inferred/keyless one (nothing to pin to).
+/// Transcript id first — UUIDs are never reused, while slot names (`lane-7-2`) are recycled on
+/// respawn, so a long-held `Window` ref could resolve to a brand-new different agent. The
+/// window is the fallback for just-spawned placeholders whose `.jsonl` hasn't appeared yet.
 fn agent_session_ref(s: &AgentSession) -> Option<SessionRef> {
-    if let Some(w) = &s.tmux_window {
-        Some(SessionRef::Window(w.clone()))
+    if let Some(id) = &s.session_id {
+        Some(SessionRef::Transcript(id.clone()))
     } else {
-        s.session_id.clone().map(SessionRef::Transcript)
+        s.tmux_window.clone().map(SessionRef::Window)
     }
 }
 
@@ -5648,10 +5651,17 @@ mod tests {
     }
 
     #[test]
-    fn agent_session_ref_prefers_window_then_transcript() {
-        // A managed agent keys on its window even when it also has a transcript id.
+    fn agent_session_ref_prefers_transcript_then_window() {
+        // A transcript-backed agent keys on its transcript id even when it also has a window:
+        // transcript UUIDs are never reused, while slot names like `lane-7-2` are recycled on
+        // respawn — a remembered Window ref could resolve to a brand-new different agent.
         assert_eq!(
             agent_session_ref(&managed("lane-7-2", Some("uuid-1"))),
+            Some(SessionRef::Transcript("uuid-1".into()))
+        );
+        // A just-spawned placeholder (window, no `.jsonl` yet) falls back to its window.
+        assert_eq!(
+            agent_session_ref(&managed("lane-7-2", None)),
             Some(SessionRef::Window("lane-7-2".into()))
         );
         // An external/transcript-only session keys on the transcript id.

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -356,12 +356,29 @@ pub struct App {
     pub recent_commits: Vec<Commit>,
     recent_commits_lane: Option<LaneId>,
     /// Which of the selected lane's agent sessions is highlighted (for adopt). Several
-    /// concurrent agents can run in one worktree; this cursor picks among them.
+    /// concurrent agents can run in one worktree; this cursor picks among them. Derived: the
+    /// daemon orders `agent_sessions` newest-active-first and re-sorts it as agents take
+    /// turns, so `sync_session_cursor` re-derives this position from `session_ref` on every
+    /// tick — a raw index held across refreshes would silently drift onto a different agent
+    /// (wrong usage account, keys routed to the wrong pane).
     pub session_idx: usize,
     session_lane: Option<LaneId>,
-    /// The agent each lane had selected when you last left it, so returning to a multi-agent
-    /// lane restores your pick instead of snapping back to the first slot. Keyed by a stable
-    /// identity (tmux window / transcript id), so it survives the session list reordering.
+    /// The durable identity of the agent the session cursor is on — the source of truth that
+    /// `session_idx` is re-derived from each tick. `None` until a lane's first pin.
+    session_ref: Option<SessionRef>,
+    /// Consecutive refreshes the anchored agent has been missing from the selected lane (see
+    /// [`SESSION_REF_GRACE`]); counted at most once per `refresh_gen`.
+    session_ref_misses: u8,
+    /// The `refresh_gen` the last anchor miss was counted against, so a burst of input events
+    /// during one bad snapshot (the cursor sync runs per event-loop iteration) can't exhaust
+    /// the grace that is meant to be measured in data refreshes.
+    session_ref_miss_gen: u64,
+    /// Bumped by every successful `refresh_lanes` — the anchor miss counter's clock.
+    refresh_gen: u64,
+    /// The agent each lane had selected when you last left it (saved from `session_ref` on
+    /// lane change), so returning to a multi-agent lane restores your pick instead of
+    /// snapping back to the first slot. Keyed by a stable identity (transcript id / tmux
+    /// window), so it survives the session list reordering.
     session_memory: HashMap<LaneId, SessionRef>,
     /// After spawning an agent, the (lane, tmux window) to move the session cursor onto once it
     /// shows up in `lane.list` — so a fresh spawn lands you on the *new* agent, not the old one.
@@ -563,6 +580,11 @@ impl App {
             recent_commits_lane: None,
             session_idx: 0,
             session_lane: None,
+            session_ref: None,
+            session_ref_misses: 0,
+            // Sentinel ≠ refresh_gen, so the very first snapshot's miss is counted too.
+            session_ref_miss_gen: u64::MAX,
+            refresh_gen: 0,
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
@@ -730,6 +752,8 @@ impl App {
                 let keep = self.selected_lane().map(|l| l.id);
                 let keep_ref = self.selected_session_ref();
                 self.lanes = l;
+                // New snapshot: advance the anchor miss counter's clock (see `refresh_gen`).
+                self.refresh_gen = self.refresh_gen.wrapping_add(1);
                 // Forget remembered agent selections for lanes that no longer exist.
                 self.session_memory
                     .retain(|id, _| self.lanes.iter().any(|l| l.id == *id));
@@ -1685,16 +1709,14 @@ impl App {
                 });
                 match hit {
                     Some(i) => {
-                        self.session_idx = i;
+                        // Anchor by identity: the ref is the window for now and upgrades to
+                        // the transcript id once the `.jsonl` lands (per-tick re-resolve).
+                        self.pin_session(i);
                         self.pending_focus_window = None;
                         self.pending_focus_ticks = 0;
                         self.reset_scroll();
                         if self.settings.expand_agents {
-                            let sref = self
-                                .selected_lane()
-                                .and_then(|l| l.agent_sessions.get(i))
-                                .and_then(agent_session_ref);
-                            self.select_lane_session(lane, sref);
+                            self.select_lane_session(lane, self.session_ref.clone());
                         }
                         return;
                     }
@@ -1713,7 +1735,8 @@ impl App {
             }
         }
         // In expanded mode an agent sub-row IS the session cursor — drive `session_idx` straight
-        // from the selected row (the memory logic below is for the collapsed lane rows).
+        // from the selected row (the row itself is identity-remapped on refresh, so it's safe);
+        // the anchor mirrors it so collapsing keeps the pick.
         if self.settings.expand_agents {
             if let Some(FleetRow {
                 session: Some(s), ..
@@ -1724,7 +1747,7 @@ impl App {
                     self.reset_scroll();
                 }
                 self.session_lane = lane_id;
-                self.session_idx = s;
+                self.pin_session(s);
                 return;
             }
         }
@@ -1734,34 +1757,80 @@ impl App {
             // your pick instead of snapping to the first slot. Identity-keyed, so it survives
             // the session list reordering; falls back to the first agent when the remembered
             // one is gone (or this lane was never visited).
-            if let Some(old) = self.session_lane {
-                if let Some(r) = self
-                    .lanes
-                    .iter()
-                    .find(|l| l.id == old)
-                    .and_then(|l| l.agent_sessions.get(self.session_idx))
-                    .and_then(agent_session_ref)
-                {
-                    self.session_memory.insert(old, r);
-                }
+            if let (Some(old), Some(r)) = (self.session_lane, self.session_ref.clone()) {
+                self.session_memory.insert(old, r);
             }
             self.session_lane = sel;
-            self.session_idx = sel
+            let idx = sel
                 .and_then(|id| self.session_memory.get(&id))
                 .and_then(|r| {
                     self.selected_lane()
                         .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
                 })
                 .unwrap_or(0);
+            self.pin_session(idx);
             self.reset_scroll(); // scrollback buffer belonged to the previous lane
+            return;
         }
-        let n = self
+        // Same lane, possibly a new snapshot: re-resolve the anchor EVERY tick. The daemon
+        // orders `agent_sessions` newest-active-first and re-sorts it as agents take turns,
+        // so identity is the truth and `session_idx` merely its current position. No scroll
+        // reset on a position change — it is the same agent.
+        let resolved = self.session_ref.as_ref().and_then(|r| {
+            self.selected_lane()
+                .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
+        });
+        match resolved {
+            Some(i) => {
+                self.session_idx = i;
+                self.session_ref_misses = 0;
+                // Re-derive the anchor from the resolved session, so a `Window` ref upgrades
+                // to the sturdier `Transcript` ref once a placeholder gains its transcript.
+                self.session_ref = self
+                    .selected_lane()
+                    .and_then(|l| l.agent_sessions.get(i))
+                    .and_then(agent_session_ref);
+            }
+            None => {
+                let n = self
+                    .selected_lane()
+                    .map(|l| l.agent_sessions.len())
+                    .unwrap_or(0);
+                if self.session_idx >= n {
+                    self.session_idx = n.saturating_sub(1);
+                }
+                if n == 0 {
+                    return;
+                }
+                if self.session_ref.is_none() {
+                    // First contact with a populated lane (arrival landed on an empty lane, or
+                    // nothing was ever pinned): pin the current occupant — and hold it, per
+                    // the pin-on-arrival rule, instead of following the daemon's re-sorts.
+                    self.pin_session(self.session_idx);
+                } else if self.session_ref_miss_gen != self.refresh_gen {
+                    // The anchored agent is missing from this snapshot. Counted once per data
+                    // refresh: a transient overlay flap must not re-pin the pick, a real exit
+                    // adopts the occupant after the grace.
+                    self.session_ref_miss_gen = self.refresh_gen;
+                    self.session_ref_misses = self.session_ref_misses.saturating_add(1);
+                    if self.session_ref_misses > SESSION_REF_GRACE {
+                        self.pin_session(self.session_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Point the session cursor at `idx` on the selected lane and anchor it by identity —
+    /// every deliberate cursor move funnels through here so `sync_session_cursor`'s per-tick
+    /// re-resolve can never snap the cursor back to a stale pick.
+    fn pin_session(&mut self, idx: usize) {
+        self.session_idx = idx;
+        self.session_ref = self
             .selected_lane()
-            .map(|l| l.agent_sessions.len())
-            .unwrap_or(0);
-        if self.session_idx >= n {
-            self.session_idx = n.saturating_sub(1);
-        }
+            .and_then(|l| l.agent_sessions.get(idx))
+            .and_then(agent_session_ref);
+        self.session_ref_misses = 0;
     }
 
     /// Drop out of Focus once the agent we were driving exits (its managed session is gone —
@@ -1943,11 +2012,12 @@ impl App {
         if n <= 1 {
             return;
         }
-        self.session_idx = if forward {
+        let idx = if forward {
             (self.session_idx + 1) % n
         } else {
             (self.session_idx + n - 1) % n
         };
+        self.pin_session(idx);
         // The scrollback snapshot belonged to the previous agent's window — drop it so the new
         // agent shows its own live tail instead of stale lines.
         self.reset_scroll();
@@ -1955,11 +2025,7 @@ impl App {
         // agent's sub-row — otherwise the per-tick cursor sync snaps session_idx straight back.
         if self.settings.expand_agents {
             if let Some(lane_id) = self.selected_lane().map(|l| l.id) {
-                let sref = self
-                    .selected_lane()
-                    .and_then(|l| l.agent_sessions.get(self.session_idx))
-                    .and_then(agent_session_ref);
-                self.select_lane_session(lane_id, sref);
+                self.select_lane_session(lane_id, self.session_ref.clone());
             }
         }
     }
@@ -2946,16 +3012,19 @@ impl App {
         if let Some(i) = idx {
             self.session_lane = Some(lane_id); // keep sync_session_cursor from resetting it
             self.session_idx = i;
+            // Anchor by identity (from the target lane — the fleet cursor may not be on it
+            // yet), or the per-tick re-resolve would snap back to the old pick within a tick.
+            self.session_ref = self
+                .lanes
+                .iter()
+                .find(|l| l.id == lane_id)
+                .and_then(|l| l.agent_sessions.get(i))
+                .and_then(agent_session_ref);
+            self.session_ref_misses = 0;
             // In expanded mode, also land the fleet cursor on that agent's row so the per-tick
             // cursor sync (which keys off the selected row) keeps it there.
             if self.settings.expand_agents {
-                let sref = self
-                    .lanes
-                    .iter()
-                    .find(|l| l.id == lane_id)
-                    .and_then(|l| l.agent_sessions.get(i))
-                    .and_then(agent_session_ref);
-                self.select_lane_session(lane_id, sref);
+                self.select_lane_session(lane_id, self.session_ref.clone());
             }
         }
     }
@@ -4882,6 +4951,12 @@ const VIEWPORT_REASSERT: std::time::Duration = std::time::Duration::from_secs(5)
 /// within ~grace refreshes.
 const FOCUS_DETACH_GRACE: u8 = 3;
 
+/// Consecutive cursor syncs the anchored agent may be missing from the selected lane before
+/// the cursor re-pins to whatever agent it currently rests on. More than one, so a transient
+/// overlay flap (one bad tmux/transcript snapshot) can't permanently retarget the pick; a
+/// real exit stays absent and re-pins within ~grace ticks.
+const SESSION_REF_GRACE: u8 = 3;
+
 /// How many ~1s refreshes to keep trying to land the cursor on a just-spawned agent's window
 /// before giving up (the transcript/window may take a moment to appear).
 const PENDING_FOCUS_GIVE_UP_TICKS: u8 = 5;
@@ -5613,6 +5688,199 @@ mod tests {
             session_index_for_ref(&sessions, &SessionRef::Window("lane-7-3".into())),
             None
         );
+    }
+
+    /// A minimal collapsed-mode fleet: real `Lane` built over the wire shape (the TUI has no
+    /// gix dependency to mint `ObjectId`s directly), sessions swapped in by the caller.
+    fn fake_lane(id: repomon_core::model::LaneId, sessions: Vec<AgentSession>) -> Lane {
+        let zero = "0".repeat(40);
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut lane: Lane = serde_json::from_value(json!({
+            "id": id,
+            "repo": {
+                "id": 1, "path": "/tmp/repo", "name": "repo",
+                "added_at": now, "worktree_root_template": null,
+            },
+            "worktree": {
+                "id": id, "repo_id": 1, "path": format!("/tmp/wt{id}"),
+                "branch": "main", "head": zero, "is_main": true, "name": format!("wt{id}"),
+            },
+            "state": {
+                "worktree_id": id, "head": zero, "branch": "main", "upstream": null,
+                "ahead": 0, "behind": 0,
+                "dirty": {"staged": 0, "unstaged": 0, "untracked": 0},
+                "last_commit_at": null,
+            },
+            "agent_sessions": [],
+            "last_activity_at": now,
+            "pinned": false,
+        }))
+        .expect("fake lane");
+        lane.agent_sessions = sessions;
+        lane
+    }
+
+    /// Two managed agents on distinct accounts for cursor-identity tests: `a` in slot 1 on
+    /// the default account, `b` in slot 2 on a work account.
+    fn two_agents() -> (AgentSession, AgentSession) {
+        let a = managed("lane-1", Some("sid-a"));
+        let mut b = managed("lane-1-2", Some("sid-b"));
+        b.config_dir = Some(PathBuf::from("/Users/x/.claude-work"));
+        (a, b)
+    }
+
+    #[tokio::test]
+    async fn session_cursor_survives_within_lane_reorder() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1; // row 0 is the pinned orchestrator row
+        app.sync_session_cursor();
+        // Tab onto the second agent and note its account.
+        app.cycle_session(true);
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        let key = app.focused_account_key().expect("account key");
+        // The daemon re-sorts `agent_sessions` newest-active-first: b moves to the front.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1-2"),
+            "the cursor must follow the agent, not the slot"
+        );
+        assert_eq!(
+            app.focused_account_key().as_deref(),
+            Some(key.as_str()),
+            "the usage corner must keep the picked agent's account"
+        );
+    }
+
+    #[tokio::test]
+    async fn pin_on_arrival_does_not_follow_newest() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1;
+        // No explicit pick: arriving on the lane pins whatever is front-most at that moment.
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+        // b takes a turn and the daemon reorders — the default pick must not drift with it.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+    }
+
+    #[tokio::test]
+    async fn anchor_rides_out_a_flap_then_adopts_occupant() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        // One "refresh": a new daemon snapshot (refresh_gen advances) then the cursor sync,
+        // mirroring refresh_lanes + the event loop.
+        fn refresh(app: &mut App, sessions: Vec<AgentSession>) {
+            app.lanes[0].agent_sessions = sessions;
+            app.refresh_gen = app.refresh_gen.wrapping_add(1);
+            app.sync_session_cursor();
+        }
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![])];
+        app.selected = 1;
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        app.cycle_session(true); // pick b
+        // b's session flaps out for one snapshot: the cursor falls back without re-pinning…
+        refresh(&mut app, vec![a.clone()]);
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+        // …even while input events re-run the sync against the same bad snapshot…
+        for _ in 0..10 {
+            app.sync_session_cursor();
+        }
+        // …and re-lands on b the moment it reappears.
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1-2"),
+            "a one-tick flap must not lose the pick"
+        );
+        // A sustained absence is a real exit: the pick re-pins to the current occupant and
+        // stays there even when the old identity's window name is later reused.
+        for _ in 0..=(SESSION_REF_GRACE as usize) {
+            refresh(&mut app, vec![a.clone()]);
+        }
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1"),
+            "after a sustained absence the pick belongs to the occupant"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_focus_pins_placeholder_then_upgrades_to_transcript() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, _) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // A second agent is spawned; its window appears before its transcript.
+        app.pending_focus_window = Some((1, "lane-1-2".to_string()));
+        let placeholder = managed("lane-1-2", None);
+        app.lanes[0].agent_sessions = vec![a.clone(), placeholder];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // The transcript lands and the daemon lists the new agent first (newest activity).
+        let b = managed("lane-1-2", Some("sid-b"));
+        app.lanes[0].agent_sessions = vec![b.clone(), a.clone()];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // A later reorder still can't move the cursor off the spawned agent.
+        app.lanes[0].agent_sessions = vec![a, b];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn notification_jump_pick_survives_resort() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // A notification jump lands on b by transcript id…
+        app.select_session(1, Some("sid-b"));
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // …and must hold through the next daemon re-sort.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn return_to_lane_restores_pick() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![
+            fake_lane(1, vec![a, b]),
+            fake_lane(2, vec![managed("lane-2", Some("sid-c"))]),
+        ];
+        app.selected = 1;
+        app.sync_session_cursor();
+        app.cycle_session(true); // pick b on lane 1
+        // Visit lane 2, then come back: the pick is restored by identity.
+        app.selected = 2;
+        app.sync_session_cursor();
+        app.selected = 1;
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -375,6 +375,15 @@ pub struct App {
     session_ref_miss_gen: u64,
     /// Bumped by every successful `refresh_lanes` — the anchor miss counter's clock.
     refresh_gen: u64,
+    /// Manual scroll offset for the Fleet page. `None` = follow the selection (the default:
+    /// the view keeps the selected lane centered); `Some(n)` = the user scrolled freely
+    /// (wheel / PgUp/PgDn) to read past the fold — e.g. the TODAY commit list. Any deliberate
+    /// selection move snaps back to `None`.
+    pub fleet_scroll: Option<usize>,
+    /// What `render_fleet` last showed: `(applied scroll, viewport height, max scroll)`.
+    /// Written each frame so scroll keys can start from the on-screen position and clamp
+    /// without re-deriving layout.
+    pub fleet_viewport: std::cell::Cell<(usize, usize, usize)>,
     /// The agent each lane had selected when you last left it (saved from `session_ref` on
     /// lane change), so returning to a multi-agent lane restores your pick instead of
     /// snapping back to the first slot. Keyed by a stable identity (transcript id / tmux
@@ -588,6 +597,8 @@ impl App {
             // Sentinel ≠ refresh_gen, so the very first snapshot's miss is counted too.
             session_ref_miss_gen: u64::MAX,
             refresh_gen: 0,
+            fleet_scroll: None,
+            fleet_viewport: std::cell::Cell::new((0, 0, 0)),
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
@@ -2214,8 +2225,19 @@ impl App {
                         }
                         _ => {}
                     },
-                    // Grid/Fleet: a left-click focuses the clicked lane (double-click opens its real
-                    // terminal, a click on empty space blurs); the wheel still navigates.
+                    // Fleet: the wheel scrolls the PAGE (lanes + the TODAY commits), not the
+                    // cursor — arrow keys and clicks snap the view back to the selection.
+                    View::Fleet => match me.kind {
+                        MouseEventKind::ScrollUp => self.fleet_scroll_by(true, 3),
+                        MouseEventKind::ScrollDown => self.fleet_scroll_by(false, 3),
+                        MouseEventKind::Down(MouseButton::Left) => {
+                            self.handle_click(me.column, me.row).await
+                        }
+                        _ => {}
+                    },
+                    // Grid (and the rest): a left-click focuses the clicked lane (double-click
+                    // opens its real terminal, a click on empty space blurs); the wheel still
+                    // navigates.
                     _ => match me.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
                             self.handle_click(me.column, me.row).await
@@ -2268,6 +2290,10 @@ impl App {
                 // `R` renames the selected agent sub-row in the expanded fleet sidebar.
                 if key.code == KeyCode::Char('R') {
                     self.start_rename();
+                } else if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown) {
+                    // Free-scroll the page (reaches the TODAY commits past the fold).
+                    let (_, h, _) = self.fleet_viewport.get();
+                    self.fleet_scroll_by(key.code == KeyCode::PageUp, h.saturating_sub(2).max(1));
                 } else if let Some(action) = keybinds::nav(key) {
                     self.apply(action).await;
                 }
@@ -3365,6 +3391,20 @@ impl App {
     /// A left-click in Grid/Fleet/Split. Hit-test the lane regions recorded during render: a click
     /// inside one focuses that lane (single-click → type in place for interactive zones; another
     /// click within `DOUBLE_CLICK` → open its real terminal). A click on empty space blurs.
+    /// Scroll the Fleet page manually (wheel / PgUp). Starts from the position currently on
+    /// screen, clamps to the rendered bounds, and stays in effect until the next deliberate
+    /// selection move snaps the view back to following the selection.
+    fn fleet_scroll_by(&mut self, up: bool, step: usize) {
+        let (applied, _, max) = self.fleet_viewport.get();
+        let cur = self.fleet_scroll.unwrap_or(applied).min(max);
+        let next = if up {
+            cur.saturating_sub(step)
+        } else {
+            (cur + step).min(max)
+        };
+        self.fleet_scroll = Some(next);
+    }
+
     async fn handle_click(&mut self, col: u16, row: u16) {
         // The pinned "repomind" row isn't a lane click-zone; hit-test it first: a click selects it
         // and opens the command-center view.
@@ -3392,6 +3432,8 @@ impl App {
         // Clicking a lane (or the gutter) leaves any repomind insert mode, since the selection is
         // moving off the pinned row.
         self.orch_insert = false;
+        // …and re-attaches a manually scrolled Fleet page to the (new) selection.
+        self.fleet_scroll = None;
         match hit {
             // A Grid shell tile: move the grid cursor onto it (input routes by active tile);
             // single-click types in place, double-click attaches into the real terminal.
@@ -4606,8 +4648,12 @@ impl App {
             self.repo_remove_armed = None;
         }
         match action {
-            Action::MoveUp => self.selected = self.selected.saturating_sub(1),
+            Action::MoveUp => {
+                self.fleet_scroll = None; // a deliberate move re-attaches the view to the cursor
+                self.selected = self.selected.saturating_sub(1);
+            }
             Action::MoveDown => {
+                self.fleet_scroll = None;
                 let n = self.rows_len();
                 if n > 0 && self.selected + 1 < n {
                     self.selected += 1;
@@ -5965,6 +6011,54 @@ mod tests {
         app.selected = 1;
         app.sync_session_cursor();
         assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn fleet_page_scrolls_to_reach_all_commits() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        let (a, _) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a])];
+        app.selected = 1;
+        let now = chrono::Utc::now().to_rfc3339();
+        app.commits = (1..=20)
+            .map(|i| {
+                serde_json::from_value(json!({
+                    "oid": "0".repeat(40),
+                    "repo_id": 1,
+                    "author_name": "t",
+                    "author_email": "t@t",
+                    "summary": format!("commit-number-{i:02}"),
+                    "time": now,
+                    "parent_count": 1,
+                }))
+                .expect("fake commit")
+            })
+            .collect();
+        // Follow-selection mode: the page top (lanes) is on screen, the commit tail is not.
+        let top = crate::render_to_string(&app, 100, 20).unwrap();
+        assert!(
+            top.contains("repomind"),
+            "page top visible in follow mode:\n{top}"
+        );
+        assert!(
+            !top.contains("commit-number-20"),
+            "the tail can't fit on one screen:\n{top}"
+        );
+        // Manual scroll reaches the very last commit — and everything past the old 12-cap.
+        app.fleet_scroll = Some(usize::MAX / 2);
+        let bottom = crate::render_to_string(&app, 100, 20).unwrap();
+        assert!(
+            bottom.contains("commit-number-20"),
+            "manual scroll must reach the last commit:\n{bottom}"
+        );
+        assert!(
+            bottom.contains("commit-number-13"),
+            "the 12-commit cap must be gone:\n{bottom}"
+        );
+        // A deliberate selection move snaps back to follow mode.
+        app.apply(Action::MoveUp).await;
+        assert_eq!(app.fleet_scroll, None);
     }
 
     #[test]

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -385,6 +385,9 @@ pub struct App {
     /// Cleared when matched (or after a few refreshes if the window never appears).
     pending_focus_window: Option<(LaneId, String)>,
     pending_focus_ticks: u8,
+    /// The `refresh_gen` the last pending-focus miss was counted against — the give-up
+    /// clock ticks per data refresh, not per event-loop iteration.
+    pending_focus_gen: u64,
     /// Plain shell terminals open for the selected lane (tmux window names).
     pub terminals: Vec<String>,
     terminals_lane: Option<LaneId>,
@@ -588,6 +591,7 @@ impl App {
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
+            pending_focus_gen: u64::MAX,
             terminals: Vec::new(),
             terminals_lane: None,
             term_windows: Vec::new(),
@@ -1721,10 +1725,16 @@ impl App {
                         return;
                     }
                     None => {
-                        self.pending_focus_ticks = self.pending_focus_ticks.saturating_add(1);
-                        if self.pending_focus_ticks > PENDING_FOCUS_GIVE_UP_TICKS {
-                            self.pending_focus_window = None;
-                            self.pending_focus_ticks = 0;
+                        // Count the give-up clock in data REFRESHES, not event-loop
+                        // iterations — this sync runs per input event, and a burst of
+                        // keystrokes during one slow snapshot must not drop the intent.
+                        if self.pending_focus_gen != self.refresh_gen {
+                            self.pending_focus_gen = self.refresh_gen;
+                            self.pending_focus_ticks = self.pending_focus_ticks.saturating_add(1);
+                            if self.pending_focus_ticks > PENDING_FOCUS_GIVE_UP_TICKS {
+                                self.pending_focus_window = None;
+                                self.pending_focus_ticks = 0;
+                            }
                         }
                     }
                 }
@@ -1743,7 +1753,16 @@ impl App {
             }) = self.selected_row()
             {
                 let lane_id = self.selected_lane().map(|l| l.id);
-                if self.session_idx != s || self.session_lane != lane_id {
+                // Same agent? Compare by identity, not raw index — the daemon re-sorts
+                // `agent_sessions` as agents take turns, so the same agent's row carries a
+                // new index after every re-sort; wiping the scrollback for that would kick
+                // the user out of what they were reading.
+                let same_agent = self.session_lane == lane_id
+                    && self.session_ref.as_ref().and_then(|r| {
+                        self.selected_lane()
+                            .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
+                    }) == Some(s);
+                if !same_agent {
                     self.reset_scroll();
                 }
                 self.session_lane = lane_id;
@@ -4926,10 +4945,11 @@ fn session_rank(
     }
 }
 
-/// A stable identity for one agent session within a lane, used to remember which agent a lane
-/// had selected across a switch away and back. The persistent `id` is `0` for daemon-overlaid
-/// placeholders so it can't be used; the managed tmux window (preferred) and the Claude
-/// transcript id are the durable handles the rest of the app already keys on.
+/// A stable identity for one agent session within a lane — the session cursor's anchor and
+/// the per-lane selection memory. The persistent `id` is `0` for daemon-overlaid
+/// placeholders so it can't be used; the Claude transcript id (preferred — UUIDs are never
+/// reused, while slot names are recycled on respawn) and the managed tmux window (the
+/// placeholder fallback) are the durable handles. See [`agent_session_ref`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SessionRef {
     Window(String),
@@ -5850,6 +5870,60 @@ mod tests {
         assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
         // A later reorder still can't move the cursor off the spawned agent.
         app.lanes[0].agent_sessions = vec![a, b];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn expanded_row_resort_keeps_scroll_on_same_agent() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = true;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        // Land the fleet cursor on b's sub-row (rows: orchestrator, header, sub, sub).
+        app.select_lane_session(1, Some(SessionRef::Transcript("sid-b".into())));
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        app.scroll = 7;
+        // The daemon re-sorts; refresh_lanes re-anchors the row by identity — same agent,
+        // new raw index. That must not read as a switch and wipe the scrollback position.
+        app.lanes[0].agent_sessions = vec![b.clone(), a.clone()];
+        app.select_lane_session(1, Some(SessionRef::Transcript("sid-b".into())));
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        assert_eq!(
+            app.scroll, 7,
+            "a re-sort of the same agent must keep the scroll"
+        );
+        // A real move to the other agent still resets it.
+        app.cycle_session(true);
+        assert_eq!(app.scroll, 0);
+    }
+
+    #[tokio::test]
+    async fn pending_focus_survives_input_burst() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, _) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // An agent was just spawned; its window hasn't shown up in lane.list yet.
+        app.pending_focus_window = Some((1, "lane-1-2".to_string()));
+        // A burst of input events re-runs the sync many times against the SAME snapshot:
+        // the give-up clock counts data refreshes, not event-loop iterations.
+        for _ in 0..20 {
+            app.sync_session_cursor();
+        }
+        assert!(
+            app.pending_focus_window.is_some(),
+            "spawn-focus intent must survive an input burst"
+        );
+        // The window appears on the next refresh: the cursor lands on it.
+        app.lanes[0].agent_sessions = vec![a, managed("lane-1-2", None)];
+        app.refresh_gen = app.refresh_gen.wrapping_add(1);
         app.sync_session_cursor();
         assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
     }

--- a/crates/repomon-tui/src/view.rs
+++ b/crates/repomon-tui/src/view.rs
@@ -17,7 +17,7 @@ use crate::keybinds::View;
 use crate::notify::NotifKind;
 use crate::theme;
 
-const FLEET_KEYS: &str = "↑↓ ↵ open · click select · dbl terminal  ·  n new · e spawn · t term · R rename  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · v peek · g/G needs-you · C auto-cont  ·  O repomind · 2 timeline · 3 sessions · 4 search  ·  spc grid · ? help · q";
+const FLEET_KEYS: &str = "↑↓ ↵ open · click select · dbl terminal · wheel/PgUp scroll  ·  n new · e spawn · t term · R rename  ·  a add-repo · A agents · , settings · d del · X rm-repo  ·  / filter · f find · ! urgent · v peek · g/G needs-you · C auto-cont  ·  O repomind · 2 timeline · 3 sessions · 4 search  ·  spc grid · ? help · q";
 const SPLIT_KEYS: &str = "↑↓ lane · tab session  ·  click focus · wheel/PgUp scroll · dbl terminal · ↵ open · → focus · i quick-type  ·  v peek · e spawn · o adopt · R rename · C auto-cont  ·  ←/esc back";
 const SPLIT_INSERT_KEYS: &str =
     "keys → agent (esc · ⇧⇥ · ^C sent) · PgUp/PgDn scroll  ·  ^O / click-out blur";
@@ -1084,13 +1084,21 @@ fn render_fleet(f: &mut Frame, app: &App) {
     let content = rows[0];
     let (lines, selected_line, lane_rows, brain_line) = fleet_lines(app, content);
     // Scroll so the selected lane stays on screen (roughly centered), clamped to the list bounds —
-    // this is what lets the fleet grow past one screenful and still be navigable with ↑/↓.
+    // this is what lets the fleet grow past one screenful and still be navigable with ↑/↓. A
+    // manual offset (wheel / PgUp — set while reading past the fold, e.g. the TODAY commits)
+    // overrides the follow-selection position until the next deliberate selection move.
     let h = content.height as usize;
     let max_scroll = lines.len().saturating_sub(h);
-    let scroll = selected_line
-        .map(|sl| sl.saturating_sub(h / 2))
-        .unwrap_or(0)
+    let scroll = app
+        .fleet_scroll
+        .unwrap_or_else(|| {
+            selected_line
+                .map(|sl| sl.saturating_sub(h / 2))
+                .unwrap_or(0)
+        })
         .min(max_scroll);
+    // What's on screen this frame — scroll keys start from here and clamp against it.
+    app.fleet_viewport.set((scroll, h, max_scroll));
     // Register the pinned repomind row's on-screen rect (scroll-adjusted) so a click opens the view.
     if let Some(bli) = brain_line {
         if bli >= scroll && bli < scroll + h {
@@ -2344,7 +2352,8 @@ fn fleet_lines(
     lines.push(section_header(width, "TODAY", "", &tz_offset(), app));
     lines.push(rule(width, false, app));
     lines.push(Line::raw(""));
-    for c in app.commits.iter().take(12) {
+    // Every commit — the page scrolls (wheel / PgUp), so nothing is silently cut off.
+    for c in &app.commits {
         lines.push(commit_line(c, app));
     }
     if !app.status.is_empty() {


### PR DESCRIPTION
## Problem

Switching between agents showed agent A's usage limits while agent B was selected, and user-assigned agent names appeared to jump between agents whenever sidebar positions shifted.

Two independent root causes:

1. **The TUI's in-lane agent cursor was positional.** `session_idx` indexes `lane.agent_sessions`, which the daemon re-sorts newest-activity-first on every poll; the index was only re-derived by identity on lane *change*, so sitting on a lane let the cursor silently drift onto whichever agent occupied that slot. The usage corner (`focused_account_key`) and key/capture routing (`selected_window`) then targeted the wrong agent.
2. **The daemon re-paired transcripts to tmux windows positionally every tick** (newest-activity transcripts zipped against slot-ordered windows). When two agents swapped activity rank, each transcript's `tmux_window` re-bound to the other window, moving names, panes, and usage accounts between rows. Labels themselves were always correctly keyed by transcript id; the pairing moved the rows out from under them.

## Fix

**Daemon: sticky transcript-window pairing.** Pairing is anchored by a `@repomon_session` tmux window option: stamped once at first contact, honored on every subsequent tick, read back at zero cost through the existing `list-windows` probe. Bindings live in tmux, so they survive daemon restarts and die with their window (slot-name recycling handled for free). First-contact heuristics run once, ordered by window id (never reused) rather than recyclable slot names.

Lifecycle hardening (from an adversarial multi-agent review of the initial design):
- Stamps are written only for transcripts that are **actively writing** — a stale transcript standing in during the spawn race (the `.jsonl` appears a beat after the window) is displayed but never bound, so a guess can't wedge.
- **Supersession**: `/clear` and fork-on-resume rotate the session id inside a window; when fresh unclaimed transcripts outnumber free windows, the *warmest* stale binding (the one that just went quiet, i.e. the rotated predecessor) is released and re-stamped to the live transcript. Idle fleets are never shuffled.
- Truncation protects both bound transcripts (a live window proves its agent) and actively-writing ones (the fresh backstop).
- Stamps target window **ids**, are skipped on ticks that ran on the last-good window snapshot, and `agent.adopt` stamps its resumed session id itself — ground truth instead of a guess.

**TUI: identity-anchored session cursor.** The cursor is pinned to a durable `SessionRef` (transcript id first — UUIDs are never reused; window name only for placeholders) and re-resolved every sync tick. Deliberate moves (Tab, notification jumps, spawn focus, expanded rows) funnel through the pin; an unanchored lane pins on arrival; a missing agent is tolerated for a few refreshes (overlay flap) before adopting the occupant. Expanded-mode rows compare identity, not raw index, before wiping scrollback, and the spawn-focus give-up clock counts data refreshes rather than event-loop iterations.

## Verification

- 30 new unit tests across daemon pairing/selection and TUI cursor behavior; full workspace suite and clippy green.
- Live e2e in an isolated instance (own socket/DB/config/tmux server): pairing held through activity flips, a daemon restart (bindings read back from tmux), slot-name recycling, and a `/clear` rotation (the rotated window re-stamped to the continuation; the idle agent untouched).

No wire changes: `AgentSession` fields and lane.list ordering are untouched, so the iOS companion and older TUIs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)