### PR TITLE
feat(daemon): multi-device remote with per-device tokens and per-connection streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repomon-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "repomon-daemon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "a2",
  "base64 0.22.1",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "repomon-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "repomon-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Ali Hamza Azam"]

--- a/crates/repomon-core/migrations/0006_remote_devices.sql
+++ b/crates/repomon-core/migrations/0006_remote_devices.sql
@@ -1,0 +1,13 @@
+-- Per-device remote-access credentials. Pairing mints one named, individually-revocable bearer
+-- token per companion device (superseding the single shared `[remote] token` in config.toml,
+-- which keeps working alongside these). Tokens are stored in plaintext deliberately: same threat
+-- model as the config-file token they replace. Hashing them at rest is a future-hardening
+-- candidate once the config token is retired.
+CREATE TABLE remote_devices (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  token TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL DEFAULT 'full',
+  created_at TEXT NOT NULL,
+  last_seen_at TEXT
+);

--- a/crates/repomon-core/src/client.rs
+++ b/crates/repomon-core/src/client.rs
@@ -64,6 +64,13 @@ struct Inner {
     /// Params of the last successful `subscribe` call, if any. `reconnect` replays it on the new
     /// connection — the daemon only forwards events to connections that asked for them.
     subscribe_params: Mutex<Option<Option<Value>>>,
+    /// Params of the currently-active `agent.watch_bytes` (`on:true`), or `None` when the last watch
+    /// was turned off. Byte watches are per-connection on the daemon, so they die with the old
+    /// socket on a transparent reconnect; `reconnect` replays this right after `subscribe` so the
+    /// TUI's Focus-view emulator keeps streaming instead of freezing until the user re-enters Focus.
+    /// A single slot suffices: the TUI holds one live emulator at a time and always turns the
+    /// previous watch off (`on:false`) before starting the next.
+    active_watch: Mutex<Option<Value>>,
     /// Bumped every time `spawn_io` starts a new connection. A reader task captures its own
     /// epoch at spawn and only runs disconnect cleanup if it's still current, so a stale reader
     /// from a superseded connection can't clobber a healthy reconnect.
@@ -93,6 +100,7 @@ impl DaemonClient {
             connected: AtomicBool::new(false),
             reconnecting: tokio::sync::Mutex::new(()),
             subscribe_params: Mutex::new(None),
+            active_watch: Mutex::new(None),
             epoch: AtomicU64::new(0),
         });
         inner.spawn_io(stream);
@@ -136,6 +144,17 @@ impl DaemonClient {
                     }
                     if method == "subscribe" {
                         *self.inner.subscribe_params.lock().unwrap() = Some(params.clone());
+                    }
+                    if method == "agent.watch_bytes" {
+                        // Track the live watch so `reconnect` can re-assert it. `on:true` records
+                        // the params; `on:false` (the stop path) clears them.
+                        let on = params
+                            .as_ref()
+                            .and_then(|p| p.get("on"))
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        *self.inner.active_watch.lock().unwrap() =
+                            if on { params.clone() } else { None };
                     }
                     return Ok(resp.result.unwrap_or(Value::Null));
                 }
@@ -247,6 +266,20 @@ impl Inner {
                 let _ = out.send(bytes).await;
             }
         }
+
+        // Re-assert the active byte watch the same way: the daemon's watch was per-connection and
+        // died with the old socket, so without this the Focus emulator's stream stays dead until the
+        // user leaves and re-enters Focus. Same fire-and-forget path as the subscribe replay (the
+        // ack lands on an id nobody awaits and is harmlessly dropped by the reader).
+        let watch = self.active_watch.lock().unwrap().clone();
+        if let Some(params) = watch {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let req = Request::new(id, "agent.watch_bytes", Some(params));
+            if let Ok(bytes) = serde_json::to_vec(&req) {
+                let out = self.out_tx.lock().unwrap().clone();
+                let _ = out.send(bytes).await;
+            }
+        }
         Ok(())
     }
 }
@@ -307,6 +340,143 @@ mod tests {
         );
     }
 
+    /// A transparent reconnect must replay BOTH the subscription and the active byte watch, so the
+    /// Focus-view emulator's stream survives instead of freezing (Finding 3). We record the methods
+    /// the latest server-side connection sees; after forcing a reconnect, the fresh connection must
+    /// receive `subscribe` and the `on:true` `agent.watch_bytes` again before the triggering call.
+    #[tokio::test]
+    async fn reconnect_replays_subscribe_and_active_watch() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("d.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        // Methods seen on the LATEST server-side connection (reset on each accept).
+        let latest: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let accepts = Arc::new(AtomicUsize::new(0));
+        {
+            let latest = latest.clone();
+            let accepts = accepts.clone();
+            tokio::spawn(async move {
+                loop {
+                    let (stream, _) = listener.accept().await.unwrap();
+                    accepts.fetch_add(1, Ordering::SeqCst);
+                    latest.lock().unwrap().clear();
+                    let latest = latest.clone();
+                    tokio::spawn(async move {
+                        let (mut rd, mut wr) = stream.into_split();
+                        while let Ok(Some(frame)) = read_frame(&mut rd).await {
+                            if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
+                                latest.lock().unwrap().push(req.method.clone());
+                                let _ =
+                                    write_message(&mut wr, &Response::ok(req.id, Value::Null)).await;
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        let client = DaemonClient::connect_inner(&sock, None).await.unwrap();
+        client
+            .call("subscribe", Some(serde_json::json!({ "topics": ["*"] })))
+            .await
+            .unwrap();
+        client
+            .call(
+                "agent.watch_bytes",
+                Some(serde_json::json!({ "lane_id": 1, "window": "lane-1", "on": true })),
+            )
+            .await
+            .unwrap();
+
+        // Force a reconnect: mark the connection dead so the next call opens a fresh socket, which
+        // must replay subscribe + the active watch before the ping.
+        client.inner.connected.store(false, Ordering::SeqCst);
+        client.call("ping", None).await.unwrap();
+
+        // Wait for the new connection's replay frames to land.
+        let mut ok = false;
+        for _ in 0..100 {
+            {
+                let seen = latest.lock().unwrap();
+                if seen.iter().any(|m| m == "subscribe")
+                    && seen.iter().any(|m| m == "agent.watch_bytes")
+                {
+                    ok = true;
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            accepts.load(Ordering::SeqCst) >= 2,
+            "the reconnect opened a second connection"
+        );
+        assert!(
+            ok,
+            "the reconnect replayed subscribe and the active byte watch, got {:?}",
+            latest.lock().unwrap()
+        );
+    }
+
+    /// A watch turned off (`on:false`) must NOT be replayed on reconnect.
+    #[tokio::test]
+    async fn reconnect_does_not_replay_a_stopped_watch() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("d.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let latest: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        {
+            let latest = latest.clone();
+            tokio::spawn(async move {
+                loop {
+                    let (stream, _) = listener.accept().await.unwrap();
+                    latest.lock().unwrap().clear();
+                    let latest = latest.clone();
+                    tokio::spawn(async move {
+                        let (mut rd, mut wr) = stream.into_split();
+                        while let Ok(Some(frame)) = read_frame(&mut rd).await {
+                            if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
+                                latest.lock().unwrap().push(req.method.clone());
+                                let _ =
+                                    write_message(&mut wr, &Response::ok(req.id, Value::Null)).await;
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        let client = DaemonClient::connect_inner(&sock, None).await.unwrap();
+        client
+            .call(
+                "agent.watch_bytes",
+                Some(serde_json::json!({ "lane_id": 1, "window": "lane-1", "on": true })),
+            )
+            .await
+            .unwrap();
+        // Stop it — the active-watch slot must clear.
+        client
+            .call(
+                "agent.watch_bytes",
+                Some(serde_json::json!({ "lane_id": 1, "on": false })),
+            )
+            .await
+            .unwrap();
+
+        client.inner.connected.store(false, Ordering::SeqCst);
+        client.call("ping", None).await.unwrap();
+
+        // Give any (erroneous) replay time to arrive, then assert none did.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let seen = latest.lock().unwrap();
+        assert!(
+            !seen.iter().any(|m| m == "agent.watch_bytes"),
+            "a stopped watch must not be replayed, got {seen:?}"
+        );
+    }
+
     /// A reader task belonging to a since-superseded connection must not run disconnect cleanup
     /// on top of a healthy newer one. Drives `Inner::spawn_io` directly (bypassing `reconnect`'s
     /// serialization) to simulate the old reader noticing EOF only after the new connection is
@@ -327,6 +497,7 @@ mod tests {
             connected: AtomicBool::new(false),
             reconnecting: tokio::sync::Mutex::new(()),
             subscribe_params: Mutex::new(None),
+            active_watch: Mutex::new(None),
             epoch: AtomicU64::new(0),
         });
 

--- a/crates/repomon-core/src/model.rs
+++ b/crates/repomon-core/src/model.rs
@@ -40,6 +40,19 @@ pub struct Repo {
     pub worktree_root_template: Option<String>,
 }
 
+/// A paired remote-access device: one named, individually-revocable bearer token minted at
+/// pairing. `token` is stored plaintext (same threat model as the legacy config-file token) and
+/// never crosses the remote bridge or `remote.devices` output. `role` is `"full"` today (the
+/// bridge's default-deny allowlist is the real authority); the column exists for future scoping.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteDevice {
+    pub name: String,
+    pub token: String,
+    pub role: String,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+}
+
 /// A single worktree of a repo (the main checkout is also a worktree).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Worktree {

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -23,12 +23,18 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0003_devices.sql"),
     include_str!("../../migrations/0004_session_labels.sql"),
     include_str!("../../migrations/0005_lanes_autoincrement.sql"),
+    include_str!("../../migrations/0006_remote_devices.sql"),
 ];
 
 /// Cap on registered push devices. Re-registration refreshes a token's timestamp; beyond this the
 /// oldest are evicted, so a misbehaving/abusive client can't grow the table (or per-alert APNs
 /// fan-out) without bound.
 const MAX_DEVICES: usize = 32;
+
+/// Cap on paired remote devices. Unlike push tokens (evicted oldest-first), these are live access
+/// credentials, so pairing a new distinct device past the cap errors rather than silently evicting
+/// one — dropping a credential out from under an in-use device would lock it out without warning.
+const MAX_REMOTE_DEVICES: usize = 16;
 
 type Job = Box<dyn FnOnce(&mut Connection) + Send + 'static>;
 
@@ -355,6 +361,79 @@ impl Store {
         .await
     }
 
+    // ---- remote devices ------------------------------------------------------
+
+    /// Mint-or-return a per-device remote token. Re-pairing an existing `name` returns the same
+    /// row unchanged (so re-showing the QR is idempotent); a new name mints a fresh 32-byte token
+    /// and inserts it. The table is capped at [`MAX_REMOTE_DEVICES`]: a new distinct name past the
+    /// cap errors rather than evicting, because these are live credentials.
+    pub async fn remote_device_pair(&self, name: &str) -> Result<RemoteDevice> {
+        let name = name.to_string();
+        self.call(move |c| {
+            // Existing device: return it as-is (a stable QR for the same phone).
+            if let Some(dev) = remote_device_by_name(c, &name)? {
+                return Ok(dev);
+            }
+            let count: i64 = c.query_row("SELECT COUNT(*) FROM remote_devices", [], |r| r.get(0))?;
+            if count as usize >= MAX_REMOTE_DEVICES {
+                return Err(Error::Other(format!(
+                    "remote device limit reached ({MAX_REMOTE_DEVICES}); revoke a device before pairing a new one"
+                )));
+            }
+            let now = Utc::now();
+            let token = generate_remote_token();
+            c.execute(
+                "INSERT INTO remote_devices(name, token, role, created_at, last_seen_at)
+                 VALUES(?1, ?2, 'full', ?3, NULL)",
+                params![name, token, to_iso(&now)],
+            )?;
+            Ok(RemoteDevice {
+                name,
+                token,
+                role: "full".into(),
+                created_at: now,
+                last_seen_at: None,
+            })
+        })
+        .await
+    }
+
+    /// All paired remote devices, oldest first (`created_at`, ties broken by insertion order).
+    pub async fn remote_device_list(&self) -> Result<Vec<RemoteDevice>> {
+        self.call(|c| {
+            let mut stmt = c.prepare(
+                "SELECT name, token, role, created_at, last_seen_at FROM remote_devices \
+                 ORDER BY created_at, id",
+            )?;
+            let rows = stmt.query_map([], remote_device_from_row)?;
+            collect(rows)
+        })
+        .await
+    }
+
+    /// Revoke a device's token by name. `Ok(false)` when no such device exists.
+    pub async fn remote_device_revoke(&self, name: &str) -> Result<bool> {
+        let name = name.to_string();
+        self.call(move |c| {
+            let n = c.execute("DELETE FROM remote_devices WHERE name = ?1", params![name])?;
+            Ok(n > 0)
+        })
+        .await
+    }
+
+    /// Stamp a device's `last_seen_at` to now. A no-op (not an error) for an unknown name.
+    pub async fn remote_device_seen(&self, name: &str) -> Result<()> {
+        let name = name.to_string();
+        self.call(move |c| {
+            c.execute(
+                "UPDATE remote_devices SET last_seen_at = ?2 WHERE name = ?1",
+                params![name, to_iso(&Utc::now())],
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
     pub async fn list_lane_meta(&self) -> Result<Vec<LaneMeta>> {
         self.call(|c| {
             let mut stmt = c.prepare(
@@ -633,6 +712,40 @@ fn oid_col(row: &Row, idx: usize) -> rusqlite::Result<gix::ObjectId> {
     })
 }
 
+fn remote_device_from_row(r: &Row) -> rusqlite::Result<RemoteDevice> {
+    Ok(RemoteDevice {
+        name: r.get(0)?,
+        token: r.get(1)?,
+        role: r.get(2)?,
+        created_at: dt_col(r, 3)?,
+        last_seen_at: opt_dt_col(r, 4)?,
+    })
+}
+
+/// Look up a single remote device by its unique name, if present.
+fn remote_device_by_name(c: &Connection, name: &str) -> rusqlite::Result<Option<RemoteDevice>> {
+    match c.query_row(
+        "SELECT name, token, role, created_at, last_seen_at FROM remote_devices WHERE name = ?1",
+        params![name],
+        remote_device_from_row,
+    ) {
+        Ok(dev) => Ok(Some(dev)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// A fresh 32-byte hex bearer token from the OS entropy pool. Mirrors the CLI's `remote enable`
+/// generator (`repomon-tui::cli::generate_token`), kept dependency-free by reading `/dev/urandom`.
+fn generate_remote_token() -> String {
+    use std::io::Read;
+    let mut buf = [0u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut buf))
+        .expect("read /dev/urandom");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 fn repo_from_row(r: &Row) -> rusqlite::Result<Repo> {
     Ok(Repo {
         id: r.get(0)?,
@@ -742,6 +855,86 @@ mod tests {
                 .any(|t| t == &format!("token-{:03}", MAX_DEVICES + 4))
         );
         assert!(!devices.iter().any(|t| t == "token-000"));
+    }
+
+    #[tokio::test]
+    async fn remote_device_pair_mints_or_returns() {
+        let s = store().await;
+        let a = s.remote_device_pair("phone").await.unwrap();
+        assert_eq!(a.name, "phone");
+        assert_eq!(a.role, "full");
+        assert!(a.token.len() >= 32, "token is 32+ bytes of entropy");
+        assert!(a.last_seen_at.is_none());
+        // Re-pairing the SAME name returns the identical row (a stable QR), no new insert.
+        let again = s.remote_device_pair("phone").await.unwrap();
+        assert_eq!(a.token, again.token);
+        assert_eq!(s.remote_device_list().await.unwrap().len(), 1);
+        // A different name mints a fresh, distinct token.
+        let b = s.remote_device_pair("ipad").await.unwrap();
+        assert_ne!(a.token, b.token);
+        assert_eq!(s.remote_device_list().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn remote_device_pair_caps_without_evicting() {
+        let s = store().await;
+        for i in 0..MAX_REMOTE_DEVICES {
+            s.remote_device_pair(&format!("dev-{i:02}")).await.unwrap();
+        }
+        // A NEW distinct name past the cap errors (credentials are never silently evicted).
+        assert!(s.remote_device_pair("one-too-many").await.is_err());
+        assert_eq!(
+            s.remote_device_list().await.unwrap().len(),
+            MAX_REMOTE_DEVICES
+        );
+        // Re-pairing an EXISTING name still works at the cap (returns the row, no insert).
+        assert!(s.remote_device_pair("dev-00").await.is_ok());
+        assert_eq!(
+            s.remote_device_list().await.unwrap().len(),
+            MAX_REMOTE_DEVICES
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_device_revoke_true_then_false() {
+        let s = store().await;
+        s.remote_device_pair("phone").await.unwrap();
+        assert!(s.remote_device_revoke("phone").await.unwrap(), "first revoke removes it");
+        assert!(
+            !s.remote_device_revoke("phone").await.unwrap(),
+            "revoking a gone device is false"
+        );
+        assert!(s.remote_device_list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_device_seen_stamps_last_seen() {
+        let s = store().await;
+        s.remote_device_pair("phone").await.unwrap();
+        assert!(s.remote_device_list().await.unwrap()[0].last_seen_at.is_none());
+        s.remote_device_seen("phone").await.unwrap();
+        assert!(
+            s.remote_device_list().await.unwrap()[0].last_seen_at.is_some(),
+            "last_seen_at is stamped"
+        );
+        // Stamping an unknown device is a harmless no-op (no error).
+        s.remote_device_seen("ghost").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn remote_device_list_ordered_by_created() {
+        let s = store().await;
+        for name in ["first", "second", "third"] {
+            s.remote_device_pair(name).await.unwrap();
+        }
+        let names: Vec<String> = s
+            .remote_device_list()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        assert_eq!(names, ["first", "second", "third"]);
     }
 
     #[tokio::test]

--- a/crates/repomon-daemon/src/bytes_stream.rs
+++ b/crates/repomon-daemon/src/bytes_stream.rs
@@ -21,12 +21,16 @@
 //!
 //! GENERATION / EOF race: lifecycle is EOF-driven — `pipe-pane` (off) or the window dying kills
 //! the `cat`, whose write end closing EOFs the reader, which exits and removes the fifo. Each
-//! fresh pipe (a first watcher creating a new entry) gets a globally-unique `generation`. On EOF
-//! the reader drops its own map entry ONLY if the entry's generation still matches the one it was
-//! started with. Without this, a rapid stop→start of the same window (the fifo path is
-//! deterministic per window) could have a dying reader delete the freshly-started entry, leaving
-//! `watched_bytes` pointing at a live window whose entry is gone — it would accept refs and stream
-//! nothing.
+//! fresh pipe (a first watcher creating a new entry) gets a globally-unique `generation`, and the
+//! generation is embedded in the fifo FILENAME, so two pipe instances of the same window never
+//! share a path. That makes the reader's EOF unlink inherently safe: it can only ever remove its
+//! own fifo, never a successor's — without the unique name, a rapid unwatch→rewatch of the same
+//! window could have the dying reader unlink the NEW pipe's fifo just before `cat > fifo` opens
+//! it, turning the fifo into a plain file that streams nothing while the fresh reader leaks. The
+//! reader additionally drops its own map entry ONLY if the entry's generation still matches the
+//! one it was started with; without that, the same race would delete the freshly-started entry,
+//! leaving `watched_bytes` pointing at a live window whose entry is gone — it would accept refs
+//! and stream nothing.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -110,8 +114,14 @@ pub async fn watch(
     }
 
     let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
-    let fifo =
-        std::env::temp_dir().join(format!("repomon-bytes-{}-{window}.fifo", tmux.session()));
+    // The generation is part of the fifo NAME: pipe instances of the same window never collide on
+    // a path, so a superseded reader's EOF unlink can only ever remove its own fifo (see the
+    // module doc). The pre-mkfifo unlink still guards the one same-path case left — a leftover
+    // fifo from a previous daemon run (the counter restarts at 0).
+    let fifo = std::env::temp_dir().join(format!(
+        "repomon-bytes-{}-{window}-{generation}.fifo",
+        tmux.session()
+    ));
     let _ = std::fs::remove_file(&fifo);
     let ok = Command::new("mkfifo")
         .arg(&fifo)
@@ -133,9 +143,10 @@ pub async fn watch(
         },
     );
 
-    // Reader first: its open() is the rendezvous with cat's write-side open. On EOF it removes the
-    // fifo and drops its own entry, but only while that entry is still this pipe's (generation
-    // match) — a later watch of the same window supersedes it.
+    // Reader first: its open() is the rendezvous with cat's write-side open. On EOF it removes its
+    // fifo (safe unconditionally: the generation-unique name means it can only be its own, never a
+    // successor's) and drops its own entry, the latter only while the entry is still this pipe's
+    // (generation match) — a later watch of the same window supersedes it.
     {
         let window = window.clone();
         let fifo = fifo.clone();

--- a/crates/repomon-daemon/src/bytes_stream.rs
+++ b/crates/repomon-daemon/src/bytes_stream.rs
@@ -1,4 +1,4 @@
-//! Streaming one pane's raw PTY bytes to the TUI — the embedded renderer's feed.
+//! Streaming one pane's raw PTY bytes — the embedded renderer's feed, shared across watchers.
 //!
 //! The mediated view is a poll → `capture-pane -e` → re-parse pipeline; the embedded renderer
 //! instead wants the pane's actual byte stream. `tmux pipe-pane` provides it: tmux runs a
@@ -6,16 +6,33 @@
 //! fifo and its reader; each chunk is broadcast as `event.agent.bytes` (base64 — PTY bytes are
 //! not valid UTF-8 at chunk boundaries).
 //!
-//! One watch at a time (the Focus view streams exactly one pane): starting a new watch stops
-//! the previous one. Lifecycle is EOF-driven — `pipe-pane` (off) or the window dying kills the
-//! `cat`, whose write end closing EOFs the reader, which exits and removes the fifo. A stale
-//! `BytesWatch` slot after that is harmless: [`stop`] is idempotent (pipe-pane off on a
-//! pipeless window is a no-op, removing a missing fifo is a no-op). ORDERING: the reader must
-//! open the fifo before `pipe-pane` starts `cat` — the fifo open is the rendezvous — so tmux
-//! never buffers behind a dead pipe.
+//! ONE PIPE PER WINDOW, SHARED. tmux allows only one `pipe-pane` per pane, so a window can have
+//! exactly one fifo/reader no matter how many clients watch it. The event bus already broadcasts
+//! every chunk to every subscriber; who actually *receives* a window's bytes is decided per
+//! connection at the forwarding loops (a connection forwards `event.agent.bytes` only for windows
+//! in its `watched_bytes` set). This module therefore refcounts watchers per window: the first
+//! watcher starts the pipe, later watchers just join the readership, and the pipe is torn down
+//! only when the last watcher leaves. A phone, an iPad, and the Mac TUI can all watch the same
+//! (or different) windows at once — the old single global slot let any new watch kill the
+//! previous one, which is exactly what broke concurrency.
+//!
+//! ORDERING: the reader must open the fifo before `pipe-pane` starts `cat` — the fifo open is the
+//! rendezvous — so tmux never buffers behind a dead pipe.
+//!
+//! GENERATION / EOF race: lifecycle is EOF-driven — `pipe-pane` (off) or the window dying kills
+//! the `cat`, whose write end closing EOFs the reader, which exits and removes the fifo. Each
+//! fresh pipe (a first watcher creating a new entry) gets a globally-unique `generation`. On EOF
+//! the reader drops its own map entry ONLY if the entry's generation still matches the one it was
+//! started with. Without this, a rapid stop→start of the same window (the fifo path is
+//! deterministic per window) could have a dying reader delete the freshly-started entry, leaving
+//! `watched_bytes` pointing at a live window whose entry is gone — it would accept refs and stream
+//! nothing.
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::Engine;
 use repomon_core::TmuxRuntime;
@@ -25,37 +42,76 @@ use tokio::sync::Mutex;
 
 use crate::pubsub::{self, EventTx};
 
-/// The active byte watch: which window streams and where its fifo lives.
-pub struct BytesWatch {
-    pub window: String,
+/// One window's single shared pipe-pane and the connections watching it.
+pub struct WatchEntry {
+    /// The lane this window belongs to (so `on:false`-without-window can match a session's watched
+    /// windows to a lane by field, not by resolving a default window name).
+    pub lane: LaneId,
+    /// The fifo tmux's `cat` writes into and the reader thread drains.
     pub fifo: PathBuf,
+    /// Connection ids sharing this window's single pipe. The pipe stops when this empties.
+    pub refs: HashSet<u64>,
+    /// Globally-unique tag for THIS pipe instance; guards EOF cleanup against a stop→restart race
+    /// (see the module doc).
+    pub generation: u64,
 }
+
+/// The registry of live byte watches, keyed by window. `Arc<Mutex<…>>` so an EOF reader thread can
+/// hold its own handle and remove its entry via `blocking_lock` when the pipe closes.
+pub type Watches = Arc<Mutex<HashMap<String, WatchEntry>>>;
 
 /// Largest chunk broadcast per event — keeps single events bounded while a busy pane floods.
 const CHUNK: usize = 16 * 1024;
 
-/// Stop the current byte watch, if any: turn the pane's pipe off (killing its `cat`, which
-/// EOFs the reader) and remove the fifo.
-pub async fn stop(tmux: &TmuxRuntime, slot: &Mutex<Option<BytesWatch>>) {
-    let Some(watch) = slot.lock().await.take() else {
-        return;
-    };
-    let t = tmux.clone();
-    let window = watch.window.clone();
-    let _ = tokio::task::spawn_blocking(move || t.pipe_pane_off_named(&window)).await;
-    let _ = std::fs::remove_file(&watch.fifo);
+/// Hands out a fresh generation to every new pipe instance. Global and monotonic: uniqueness
+/// across all windows is all the EOF guard needs.
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Release `conn_id` from an entry's readership; returns true once no watcher remains (the pipe
+/// must then be torn down). Pure — the refcount transition unit tests drive this directly.
+///
+/// An entry always holds at least one ref (it is created with one and removed the moment it
+/// empties), so `is_empty()` can only become true right after removing the entry's last watcher.
+/// Releasing a `conn_id` the entry never held is a harmless no-op that leaves it non-empty.
+fn release_ref(entry: &mut WatchEntry, conn_id: u64) -> bool {
+    entry.refs.remove(&conn_id);
+    entry.refs.is_empty()
 }
 
-/// Start streaming `window`'s bytes. The caller stops any previous watch first (the RPC
-/// handler always calls [`stop`] before this).
-pub async fn start(
+/// Whether the reader that started at `generation` still owns `window`'s entry — the EOF-cleanup
+/// guard. False if the entry is gone or has been superseded by a newer pipe. Pure.
+fn eof_entry_is_current(
+    map: &HashMap<String, WatchEntry>,
+    window: &str,
+    generation: u64,
+) -> bool {
+    map.get(window).is_some_and(|e| e.generation == generation)
+}
+
+/// Start (or join) a byte watch on `window` for `conn_id`.
+///
+/// - Entry exists → the pipe is already flowing; `conn_id` just joins the readership.
+/// - No entry → create the window's single pipe (remove any stale fifo, mkfifo, reader-first
+///   rendezvous, then `pipe-pane`) with a fresh generation and `refs = {conn_id}`.
+pub async fn watch(
     tmux: TmuxRuntime,
     events: EventTx,
-    slot: &Mutex<Option<BytesWatch>>,
+    watches: &Watches,
     lane: LaneId,
     window: String,
+    conn_id: u64,
 ) -> Result<(), String> {
-    let fifo = std::env::temp_dir().join(format!("repomon-bytes-{}-{window}.fifo", tmux.session()));
+    // Hold the lock across setup: a concurrent watcher of the SAME window must either join the
+    // entry we create or wait and find it — never start a second pipe (tmux allows only one).
+    let mut map = watches.lock().await;
+    if let Some(entry) = map.get_mut(&window) {
+        entry.refs.insert(conn_id);
+        return Ok(());
+    }
+
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
+    let fifo =
+        std::env::temp_dir().join(format!("repomon-bytes-{}-{window}.fifo", tmux.session()));
     let _ = std::fs::remove_file(&fifo);
     let ok = Command::new("mkfifo")
         .arg(&fifo)
@@ -67,15 +123,23 @@ pub async fn start(
         return Err(format!("mkfifo {} failed", fifo.display()));
     }
 
-    *slot.lock().await = Some(BytesWatch {
-        window: window.clone(),
-        fifo: fifo.clone(),
-    });
+    map.insert(
+        window.clone(),
+        WatchEntry {
+            lane,
+            fifo: fifo.clone(),
+            refs: HashSet::from([conn_id]),
+            generation,
+        },
+    );
 
-    // Reader first: its open() is the rendezvous with cat's write-side open.
+    // Reader first: its open() is the rendezvous with cat's write-side open. On EOF it removes the
+    // fifo and drops its own entry, but only while that entry is still this pipe's (generation
+    // match) — a later watch of the same window supersedes it.
     {
         let window = window.clone();
         let fifo = fifo.clone();
+        let watches = watches.clone();
         tokio::task::spawn_blocking(move || {
             use std::io::Read;
             let Ok(mut f) = std::fs::File::open(&fifo) else {
@@ -102,17 +166,71 @@ pub async fn start(
                 }
             }
             let _ = std::fs::remove_file(&fifo);
+            let mut map = watches.blocking_lock();
+            if eof_entry_is_current(&map, &window, generation) {
+                map.remove(&window);
+            }
         });
     }
 
     let t = tmux.clone();
     let win = window.clone();
     let fifo_w = fifo.clone();
-    tokio::task::spawn_blocking(move || t.pipe_pane_named(&win, &fifo_w))
+    let started = tokio::task::spawn_blocking(move || t.pipe_pane_named(&win, &fifo_w))
         .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())
+        .and_then(|r| r.map_err(|e| e.to_string()));
+    if let Err(e) = started {
+        // The pipe never started: drop the entry so it can't accept refs and stream nothing, and
+        // remove the fifo (the reader, still blocked on open(), is a pre-existing leak parity —
+        // no `cat` ever opens the write side, same as the old single-slot `start`).
+        map.remove(&window);
+        let _ = std::fs::remove_file(&fifo);
+        return Err(e);
+    }
     Ok(())
+}
+
+/// Release `conn_id` from `window`'s watch. When the last watcher leaves, turn the pane's pipe off
+/// (EOFing the reader) and remove the fifo and entry. Idempotent: releasing an unwatched window,
+/// or a conn that wasn't a watcher, is a no-op.
+pub async fn unwatch(tmux: &TmuxRuntime, watches: &Watches, window: &str, conn_id: u64) {
+    let mut map = watches.lock().await;
+    let Some(entry) = map.get_mut(window) else {
+        return;
+    };
+    if !release_ref(entry, conn_id) {
+        return; // other connections still share this window's pipe
+    }
+    let entry = map.remove(window).expect("entry present under the same lock");
+    drop(map);
+    let t = tmux.clone();
+    let win = window.to_string();
+    let _ = tokio::task::spawn_blocking(move || t.pipe_pane_off_named(&win)).await;
+    let _ = std::fs::remove_file(&entry.fifo);
+}
+
+/// Release `conn_id` from EVERY window it watches, stopping the pipes that thereby empty. Called
+/// from `Ctx::close_session` so a connection's byte watches die with it, whatever it was watching.
+pub async fn unwatch_all(tmux: &TmuxRuntime, watches: &Watches, conn_id: u64) {
+    let mut stopped: Vec<(String, PathBuf)> = Vec::new();
+    {
+        let mut map = watches.lock().await;
+        map.retain(|window, entry| {
+            if release_ref(entry, conn_id) {
+                stopped.push((window.clone(), entry.fifo.clone()));
+                false // this window's last watcher left: drop the entry
+            } else {
+                true
+            }
+        });
+    }
+    for (window, fifo) in stopped {
+        let t = tmux.clone();
+        let win = window.clone();
+        let _ = tokio::task::spawn_blocking(move || t.pipe_pane_off_named(&win)).await;
+        let _ = std::fs::remove_file(&fifo);
+    }
 }
 
 /// Startup sweep: turn `pipe-pane` off on every window of our session. A daemon that died with
@@ -125,4 +243,85 @@ pub async fn sweep(tmux: TmuxRuntime) {
         }
     })
     .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(refs: &[u64], generation: u64) -> WatchEntry {
+        WatchEntry {
+            lane: 1,
+            fifo: PathBuf::from("/tmp/none.fifo"),
+            refs: refs.iter().copied().collect(),
+            generation,
+        }
+    }
+
+    #[test]
+    fn release_ref_reports_empty_only_when_last_watcher_leaves() {
+        let mut e = entry(&[1, 2], 0);
+        // Removing one of two watchers leaves the pipe live.
+        assert!(!release_ref(&mut e, 1));
+        assert_eq!(e.refs.iter().copied().collect::<Vec<_>>(), vec![2]);
+        // Removing the last watcher empties it — the caller must stop the pipe.
+        assert!(release_ref(&mut e, 2));
+        assert!(e.refs.is_empty());
+    }
+
+    #[test]
+    fn release_ref_of_non_watcher_never_empties_a_live_entry() {
+        let mut e = entry(&[7], 0);
+        // Conn 99 never watched this window: no-op, still one watcher.
+        assert!(!release_ref(&mut e, 99));
+        assert!(e.refs.contains(&7));
+    }
+
+    #[test]
+    fn joining_watcher_shares_the_single_pipe() {
+        // Modelling `watch`'s "entry exists" branch: a second conn just joins the readership.
+        let mut e = entry(&[1], 5);
+        e.refs.insert(2);
+        assert_eq!(e.refs.len(), 2);
+        // The generation is untouched — the same pipe, not a new one.
+        assert_eq!(e.generation, 5);
+    }
+
+    #[test]
+    fn eof_guard_removes_only_the_current_generation() {
+        let mut map = HashMap::new();
+        map.insert("lane-1".to_string(), entry(&[1], 3));
+        // A reader from the current pipe (gen 3) owns the entry.
+        assert!(eof_entry_is_current(&map, "lane-1", 3));
+        // A stale reader (gen 2) from a superseded pipe must NOT delete the live entry.
+        assert!(!eof_entry_is_current(&map, "lane-1", 2));
+        // A window with no entry at all.
+        assert!(!eof_entry_is_current(&map, "lane-9", 3));
+    }
+
+    #[test]
+    fn unwatch_all_stops_only_the_windows_that_empty() {
+        // Conn 1 watches window A alone and shares window B with conn 2. Releasing conn 1 should
+        // stop A (its last watcher) but keep B (conn 2 still watches it).
+        let mut map = HashMap::new();
+        map.insert("A".to_string(), entry(&[1], 0));
+        map.insert("B".to_string(), entry(&[1, 2], 1));
+        let mut stopped: Vec<String> = Vec::new();
+        map.retain(|window, e| {
+            if release_ref(e, 1) {
+                stopped.push(window.clone());
+                false
+            } else {
+                true
+            }
+        });
+        assert_eq!(stopped, vec!["A".to_string()]);
+        assert!(!map.contains_key("A"));
+        assert!(map.contains_key("B"));
+        assert_eq!(
+            map["B"].refs.iter().copied().collect::<Vec<_>>(),
+            vec![2],
+            "conn 1 was released from the shared window too"
+        );
+    }
 }

--- a/crates/repomon-daemon/src/conn.rs
+++ b/crates/repomon-daemon/src/conn.rs
@@ -46,6 +46,14 @@ pub struct ConnSession {
     /// Windows this connection byte-watches. std Mutex: read on the event-forward hot path.
     /// (Populated by task A4; the field exists now so the struct is final.)
     pub watched_bytes: std::sync::Mutex<HashSet<String>>,
+    /// Snapshot of `(viewport lanes, viewport_windows)` used to filter `event.agent.output` on the
+    /// event-forward hot path. Deliberately duplicates the tokio `viewport`/`viewport_windows`
+    /// fields: those stay the source of truth for the async poll loop (`viewport_snapshot`), but
+    /// the forwarding loops must not `await`, so they read this std-Mutex mirror instead. The
+    /// `viewport.set` handler is the single writer and rewrites BOTH the tokio fields and this
+    /// snapshot together, so they never diverge. Empty at session creation, matching a connection
+    /// that has not yet asserted a viewport (it receives no output events).
+    pub output_filter: std::sync::Mutex<(HashSet<LaneId>, HashSet<String>)>,
     /// When this connection last drove an agent (send_input/signal/key/scroll/answer, and a fit
     /// that actually applied). `agent.fit`'s remote-vs-remote arbitration is last-interaction-wins.
     pub last_interaction: Mutex<Option<Instant>>,
@@ -61,6 +69,7 @@ impl ConnSession {
             viewport_focus_at: Mutex::new(None),
             viewport_windows: Mutex::new(Vec::new()),
             watched_bytes: std::sync::Mutex::new(HashSet::new()),
+            output_filter: std::sync::Mutex::new((HashSet::new(), HashSet::new())),
             last_interaction: Mutex::new(None),
         }
     }

--- a/crates/repomon-daemon/src/conn.rs
+++ b/crates/repomon-daemon/src/conn.rs
@@ -1,0 +1,95 @@
+//! Per-connection session state.
+//!
+//! Each live client connection (the local TUI over the Unix socket, or a companion app over the
+//! remote WebSocket bridge) owns one [`ConnSession`]. It holds what THIS device is looking at —
+//! the viewport it streams and the window it focuses — so an iPhone, an iPad, and the Mac TUI can
+//! each hold their own view at once. The capture poll loop streams the UNION across every live
+//! session (see [`crate::Ctx::viewport_snapshot`]), and `agent.fit` arbitrates pane sizing across
+//! them (see `rpc::fit_allowed`). This replaces the old daemon-global viewport/focus slots, which
+//! a second device would clobber.
+
+use std::collections::HashSet;
+use std::time::Instant;
+
+use repomon_core::model::LaneId;
+use tokio::sync::Mutex;
+
+/// What kind of transport a connection arrived on. `agent.fit` gives a Local (TUI) focus
+/// precedence over remote viewers; the device name is carried for a Remote so a session can be
+/// attributed to its paired device.
+#[derive(Debug, Clone)]
+pub enum ConnKind {
+    /// The local Unix-socket client (the TUI).
+    Local,
+    /// A companion app over the remote bridge. `device` is the paired device name, or `None` for
+    /// the legacy shared `[remote] token`.
+    Remote { device: Option<String> },
+}
+
+/// One client connection's streaming state — what THIS device is looking at. Replaces the old
+/// daemon-global viewport/focus slots so multiple devices can each hold their own view at once.
+pub struct ConnSession {
+    /// Monotonic connection id (from [`crate::Ctx::next_conn`]); the key in `Ctx::sessions`.
+    pub id: u64,
+    pub kind: ConnKind,
+    /// Lanes this connection currently has visible — fast-polled for output.
+    pub viewport: Mutex<Vec<LaneId>>,
+    /// Which agent window the focused lane streams (Tab in Focus/Split), if a specific session is
+    /// selected. Lanes not named here stream their first slot.
+    pub viewport_focus: Mutex<Option<(LaneId, String)>>,
+    /// When this connection last (re)asserted its viewport. The client heartbeats `viewport.set`
+    /// every few seconds; a focus is treated as size-owning (and cadence-boosting) only while this
+    /// is fresh, so a crashed or closed client releases its hold within seconds.
+    pub viewport_focus_at: Mutex<Option<Instant>>,
+    /// Plain-terminal windows (`term-{lane}-{n}`) this connection has visible as Grid tiles.
+    pub viewport_windows: Mutex<Vec<String>>,
+    /// Windows this connection byte-watches. std Mutex: read on the event-forward hot path.
+    /// (Populated by task A4; the field exists now so the struct is final.)
+    pub watched_bytes: std::sync::Mutex<HashSet<String>>,
+    /// When this connection last drove an agent (send_input/signal/key/scroll/answer, and a fit
+    /// that actually applied). `agent.fit`'s remote-vs-remote arbitration is last-interaction-wins.
+    pub last_interaction: Mutex<Option<Instant>>,
+}
+
+impl ConnSession {
+    pub fn new(id: u64, kind: ConnKind) -> Self {
+        ConnSession {
+            id,
+            kind,
+            viewport: Mutex::new(Vec::new()),
+            viewport_focus: Mutex::new(None),
+            viewport_focus_at: Mutex::new(None),
+            viewport_windows: Mutex::new(Vec::new()),
+            watched_bytes: std::sync::Mutex::new(HashSet::new()),
+            last_interaction: Mutex::new(None),
+        }
+    }
+
+    /// True if this connection is the local TUI.
+    pub fn is_local(&self) -> bool {
+        matches!(self.kind, ConnKind::Local)
+    }
+}
+
+/// Drops a connection's [`ConnSession`] from `Ctx::sessions` when the connection task ends —
+/// including on an early `?`/`return` error path or a panic. `close_session` is async, so cleanup
+/// is spawned onto the runtime rather than awaited in `drop`. Both transports hold one of these
+/// for the life of a connection so no session ever outlives its socket.
+pub struct SessionGuard {
+    ctx: std::sync::Arc<crate::Ctx>,
+    id: u64,
+}
+
+impl SessionGuard {
+    pub fn new(ctx: std::sync::Arc<crate::Ctx>, id: u64) -> Self {
+        SessionGuard { ctx, id }
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let ctx = self.ctx.clone();
+        let id = self.id;
+        tokio::spawn(async move { ctx.close_session(id).await });
+    }
+}

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -170,8 +170,11 @@ pub struct Ctx {
     /// Per worktree: the dxkit loop ledger's mtime and the verdict parsed from its tail, so
     /// the overlay re-reads only when the gate actually ran again. Keyed by worktree path.
     pub gate_cache: Mutex<HashMap<PathBuf, GateCacheEntry>>,
-    /// The single active PTY byte watch (the Focus view's embedded renderer feed), if any.
-    pub bytes_watch: Mutex<Option<bytes_stream::BytesWatch>>,
+    /// Live PTY byte watches, keyed by window — the embedded renderer's feed. tmux allows one
+    /// `pipe-pane` per pane, so each window has exactly one shared pipe; the entry refcounts the
+    /// connections watching it (see [`bytes_stream`]). `Arc<Mutex<…>>` so an EOF reader thread can
+    /// clean up its own entry.
+    pub bytes_watches: bytes_stream::Watches,
     /// Lanes currently paused on a usage limit, with their reset time — written by the
     /// auto-continue watcher and read by `overlay_agents` to surface the `RateLimited` status.
     pub rate_limits: Mutex<HashMap<LaneId, auto_continue::RateLimit>>,
@@ -280,7 +283,7 @@ impl Ctx {
             prompt_cache: Mutex::new(HashMap::new()),
             pane_seen: Mutex::new(HashMap::new()),
             gate_cache: Mutex::new(HashMap::new()),
-            bytes_watch: Mutex::new(None),
+            bytes_watches: Arc::new(Mutex::new(HashMap::new())),
             rate_limits: Mutex::new(HashMap::new()),
             usage: Mutex::new(HashMap::new()),
             auto_continue_off: Mutex::new(HashSet::new()),
@@ -321,12 +324,14 @@ impl Ctx {
     /// Remove a connection's session when it disconnects, so its viewport no longer contributes to
     /// the streamed union and its focus no longer arbitrates fits.
     pub async fn close_session(&self, id: u64) {
-        let Some(sess) = self.sessions.lock().await.remove(&id) else {
+        if self.sessions.lock().await.remove(&id).is_none() {
             return;
-        };
-        // A connection's byte watches die with it: task A4 releases each window in
-        // `sess.watched_bytes` from the shared byte-stream registry here, before the Arc drops.
-        let _ = &sess.watched_bytes;
+        }
+        // A connection's byte watches die with it: release every window this connection held from
+        // the shared byte-stream registry (stopping the pipes no other connection still watches).
+        // Keyed by connection id, so it cleans up whatever the session was watching without relying
+        // on `watched_bytes` being in sync.
+        crate::bytes_stream::unwatch_all(&self.tmux, &self.bytes_watches, id).await;
     }
 
     /// Union of every live session's stream targets, plus the set of windows any fresh-beat session

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -240,6 +240,15 @@ pub struct Ctx {
     /// handshake callback (which is not an async context). Rebuilt from the store by
     /// [`rpc::refresh_remote_tokens`] at startup and after every pair/revoke.
     pub remote_tokens: std::sync::RwLock<Vec<(String, Option<String>)>>,
+    /// Serializes the *mutate-then-refresh* pair behind every `remote.pair` / `remote.revoke` (and
+    /// the startup seed). [`rpc::refresh_remote_tokens`] is read-then-write (read the store's device
+    /// list, then overwrite `remote_tokens`); running two of them concurrently races. Interleaving a
+    /// `remote.pair` and a `remote.revoke` can otherwise let the pair's stale post-mutation read land
+    /// AFTER the revoke's write, resurrecting a just-revoked token in the auth cache. Holding this
+    /// lock across the store mutation and the refresh makes each token change atomic. It is separate
+    /// from `remote_tokens`'s own (std) `RwLock`, which only guards a single read/write of the Vec —
+    /// not the compound mutate+rebuild transaction.
+    pub remote_mutate_lock: Mutex<()>,
     pub shutdown: Notify,
 }
 
@@ -300,6 +309,7 @@ impl Ctx {
             orchestrator_input_seen: Mutex::new(None),
             orchestrator_attention: Mutex::new(("none".to_string(), None)),
             remote_tokens: std::sync::RwLock::new(Vec::new()),
+            remote_mutate_lock: Mutex::new(()),
             shutdown: Notify::new(),
         })
     }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -231,6 +231,12 @@ pub struct Ctx {
     /// command-center header stay live) and folded into `orchestrator_status_value`'s payload on
     /// change. See `notify_watch::check_orchestrator_attention`.
     pub orchestrator_attention: Mutex<(String, Option<String>)>,
+    /// The valid remote bearer tokens, each paired with its device name (`None` for the legacy
+    /// shared `[remote] token` from config). This is a **std** `RwLock`, not the tokio locks the
+    /// rest of `Ctx` uses, because it is read synchronously inside the tungstenite WebSocket
+    /// handshake callback (which is not an async context). Rebuilt from the store by
+    /// [`rpc::refresh_remote_tokens`] at startup and after every pair/revoke.
+    pub remote_tokens: std::sync::RwLock<Vec<(String, Option<String>)>>,
     pub shutdown: Notify,
 }
 
@@ -292,6 +298,7 @@ impl Ctx {
             orchestrator_watched: Mutex::new(false),
             orchestrator_input_seen: Mutex::new(None),
             orchestrator_attention: Mutex::new(("none".to_string(), None)),
+            remote_tokens: std::sync::RwLock::new(Vec::new()),
             shutdown: Notify::new(),
         })
     }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod auto_continue;
 pub mod bytes_stream;
+pub mod conn;
 pub mod notify_watch;
 pub mod pubsub;
 pub mod push;
@@ -18,6 +19,7 @@ pub mod usage_watch;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use repomon_core::model::{Lane, LaneId};
@@ -25,6 +27,8 @@ use repomon_core::protocol::Notification;
 use repomon_core::{Config, Lanes, Registry, Store, TmuxRuntime, Watcher, config};
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock, broadcast};
+
+use conn::{ConnKind, ConnSession};
 
 pub use socket::serve;
 
@@ -133,18 +137,14 @@ pub struct Ctx {
     pub started: Instant,
     pub db_path: Option<PathBuf>,
     pub events: pubsub::EventTx,
-    /// Lanes the TUI currently has visible — fast-polled for output (M9).
-    pub viewport: Mutex<Vec<LaneId>>,
-    /// Which agent window the focused lane should stream, when the TUI has a specific session
-    /// selected (Tab in Focus/Split). Lanes not named here stream their first slot.
-    pub viewport_focus: Mutex<Option<(LaneId, String)>>,
-    /// When the viewport was last (re)asserted. The TUI heartbeats `viewport.set` every few
-    /// seconds; `agent.fit` treats the focused window as size-owned only while this is fresh,
-    /// so a closed or crashed TUI frees the pane for remote reflow within seconds.
-    pub viewport_focus_at: Mutex<Option<Instant>>,
-    /// Plain-terminal windows (`term-{lane}-{n}`) the TUI has visible as Grid tiles — streamed
-    /// alongside the lane panes, each tagged with its window in the output event.
-    pub viewport_windows: Mutex<Vec<String>>,
+    /// Every live client connection's per-device streaming state, keyed by connection id. The
+    /// local TUI and each companion app each register one on connect and drop it on disconnect;
+    /// the capture poll loop streams the union of their viewports (see [`Ctx::viewport_snapshot`])
+    /// and `agent.fit` arbitrates pane sizing across them. Replaces the old daemon-global viewport
+    /// slots, which a second device would clobber.
+    pub sessions: Mutex<HashMap<u64, Arc<ConnSession>>>,
+    /// Hands out monotonic connection ids for [`Ctx::open_session`].
+    pub next_conn: AtomicU64,
     /// Cache of how many live `claude` processes have each working dir (ps/lsof, 10s TTL), so
     /// `/exit`ed sessions whose transcripts linger aren't counted as running.
     pub live_cwds: Mutex<Option<(Instant, HashMap<PathBuf, usize>)>>,
@@ -272,10 +272,8 @@ impl Ctx {
             started: Instant::now(),
             db_path,
             events,
-            viewport: Mutex::new(Vec::new()),
-            viewport_focus: Mutex::new(None),
-            viewport_focus_at: Mutex::new(None),
-            viewport_windows: Mutex::new(Vec::new()),
+            sessions: Mutex::new(HashMap::new()),
+            next_conn: AtomicU64::new(0),
             live_cwds: Mutex::new(None),
             cwds_sticky: Mutex::new(HashMap::new()),
             overlay_cache: Mutex::new(None),
@@ -310,6 +308,73 @@ impl Ctx {
         *self.overlay_cache.lock().await = None;
     }
 
+    /// Register a new client connection's session and return it. Each transport calls this once on
+    /// connect (Local for the Unix socket, Remote for the bridge) and drops the session via
+    /// [`close_session`](Self::close_session) — or a `conn::SessionGuard` — on every exit path.
+    pub async fn open_session(self: &Arc<Self>, kind: ConnKind) -> Arc<ConnSession> {
+        let id = self.next_conn.fetch_add(1, Ordering::Relaxed);
+        let sess = Arc::new(ConnSession::new(id, kind));
+        self.sessions.lock().await.insert(id, sess.clone());
+        sess
+    }
+
+    /// Remove a connection's session when it disconnects, so its viewport no longer contributes to
+    /// the streamed union and its focus no longer arbitrates fits.
+    pub async fn close_session(&self, id: u64) {
+        let Some(sess) = self.sessions.lock().await.remove(&id) else {
+            return;
+        };
+        // A connection's byte watches die with it: task A4 releases each window in
+        // `sess.watched_bytes` from the shared byte-stream registry here, before the Arc drops.
+        let _ = &sess.watched_bytes;
+    }
+
+    /// Union of every live session's stream targets, plus the set of windows any fresh-beat session
+    /// focuses (those get the fast cadence and cursor capture). The capture poll loop drives itself
+    /// off this instead of the old daemon-global viewport slots.
+    ///
+    /// Single-connection equivalence (the wire-compat proof): with exactly one session, `targets`
+    /// is that session's viewport built exactly as the loop built it before (a `stream_window_for`
+    /// target per lane, then its filtered terminal windows, deduped by window), and `focused` is
+    /// `{its focus window}` when its beat is fresh — which a live client's `viewport.set` heartbeat
+    /// keeps it. So every observable capture is identical to before the per-connection refactor.
+    pub async fn viewport_snapshot(&self) -> ViewportSnapshot {
+        let now = Instant::now();
+        let sessions: Vec<Arc<ConnSession>> =
+            self.sessions.lock().await.values().cloned().collect();
+        let mut targets: Vec<(LaneId, String)> = Vec::new();
+        let mut focused: HashSet<String> = HashSet::new();
+        for sess in &sessions {
+            let lanes = sess.viewport.lock().await.clone();
+            let focus = sess.viewport_focus.lock().await.clone();
+            // One target per visible lane (its resolved window), deduped across sessions by window.
+            for lane in &lanes {
+                let w = stream_window_for(*lane, &focus);
+                if !targets.iter().any(|(_, tw)| tw == &w) {
+                    targets.push((*lane, w));
+                }
+            }
+            // Plain terminals the Grid tiles, each with the lane it belongs to. `viewport.set`
+            // already filtered these to valid `term-…` windows, so a session can't inject others.
+            for w in sess.viewport_windows.lock().await.iter() {
+                if let Some(lane) = TmuxRuntime::parse_term_window(w) {
+                    if !targets.iter().any(|(_, tw)| tw == w) {
+                        targets.push((lane, w.clone()));
+                    }
+                }
+            }
+            // A window is focused (fast cadence + cursor) if any FRESH-beat session focuses it.
+            let at = *sess.viewport_focus_at.lock().await;
+            let fresh = at.is_some_and(|t| now.duration_since(t) < rpc::FOCUS_OWNED_TTL);
+            if fresh {
+                if let Some((_, w)) = &focus {
+                    focused.insert(w.clone());
+                }
+            }
+        }
+        ViewportSnapshot { targets, focused }
+    }
+
     /// Publish an `event.<topic>` notification to all subscribers.
     pub fn broadcast(&self, method: &str, params: Value) {
         let note = Notification::new(method, params);
@@ -325,7 +390,17 @@ impl Ctx {
     }
 }
 
-/// Viewport-aware output streaming: fast-poll the tmux panes the TUI currently has visible
+/// The capture poll loop's view of every live session, from [`Ctx::viewport_snapshot`].
+#[derive(Debug, Default, Clone)]
+pub struct ViewportSnapshot {
+    /// Every window to stream this tick — the union across sessions, deduped by window, each
+    /// tagged with the lane it belongs to for the output event payload.
+    pub targets: Vec<(LaneId, String)>,
+    /// Windows any fresh-beat session focuses: fast cadence floor/cap + cursor capture.
+    pub focused: HashSet<String>,
+}
+
+/// Viewport-aware output streaming: fast-poll the tmux panes any client currently has visible
 /// and push `event.agent.output` deltas. When nothing is visible, this is nearly free.
 pub async fn stream_output(ctx: Arc<Ctx>) {
     use std::collections::HashMap;
@@ -357,7 +432,8 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
     const TYPING_WINDOW: Duration = Duration::from_millis(400);
     // Hard ceiling on captures per tick so entering a busy Grid (every pane "fresh" at once) can't
     // burst the whole viewport in one tick — the focused lane always goes first, the rest are
-    // serviced round-robin across ticks.
+    // serviced round-robin across ticks. A multi-device union is only larger, so the same cap just
+    // amortizes it across more ticks; no per-device budget is needed.
     const MAX_PER_TICK: usize = 3;
 
     let mut state: HashMap<String, St> = HashMap::new();
@@ -377,44 +453,31 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
             let mut m = ctx.input_seen.lock().await;
             m.retain(|_, t| now.saturating_duration_since(*t) < TYPING_WINDOW);
         }
-        let lanes: Vec<LaneId> = ctx.viewport.lock().await.clone();
-        let extra_windows: Vec<String> = ctx.viewport_windows.lock().await.clone();
-        if lanes.is_empty() && extra_windows.is_empty() {
+        // The union of every live session's stream targets, plus the windows any fresh-beat
+        // session focuses. With one connection this is exactly that connection's viewport and
+        // focus window — see `Ctx::viewport_snapshot` for the single-connection equivalence proof.
+        let ViewportSnapshot { targets, focused } = ctx.viewport_snapshot().await;
+        if targets.is_empty() {
             state.clear();
             continue;
-        }
-        let focus = ctx.viewport_focus.lock().await.clone();
-        // One stream target per visible pane: each lane's resolved window, plus any plain
-        // terminals the Grid is tiling (each with the lane it belongs to for the event payload).
-        let mut targets: Vec<(LaneId, String)> = lanes
-            .iter()
-            .map(|&lane| (lane, stream_window_for(lane, &focus)))
-            .collect();
-        for w in &extra_windows {
-            if let Some(lane) = TmuxRuntime::parse_term_window(w) {
-                if !targets.iter().any(|(_, tw)| tw == w) {
-                    targets.push((lane, w.clone()));
-                }
-            }
         }
         state.retain(|w, _| targets.iter().any(|(_, tw)| tw == w));
         // Snapshot which lanes were typed into recently — they capture at frame-rate. The map was
         // just pruned above, so this is the live set of within-TYPING_WINDOW lanes.
         let typing_lanes: HashMap<LaneId, Instant> = ctx.input_seen.lock().await.clone();
 
-        // Service the focused pane first (so the per-tick cap never starves what the user is
-        // watching), then the rest from a rotating offset so every background pane gets a turn.
-        let focus_window = focus.as_ref().map(|(_, w)| w.clone());
+        // Service focused panes first (so the per-tick cap never starves what a user is watching),
+        // then the rest from a rotating offset so every background pane gets a turn.
         let n = targets.len();
         let mut order: Vec<(LaneId, String)> = Vec::with_capacity(n);
-        if let Some(fw) = &focus_window {
-            if let Some(t) = targets.iter().find(|(_, w)| w == fw) {
+        for t in &targets {
+            if focused.contains(&t.1) {
                 order.push(t.clone());
             }
         }
         for i in 0..n {
             let t = &targets[(rr + i) % n];
-            if Some(&t.1) != focus_window.as_ref() {
+            if !focused.contains(&t.1) {
                 order.push(t.clone());
             }
         }
@@ -422,7 +485,7 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
 
         let mut budget = MAX_PER_TICK;
         for (lane, window) in order {
-            let is_focused = focus_window.as_deref() == Some(window.as_str());
+            let is_focused = focused.contains(&window);
             // Cadence regime: a lane typed into within TYPING_WINDOW captures at frame-rate;
             // otherwise the focused pane is fast and background/Grid tiles slow.
             let typing = typing_lanes
@@ -624,6 +687,8 @@ pub async fn stream_orchestrator(ctx: Arc<Ctx>) {
 
 #[cfg(test)]
 mod stream_tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -644,6 +709,95 @@ mod stream_tests {
         assert_eq!(
             stream_window_for(7, &Some((7, "term-7-1".into()))),
             "lane-7"
+        );
+    }
+
+    async fn test_ctx() -> Arc<Ctx> {
+        Ctx::new(Store::open_in_memory().unwrap(), Config::default(), None)
+    }
+
+    #[tokio::test]
+    async fn viewport_snapshot_single_session_equivalence() {
+        // One session's snapshot is exactly what the loop built before: a stream target per lane,
+        // then its terminal windows, and its fresh focus window is the sole focused window.
+        let ctx = test_ctx().await;
+        let s = ctx.open_session(ConnKind::Local).await;
+        *s.viewport.lock().await = vec![7, 9];
+        *s.viewport_focus.lock().await = Some((7, "lane-7-2".to_string()));
+        *s.viewport_focus_at.lock().await = Some(Instant::now());
+        *s.viewport_windows.lock().await = vec!["term-9-1".to_string()];
+
+        let snap = ctx.viewport_snapshot().await;
+        assert_eq!(
+            snap.targets,
+            vec![
+                (7, "lane-7-2".to_string()), // focused lane streams its selected window
+                (9, "lane-9".to_string()),   // other lane streams its first slot
+                (9, "term-9-1".to_string()), // the tiled terminal
+            ]
+        );
+        assert_eq!(
+            snap.focused,
+            HashSet::from(["lane-7-2".to_string()]),
+            "the sole fresh focus is the only focused window"
+        );
+    }
+
+    #[tokio::test]
+    async fn viewport_snapshot_unions_overlapping_viewports() {
+        // Two devices with an overlapping lane dedup by window, but each contributes its own extras.
+        let ctx = test_ctx().await;
+        let a = ctx.open_session(ConnKind::Local).await;
+        *a.viewport.lock().await = vec![7, 9];
+        *a.viewport_focus.lock().await = Some((7, "lane-7".to_string()));
+        *a.viewport_focus_at.lock().await = Some(Instant::now());
+
+        let b = ctx
+            .open_session(ConnKind::Remote { device: None })
+            .await;
+        *b.viewport.lock().await = vec![9, 12]; // 9 overlaps with A
+        *b.viewport_focus.lock().await = Some((12, "lane-12".to_string()));
+        *b.viewport_focus_at.lock().await = Some(Instant::now());
+
+        let snap = ctx.viewport_snapshot().await;
+        let windows: HashSet<String> = snap.targets.iter().map(|(_, w)| w.clone()).collect();
+        assert_eq!(
+            windows,
+            HashSet::from([
+                "lane-7".to_string(),
+                "lane-9".to_string(),
+                "lane-12".to_string(),
+            ]),
+            "the union covers every lane exactly once (lane 9 deduped)"
+        );
+        // lane 9 appears once despite being in both viewports.
+        assert_eq!(
+            snap.targets.iter().filter(|(_, w)| w == "lane-9").count(),
+            1
+        );
+        // Both fresh focuses union into the focused set.
+        assert_eq!(
+            snap.focused,
+            HashSet::from(["lane-7".to_string(), "lane-12".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn viewport_snapshot_focuses_only_fresh_beats() {
+        // A session that focuses a window but whose beat has gone stale (or was never stamped) does
+        // not contribute to the focused set — though its viewport still streams (it is a target).
+        let ctx = test_ctx().await;
+        let stale = ctx.open_session(ConnKind::Remote { device: None }).await;
+        *stale.viewport.lock().await = vec![7];
+        *stale.viewport_focus.lock().await = Some((7, "lane-7".to_string()));
+        *stale.viewport_focus_at.lock().await =
+            Some(Instant::now() - rpc::FOCUS_OWNED_TTL - Duration::from_secs(1));
+
+        let snap = ctx.viewport_snapshot().await;
+        assert_eq!(snap.targets, vec![(7, "lane-7".to_string())]);
+        assert!(
+            snap.focused.is_empty(),
+            "a stale beat streams its viewport but claims no fast-cadence focus"
         );
     }
 }

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -144,19 +144,22 @@ async fn main() {
     {
         let remote = ctx.config.read().await.remote.clone();
         if remote.enabled {
-            match (remote.bind, remote.token) {
-                (Some(bind), Some(token)) if !token.is_empty() => {
+            match remote.bind {
+                Some(bind) => {
+                    // Seed the auth cache (paired device tokens + the legacy config token) before
+                    // the listener accepts, so the first handshake matches against a current set.
+                    if let Err(e) = repomon_daemon::rpc::refresh_remote_tokens(&ctx).await {
+                        tracing::error!("failed to seed remote tokens: {e:?}");
+                    }
                     let ctx_r = ctx.clone();
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            repomon_daemon::remote::serve_remote(ctx_r, &bind, token).await
-                        {
+                        if let Err(e) = repomon_daemon::remote::serve_remote(ctx_r, &bind).await {
                             tracing::error!("remote bridge failed: {e}");
                         }
                     });
                 }
-                _ => tracing::warn!(
-                    "[remote] enabled but bind/token missing — run `repomon remote enable`"
+                None => tracing::warn!(
+                    "[remote] enabled but bind missing — run `repomon remote enable`"
                 ),
             }
         }

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -148,8 +148,13 @@ async fn main() {
                 Some(bind) => {
                     // Seed the auth cache (paired device tokens + the legacy config token) before
                     // the listener accepts, so the first handshake matches against a current set.
-                    if let Err(e) = repomon_daemon::rpc::refresh_remote_tokens(&ctx).await {
-                        tracing::error!("failed to seed remote tokens: {e:?}");
+                    // Under the mutate lock for consistency with pair/revoke (nothing races here yet,
+                    // but the choke point stays uniform).
+                    {
+                        let _guard = ctx.remote_mutate_lock.lock().await;
+                        if let Err(e) = repomon_daemon::rpc::refresh_remote_tokens(&ctx).await {
+                            tracing::error!("failed to seed remote tokens: {e:?}");
+                        }
                     }
                     let ctx_r = ctx.clone();
                     tokio::spawn(async move {

--- a/crates/repomon-daemon/src/pubsub.rs
+++ b/crates/repomon-daemon/src/pubsub.rs
@@ -27,3 +27,56 @@ pub mod topic {
     /// The repomind orchestrator started/stopped (its `{running, agent, model, window}` status).
     pub const ORCHESTRATOR_STATUS: &str = "event.orchestrator.status";
 }
+
+/// Whether a connection whose byte-watched windows are `watched` should receive `value`.
+///
+/// Every topic forwards unchanged EXCEPT `event.agent.bytes`, which is per-connection: the event
+/// bus broadcasts one window's bytes to every subscriber, so each forwarding loop filters them to
+/// the connections that actually watch that window. A bytes event forwards only when its `window`
+/// param is in `watched`; a bytes event with no `window` param goes to nobody. Cheap and sync (a
+/// `std::sync::Mutex` read) so it adds no `await` on the event-forward hot path.
+pub fn deliver_to(value: &Value, watched: &std::collections::HashSet<String>) -> bool {
+    if value.get("method").and_then(Value::as_str) != Some(topic::AGENT_BYTES) {
+        return true;
+    }
+    match value
+        .get("params")
+        .and_then(|p| p.get("window"))
+        .and_then(Value::as_str)
+    {
+        Some(window) => watched.contains(window),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn watched(windows: &[&str]) -> std::collections::HashSet<String> {
+        windows.iter().map(|w| w.to_string()).collect()
+    }
+
+    #[test]
+    fn non_bytes_topics_always_forward() {
+        let ev = json!({ "method": topic::AGENT_STATUS, "params": { "window": "lane-9" } });
+        assert!(deliver_to(&ev, &watched(&[])));
+        assert!(deliver_to(&ev, &watched(&["lane-1"])));
+    }
+
+    #[test]
+    fn bytes_forward_only_to_watchers_of_that_window() {
+        let ev = json!({ "method": topic::AGENT_BYTES, "params": { "window": "lane-1", "data": "x" } });
+        assert!(deliver_to(&ev, &watched(&["lane-1"])));
+        assert!(deliver_to(&ev, &watched(&["lane-1", "lane-2"])));
+        assert!(!deliver_to(&ev, &watched(&["lane-2"])));
+        assert!(!deliver_to(&ev, &watched(&[])));
+    }
+
+    #[test]
+    fn bytes_without_a_window_go_to_nobody() {
+        let ev = json!({ "method": topic::AGENT_BYTES, "params": { "data": "x" } });
+        assert!(!deliver_to(&ev, &watched(&["lane-1"])));
+    }
+}

--- a/crates/repomon-daemon/src/pubsub.rs
+++ b/crates/repomon-daemon/src/pubsub.rs
@@ -3,6 +3,9 @@
 //! Background services (the watcher, the agent monitor) call [`crate::Ctx::broadcast`];
 //! every subscribed connection forwards the notifications to its client.
 
+use std::collections::HashSet;
+
+use repomon_core::model::LaneId;
 use serde_json::Value;
 use tokio::sync::broadcast;
 
@@ -28,24 +31,51 @@ pub mod topic {
     pub const ORCHESTRATOR_STATUS: &str = "event.orchestrator.status";
 }
 
-/// Whether a connection whose byte-watched windows are `watched` should receive `value`.
+/// Whether a connection with the given per-connection filter state should receive `value`.
 ///
-/// Every topic forwards unchanged EXCEPT `event.agent.bytes`, which is per-connection: the event
-/// bus broadcasts one window's bytes to every subscriber, so each forwarding loop filters them to
-/// the connections that actually watch that window. A bytes event forwards only when its `window`
-/// param is in `watched`; a bytes event with no `window` param goes to nobody. Cheap and sync (a
-/// `std::sync::Mutex` read) so it adds no `await` on the event-forward hot path.
-pub fn deliver_to(value: &Value, watched: &std::collections::HashSet<String>) -> bool {
-    if value.get("method").and_then(Value::as_str) != Some(topic::AGENT_BYTES) {
-        return true;
-    }
-    match value
-        .get("params")
-        .and_then(|p| p.get("window"))
-        .and_then(Value::as_str)
-    {
-        Some(window) => watched.contains(window),
-        None => false,
+/// Two topics are per-connection; every other topic forwards unchanged. The event bus broadcasts
+/// each event to every subscriber, so the forwarding loops narrow the two streaming topics to the
+/// connections that actually asked for them. All state read here lives behind `std::sync::Mutex`es,
+/// so the check adds no `await` on the event-forward hot path.
+///
+/// - `event.agent.bytes` (A4): forwards only when its `window` param is in `watched`; a bytes event
+///   with no `window` goes to nobody.
+/// - `event.agent.output` (A5): forwards when its `lane_id` is in the connection's viewport
+///   `output_lanes` OR its `window` is in `output_windows` — i.e. lane-membership or the terminal
+///   window the client put in its viewport. This is what the client literally requested via
+///   `viewport.set`, NOT the resolved stream-target window for each lane: window resolution for a
+///   lane can change between `viewport.set` calls, so a name-resolved cache would go stale and
+///   silently drop output for a lane the session is still subscribed to. Lane-membership cannot go
+///   stale. Over-delivery within a subscribed lane that has multiple windows is acceptable by
+///   design. An event missing both a matching `lane_id` and `window` goes to nobody, so a
+///   connection that never called `viewport.set` (empty sets) receives no output events at all.
+pub fn deliver_to(
+    value: &Value,
+    watched: &HashSet<String>,
+    output_lanes: &HashSet<LaneId>,
+    output_windows: &HashSet<String>,
+) -> bool {
+    let method = value.get("method").and_then(Value::as_str);
+    let params = value.get("params");
+    match method {
+        Some(topic::AGENT_BYTES) => {
+            match params.and_then(|p| p.get("window")).and_then(Value::as_str) {
+                Some(window) => watched.contains(window),
+                None => false,
+            }
+        }
+        Some(topic::AGENT_OUTPUT) => {
+            let lane_hit = params
+                .and_then(|p| p.get("lane_id"))
+                .and_then(Value::as_i64)
+                .is_some_and(|lane| output_lanes.contains(&lane));
+            let window_hit = params
+                .and_then(|p| p.get("window"))
+                .and_then(Value::as_str)
+                .is_some_and(|window| output_windows.contains(window));
+            lane_hit || window_hit
+        }
+        _ => true,
     }
 }
 
@@ -54,29 +84,76 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn watched(windows: &[&str]) -> std::collections::HashSet<String> {
-        windows.iter().map(|w| w.to_string()).collect()
+    fn windows(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|w| w.to_string()).collect()
+    }
+
+    fn lanes(ids: &[LaneId]) -> HashSet<LaneId> {
+        ids.iter().copied().collect()
+    }
+
+    /// A connection subscribed to nothing: no watched bytes windows, no viewport lanes/windows.
+    fn nothing() -> (HashSet<String>, HashSet<LaneId>, HashSet<String>) {
+        (HashSet::new(), HashSet::new(), HashSet::new())
     }
 
     #[test]
-    fn non_bytes_topics_always_forward() {
+    fn non_filtered_topics_always_forward() {
         let ev = json!({ "method": topic::AGENT_STATUS, "params": { "window": "lane-9" } });
-        assert!(deliver_to(&ev, &watched(&[])));
-        assert!(deliver_to(&ev, &watched(&["lane-1"])));
+        let (w, ol, ow) = nothing();
+        assert!(deliver_to(&ev, &w, &ol, &ow));
+        assert!(deliver_to(
+            &ev,
+            &windows(&["lane-1"]),
+            &lanes(&[1]),
+            &windows(&["term-2-1"])
+        ));
     }
 
     #[test]
     fn bytes_forward_only_to_watchers_of_that_window() {
         let ev = json!({ "method": topic::AGENT_BYTES, "params": { "window": "lane-1", "data": "x" } });
-        assert!(deliver_to(&ev, &watched(&["lane-1"])));
-        assert!(deliver_to(&ev, &watched(&["lane-1", "lane-2"])));
-        assert!(!deliver_to(&ev, &watched(&["lane-2"])));
-        assert!(!deliver_to(&ev, &watched(&[])));
+        let (_, ol, ow) = nothing();
+        assert!(deliver_to(&ev, &windows(&["lane-1"]), &ol, &ow));
+        assert!(deliver_to(&ev, &windows(&["lane-1", "lane-2"]), &ol, &ow));
+        assert!(!deliver_to(&ev, &windows(&["lane-2"]), &ol, &ow));
+        assert!(!deliver_to(&ev, &windows(&[]), &ol, &ow));
     }
 
     #[test]
     fn bytes_without_a_window_go_to_nobody() {
         let ev = json!({ "method": topic::AGENT_BYTES, "params": { "data": "x" } });
-        assert!(!deliver_to(&ev, &watched(&["lane-1"])));
+        let (_, ol, ow) = nothing();
+        assert!(!deliver_to(&ev, &windows(&["lane-1"]), &ol, &ow));
+    }
+
+    #[test]
+    fn output_forwards_when_lane_is_in_the_viewport() {
+        let ev = json!({ "method": topic::AGENT_OUTPUT, "params": { "lane_id": 7, "window": "lane-7", "content": "hi" } });
+        let (w, _, ow) = nothing();
+        assert!(deliver_to(&ev, &w, &lanes(&[7]), &ow));
+        assert!(deliver_to(&ev, &w, &lanes(&[7, 9]), &ow));
+        assert!(!deliver_to(&ev, &w, &lanes(&[9]), &ow));
+    }
+
+    #[test]
+    fn output_forwards_when_window_is_a_viewport_terminal_tile() {
+        // A plain terminal tile the client put in its viewport, whose lane the client is NOT
+        // otherwise subscribed to: the window match alone delivers it.
+        let ev = json!({ "method": topic::AGENT_OUTPUT, "params": { "lane_id": 3, "window": "term-3-1", "content": "hi" } });
+        let (w, _, _) = nothing();
+        assert!(deliver_to(&ev, &w, &lanes(&[]), &windows(&["term-3-1"])));
+        assert!(!deliver_to(&ev, &w, &lanes(&[]), &windows(&["term-3-2"])));
+    }
+
+    #[test]
+    fn output_goes_to_nobody_without_a_viewport() {
+        // The core A5 guarantee: a connection that never called `viewport.set` has empty sets, so
+        // it receives no output events at all. TODAY's shipping iPhone app never calls viewport.set
+        // and never consumes event.agent.output (it polls agent.capture), so nothing it relies on
+        // goes missing while the iPad's tiles stop wasting its bandwidth.
+        let ev = json!({ "method": topic::AGENT_OUTPUT, "params": { "lane_id": 7, "window": "lane-7", "content": "hi" } });
+        let (w, ol, ow) = nothing();
+        assert!(!deliver_to(&ev, &w, &ol, &ow));
     }
 }

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -248,7 +248,14 @@ async fn handle_conn(
             }
             event = events.recv() => match event {
                 Ok(value) => {
-                    if forwarding {
+                    // Per-connection filtering: `event.agent.bytes` reaches only the connections
+                    // that watch its window (the pipe is shared and broadcast to all); every other
+                    // topic forwards unchanged. Sync std-Mutex read, dropped before the await.
+                    let deliver = {
+                        let watched = sess.watched_bytes.lock().unwrap();
+                        crate::pubsub::deliver_to(&value, &watched)
+                    };
+                    if forwarding && deliver {
                         send_json(&mut sink, &value).await?;
                     }
                 }

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -44,11 +44,12 @@ impl Drop for ConnGuard {
 }
 
 /// Methods the remote WebSocket bridge may invoke. **Default-deny**: anything not listed here
-/// (including any future RPC) is rejected over the network, so the bridge can't be used to manage
-/// the host. Allows read + interaction with *existing* agents and the companion's own push
-/// registration; blocks host-management (repo/lane/worktree mutation, agent spawn/adopt/stop,
-/// config writes, terminal/filesystem access, daemon shutdown) and secret-exposing reads
-/// (`config.get` can carry the remote token). The local Unix socket is unaffected.
+/// (including any future RPC) is rejected over the network, so the bridge can't be used to reach
+/// past what's listed. Paired devices get full fleet control: read the fleet, drive existing
+/// agents, and now spawn/stop/adopt agents and create/delete/merge lanes too. Still blocked:
+/// daemon lifecycle (`daemon.shutdown`), config/secrets (`config.get` can carry the remote token,
+/// `config.set`), host terminal + filesystem access (`terminal.open/close/target`, `fs.browse`),
+/// and credential minting (`remote.*`, local-only). The local Unix socket is unaffected.
 fn remote_method_allowed(method: &str) -> bool {
     matches!(
         method,
@@ -74,11 +75,20 @@ fn remote_method_allowed(method: &str) -> bool {
         | "agent.send_input" | "agent.signal" | "agent.key" | "agent.scroll"
         | "agent.target" | "agent.fit"
         | "agent.prompt" | "agent.answer" | "agent.watch_bytes"
+        // full fleet control: spawn/stop/adopt an agent, and manage the lanes they run in.
+        // agent.detect is a read (the spawn sheet's agent picker) — it's the only remote door to
+        // the configured agent list, since config.get stays blocked. lane.create's `path` param
+        // is optional, so no fs.browse is needed; the repo picker is the already-allowed
+        // repo.list.
+        | "agent.spawn" | "agent.stop" | "agent.adopt" | "agent.detect"
+        | "lane.create" | "lane.delete" | "lane.merge"
+        | "lane.diff" | "lane.focus"
         // repomind orchestrator: read (status/transcript) + interact (send_input/key) are safe like
         // the agent equivalents above. start/stop spawn/kill the orchestrator's claude — a remote
         // process-spawn with caller-chosen autonomy/max_agents/prompt, so strictly higher privilege
-        // than the already-blocked agent.spawn. Remote tokens may chat with a running repomind but
-        // cannot start or stop it.
+        // than the already-allowed agent.spawn (which targets a known, already-configured agent
+        // rather than an arbitrary claude invocation). Remote tokens may chat with a running
+        // repomind but cannot start or stop it.
         | "orchestrator.status" | "orchestrator.transcript"
         | "orchestrator.send_input" | "orchestrator.key"
         // benign metadata
@@ -271,19 +281,29 @@ mod tests {
     }
 
     #[test]
-    fn remote_allowlist_permits_read_and_interaction_only() {
-        // Read + interaction with existing agents, and the companion's own push registration.
+    fn remote_allowlist_permits_full_fleet_control() {
+        // Read, interact with, and now manage the fleet: spawn/stop/adopt agents, create/delete/
+        // merge lanes, plus the companion's own push registration.
         for m in [
             "ping",
             "repo.list",
             "lane.list",
             "lane.get",
+            "lane.create",
+            "lane.delete",
+            "lane.merge",
+            "lane.diff",
+            "lane.focus",
             "commit.recent",
             "agent.capture",
             "agent.transcript",
             "agent.prompt",
             "agent.answer",
             "agent.watch_bytes",
+            "agent.spawn",
+            "agent.stop",
+            "agent.adopt",
+            "agent.detect",
             "terminal.list_all",
             "agent.send_input",
             "agent.signal",
@@ -306,20 +326,16 @@ mod tests {
         ] {
             assert!(remote_method_allowed(m), "{m} should be allowed");
         }
-        // Host-management, dangerous, and secret-exposing methods are blocked over the bridge.
+        // Daemon lifecycle, config/secrets, host terminal + filesystem access, and credential
+        // minting stay blocked over the bridge even under full fleet control.
         for m in [
-            "agent.adopt",
-            "agent.spawn",
-            "agent.stop",
             "agent.resize",
+            "agent.add",
+            "agent.remove",
+            "agent.set_default",
             "repo.add",
             "repo.remove",
             "repo.discover",
-            "lane.create",
-            "lane.delete",
-            "lane.merge",
-            "lane.focus",
-            "lane.diff",
             "config.get",
             "config.set",
             "terminal.open",
@@ -327,14 +343,16 @@ mod tests {
             "terminal.target",
             "fs.browse",
             "daemon.shutdown",
-            "agent.add",
-            "agent.remove",
-            "agent.detect",
             "watcher.park",
             "orchestrator.watch",
             "orchestrator.resize",
             "orchestrator.start",
             "orchestrator.stop",
+            // upcoming local-only credential-minting RPCs (task A2) — must never be reachable
+            // over the remote bridge.
+            "remote.pair",
+            "remote.devices",
+            "remote.revoke",
             "some.future.method",
         ] {
             assert!(!remote_method_allowed(m), "{m} must be blocked");

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -249,11 +249,14 @@ async fn handle_conn(
             event = events.recv() => match event {
                 Ok(value) => {
                     // Per-connection filtering: `event.agent.bytes` reaches only the connections
-                    // that watch its window (the pipe is shared and broadcast to all); every other
-                    // topic forwards unchanged. Sync std-Mutex read, dropped before the await.
+                    // that watch its window, and `event.agent.output` only the connections whose
+                    // viewport covers its lane/window (the bus broadcasts both to every subscriber);
+                    // every other topic forwards unchanged. Sync std-Mutex reads, dropped before the
+                    // await.
                     let deliver = {
                         let watched = sess.watched_bytes.lock().unwrap();
-                        crate::pubsub::deliver_to(&value, &watched)
+                        let out = sess.output_filter.lock().unwrap();
+                        crate::pubsub::deliver_to(&value, &watched, &out.0, &out.1)
                     };
                     if forwarding && deliver {
                         send_json(&mut sink, &value).await?;

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -9,15 +9,14 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use futures::{SinkExt, StreamExt};
 use repomon_core::protocol::{MAX_FRAME_BYTES, Request, Response, RpcError};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast::error::RecvError;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::tungstenite::handshake::server::{
-    ErrorResponse, Request as HsRequest, Response as HsResponse,
-};
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request as HsRequest};
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 
 use crate::{Ctx, rpc};
@@ -98,11 +97,12 @@ fn remote_method_allowed(method: &str) -> bool {
     )
 }
 
-/// Bind the WebSocket bridge and serve until shutdown is requested.
-pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str, token: String) -> std::io::Result<()> {
+/// Bind the WebSocket bridge and serve until shutdown is requested. The set of valid tokens lives
+/// in `ctx.remote_tokens` (seeded from the store's paired devices plus the legacy config token, and
+/// refreshed on every pair/revoke), so no token is passed in here.
+pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str) -> std::io::Result<()> {
     let listener = TcpListener::bind(bind).await?;
     tracing::info!("remote bridge listening on ws://{bind}");
-    let token = Arc::new(token);
     let conns = Arc::new(AtomicUsize::new(0));
 
     loop {
@@ -117,10 +117,9 @@ pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str, token: String) -> std::io::
                         continue; // `guard` drops here, undoing the increment
                     }
                     let ctx = ctx.clone();
-                    let token = token.clone();
                     tokio::spawn(async move {
                         let _guard = guard;
-                        if let Err(e) = handle_conn(ctx, stream, &token).await {
+                        if let Err(e) = handle_conn(ctx, stream).await {
                             tracing::debug!("remote conn {addr}: {e}");
                         }
                     });
@@ -132,23 +131,48 @@ pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str, token: String) -> std::io::
     Ok(())
 }
 
+/// How often a live connection re-stamps its device's `last_seen_at` (throttled, per connection).
+const LAST_SEEN_THROTTLE: Duration = Duration::from_secs(60);
+
 // `result_large_err`: the auth closure's Err type (a full http::Response) is dictated by
 // tungstenite's `Callback` contract — nothing to box here.
 #[allow(clippy::result_large_err)]
 async fn handle_conn(
     ctx: Arc<Ctx>,
     stream: TcpStream,
-    token: &str,
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
-    // Check the token during the handshake — an unauthorized client never completes the
-    // upgrade and learns nothing but "401".
+    // Check the token during the handshake — an unauthorized client never completes the upgrade
+    // and learns nothing but "401". The matching entry's identity (device name, `None` for the
+    // legacy shared token) and the token itself are captured out of the callback.
+    let mut identity: Option<(String, Option<String>)> = None;
     let ws = tokio_tungstenite::accept_hdr_async_with_config(
         stream,
-        |req: &HsRequest, resp| auth(req, resp, token),
+        |req: &HsRequest, resp| match authorize(req, &ctx) {
+            Some(hit) => {
+                identity = Some(hit);
+                Ok(resp)
+            }
+            None => {
+                let mut deny = ErrorResponse::new(Some("unauthorized".into()));
+                *deny.status_mut() =
+                    tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
+                Err(deny)
+            }
+        },
         Some(remote_ws_config()),
     )
     .await?;
+    // Present because the handshake only completes on a match. This connection's identity is a
+    // plain local for now; task A3 will move it into a per-connection session struct.
+    let (conn_token, device_name) =
+        identity.expect("authorized handshake must record an identity");
     let (mut sink, mut source) = ws.split();
+
+    // Stamp last-seen once on connect for a named device, then at most once per minute below.
+    let mut last_seen_stamp = Instant::now();
+    if let Some(name) = &device_name {
+        let _ = ctx.store.remote_device_seen(name).await;
+    }
 
     // Every connection holds an event receiver, but only forwards once subscribed —
     // mirroring the Unix-socket connection loop.
@@ -178,6 +202,20 @@ async fn handle_conn(
                     }
                 };
                 let id = req.id;
+                // Live revocation: if this connection's token has been revoked since the
+                // handshake (dropped from the auth cache), refuse this request and close.
+                if !token_present(&ctx, &conn_token) {
+                    let resp = Response::err(id, RpcError::new(-32000, "device revoked"));
+                    send_json(&mut sink, &resp).await?;
+                    break;
+                }
+                // Throttled last-seen refresh for named devices (at most once a minute).
+                if let Some(name) = &device_name {
+                    if last_seen_stamp.elapsed() >= LAST_SEEN_THROTTLE {
+                        last_seen_stamp = Instant::now();
+                        let _ = ctx.store.remote_device_seen(name).await;
+                    }
+                }
                 let resp = if remote_method_allowed(&req.method) {
                     if req.method == "subscribe" {
                         forwarding = true;
@@ -227,23 +265,33 @@ where
     sink.send(Message::text(text)).await
 }
 
-/// The handshake gatekeeper: pass the upgrade through when the token matches, else 401.
-#[allow(clippy::result_large_err)] // the signature is tungstenite's Callback contract
-fn auth(req: &HsRequest, resp: HsResponse, token: &str) -> Result<HsResponse, ErrorResponse> {
-    if request_authorized(req, token) {
-        Ok(resp)
-    } else {
-        let mut deny = ErrorResponse::new(Some("unauthorized".into()));
-        *deny.status_mut() = tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
-        Err(deny)
+/// Match the handshake's presented token against the auth cache. On a hit, returns
+/// `Some((token, device_name))` — `device_name` is `None` for the legacy shared config token — so
+/// the connection learns the identity it authenticated as. `None` means no valid token (→ 401).
+fn authorize(req: &HsRequest, ctx: &Ctx) -> Option<(String, Option<String>)> {
+    let presented = presented_token(req)?;
+    let tokens = ctx.remote_tokens.read().unwrap();
+    for (tok, name) in tokens.iter() {
+        if constant_time_eq(presented.as_bytes(), tok.as_bytes()) {
+            return Some((presented, name.clone()));
+        }
     }
+    None
 }
 
-/// Whether the handshake request carries the right token: `Authorization: Bearer <token>` or a
-/// `token=<token>` query parameter (for clients that can't set headers on a WS dial).
-fn request_authorized(req: &HsRequest, token: &str) -> bool {
-    let presented = req
-        .headers()
+/// Whether a token is still in the auth cache — the live-revocation check on each request.
+fn token_present(ctx: &Ctx, token: &str) -> bool {
+    ctx.remote_tokens
+        .read()
+        .unwrap()
+        .iter()
+        .any(|(t, _)| constant_time_eq(token.as_bytes(), t.as_bytes()))
+}
+
+/// The token a handshake request carries: `Authorization: Bearer <token>` or a `token=<token>`
+/// query parameter (for clients that can't set headers on a WS dial).
+fn presented_token(req: &HsRequest) -> Option<String> {
+    req.headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
@@ -253,11 +301,7 @@ fn request_authorized(req: &HsRequest, token: &str) -> bool {
                 q.split('&')
                     .find_map(|kv| kv.strip_prefix("token=").map(str::to_string))
             })
-        });
-    match presented {
-        Some(p) => constant_time_eq(p.as_bytes(), token.as_bytes()),
-        None => false,
-    }
+        })
 }
 
 /// Compare two byte strings without early exit on the first mismatch (timing side channel).

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -162,11 +162,20 @@ async fn handle_conn(
         Some(remote_ws_config()),
     )
     .await?;
-    // Present because the handshake only completes on a match. This connection's identity is a
-    // plain local for now; task A3 will move it into a per-connection session struct.
+    // Present because the handshake only completes on a match.
     let (conn_token, device_name) =
         identity.expect("authorized handshake must record an identity");
     let (mut sink, mut source) = ws.split();
+
+    // This connection's per-device session, carrying its identity (device name) and its own
+    // viewport/focus/fit state. The guard drops it from `ctx.sessions` on every exit path below —
+    // each `break`, every `?` early return, and a panic.
+    let sess = ctx
+        .open_session(crate::conn::ConnKind::Remote {
+            device: device_name.clone(),
+        })
+        .await;
+    let _session_guard = crate::conn::SessionGuard::new(ctx.clone(), sess.id);
 
     // Stamp last-seen once on connect for a named device, then at most once per minute below.
     let mut last_seen_stamp = Instant::now();
@@ -220,7 +229,7 @@ async fn handle_conn(
                     if req.method == "subscribe" {
                         forwarding = true;
                     }
-                    match rpc::dispatch(&ctx, &req.method, req.params).await {
+                    match rpc::dispatch(&ctx, &sess, &req.method, req.params).await {
                         Ok(value) => Response::ok(id, value),
                         Err(err) => Response::err(id, err),
                     }

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -248,6 +248,14 @@ async fn handle_conn(
             }
             event = events.recv() => match event {
                 Ok(value) => {
+                    // Passive revocation: a device that stays silent still holds a live event
+                    // receiver, so the request-arm's revocation check never runs for it. Re-check
+                    // the token on every forward and drop the connection the moment it's gone —
+                    // otherwise a revoked-but-quiet device keeps receiving event.agent.bytes/output
+                    // forever. Sync std RwLock read, no await held.
+                    if !token_present(&ctx, &conn_token) {
+                        break;
+                    }
                     // Per-connection filtering: `event.agent.bytes` reaches only the connections
                     // that watch its window, and `event.agent.output` only the connections whose
                     // viewport covers its lane/window (the bus broadcasts both to every subscriber);

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -15,6 +15,9 @@ use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
+use std::sync::Arc;
+
+use crate::conn::ConnSession;
 use crate::{Ctx, ORCHESTRATOR_WINDOW};
 
 fn internal<E: std::fmt::Display>(e: E) -> RpcError {
@@ -514,7 +517,22 @@ struct OrchestratorTranscript {
 }
 
 /// Dispatch a single request to its handler.
-pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<Value, RpcError> {
+pub async fn dispatch(
+    ctx: &Ctx,
+    sess: &Arc<ConnSession>,
+    method: &str,
+    params: Option<Value>,
+) -> Result<Value, RpcError> {
+    // Agent-driving calls stamp this connection's last-interaction beat, which `agent.fit`'s
+    // remote-vs-remote arbitration reads (last-interaction-wins). Done here on the method name so
+    // the per-handler code needn't thread `sess`. `agent.fit` is deliberately absent: it stamps
+    // itself only when it actually applies a resize (see its handler).
+    if matches!(
+        method,
+        "agent.send_input" | "agent.signal" | "agent.key" | "agent.scroll" | "agent.answer"
+    ) {
+        *sess.last_interaction.lock().await = Some(std::time::Instant::now());
+    }
     match method {
         // ---- system ----
         // The local TUI calls this just before parking in a full-screen tmux attach (where it
@@ -1311,20 +1329,20 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             Ok(Value::Null)
         }
         "agent.fit" => {
-            // The arbitrated resize for remote viewers: reflow the pane to the caller's grid
-            // ONLY while no live mediated viewer (the TUI's viewport focus, kept fresh by its
-            // heartbeat) owns the window's size. Always answers with the authoritative grid,
+            // The arbitrated resize for mediated viewers: reflow the pane to the caller's grid
+            // only when no other session with a fresher claim owns the window's size (a Local/TUI
+            // focus always wins; a remote peer wins only while its focus beat is fresh AND it drove
+            // the agent more recently than the caller). Always answers with the authoritative grid,
             // so a refused caller renders pinned at the shared size instead of fighting.
             let p: AgentResize = parse(params)?;
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
-            let owned = {
-                let focus = ctx.viewport_focus.lock().await;
-                let at = *ctx.viewport_focus_at.lock().await;
-                fit_owned(focus.as_ref(), at, &window, std::time::Instant::now())
-            };
-            if owned {
+            let now = std::time::Instant::now();
+            let caller = sess_snapshot(sess).await;
+            let others = other_session_snapshots(ctx, sess.id).await;
+            let allowed = fit_allowed(&caller, &others, &window, now);
+            if !allowed {
                 let tmux = ctx.tmux.clone();
                 let w = window.clone();
                 let dims = tokio::task::spawn_blocking(move || tmux.size_named(&w))
@@ -1343,6 +1361,9 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
+            // The applied fit is this connection's most recent agent-driving act — stamp it so a
+            // later remote peer's fit yields to us (last-interaction-wins). Denied fits don't stamp.
+            *sess.last_interaction.lock().await = Some(now);
             Ok(json!({ "applied": true, "cols": cols, "rows": rows }))
         }
         "agent.scroll" => {
@@ -1582,17 +1603,19 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
         }
         "viewport.set" => {
             let mut p: ViewportSet = parse(params)?;
-            *ctx.viewport.lock().await = p.lane_ids;
-            *ctx.viewport_focus.lock().await = p.focus_lane.zip(p.focus_window);
+            // Per connection now: each device writes its OWN viewport/focus into its session, and
+            // the capture loop streams the union across all live sessions. Wire shape unchanged.
+            *sess.viewport.lock().await = p.lane_ids;
+            *sess.viewport_focus.lock().await = p.focus_lane.zip(p.focus_window);
             // The focus heartbeat: `agent.fit` treats the focused window as size-owned while
-            // this is fresh. The TUI re-asserts its viewport every few seconds, so a crashed
-            // or closed TUI releases ownership when the beat stops.
-            *ctx.viewport_focus_at.lock().await = Some(std::time::Instant::now());
+            // this is fresh. A client re-asserts its viewport every few seconds, so a crashed
+            // or closed client releases ownership when the beat stops.
+            *sess.viewport_focus_at.lock().await = Some(std::time::Instant::now());
             // Only real terminal windows are streamable extras — anything else is dropped so a
             // client can't point the capture loop at arbitrary windows.
             p.windows
                 .retain(|w| TmuxRuntime::parse_term_window(w).is_some());
-            *ctx.viewport_windows.lock().await = p.windows;
+            *sess.viewport_windows.lock().await = p.windows;
             Ok(Value::Null)
         }
 
@@ -2408,26 +2431,88 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
     }
 }
 
-/// How long a viewport focus keeps owning its window's size after the last `viewport.set`.
-/// Three missed ~5s TUI heartbeats — generous against a busy tick, short enough that a
-/// closed/crashed TUI frees the pane for remote reflow within seconds.
-const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::from_secs(15);
+/// How long a viewport focus keeps owning its window's size after the last `viewport.set`, and how
+/// long the capture loop treats a session's focus as cadence-boosting. Three missed ~5s client
+/// heartbeats — generous against a busy tick, short enough that a closed/crashed client frees the
+/// pane for reflow within seconds. `pub(crate)` so [`crate::Ctx::viewport_snapshot`] shares it.
+pub(crate) const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::from_secs(15);
 
-/// Whether a live mediated viewer owns `window`'s size (`agent.fit`'s arbitration): the
-/// viewport focus names this window and the viewport beat is fresh.
-fn fit_owned(
-    focus: Option<&(repomon_core::model::LaneId, String)>,
+/// The fit-arbitration-relevant slice of one session, snapshotted so [`fit_allowed`] is a pure
+/// function over plain data (and unit-testable without a live `Ctx`).
+struct SessSnapshot {
+    /// True for the local TUI connection; false for a remote (companion) connection.
+    local: bool,
+    /// The window this session focuses, if any (with its lane, unused by the arbitration).
+    focus: Option<(repomon_core::model::LaneId, String)>,
+    /// When this session last (re)asserted its viewport — its focus beat's freshness clock.
     focus_at: Option<std::time::Instant>,
+    /// When this session last drove an agent (for remote-vs-remote last-interaction-wins).
+    last_interaction: Option<std::time::Instant>,
+}
+
+async fn sess_snapshot(sess: &ConnSession) -> SessSnapshot {
+    SessSnapshot {
+        local: sess.is_local(),
+        focus: sess.viewport_focus.lock().await.clone(),
+        focus_at: *sess.viewport_focus_at.lock().await,
+        last_interaction: *sess.last_interaction.lock().await,
+    }
+}
+
+/// Snapshot every live session EXCEPT `caller_id` (the fit's caller never blocks itself).
+async fn other_session_snapshots(ctx: &Ctx, caller_id: u64) -> Vec<SessSnapshot> {
+    let sessions: Vec<Arc<ConnSession>> = ctx
+        .sessions
+        .lock()
+        .await
+        .values()
+        .filter(|s| s.id != caller_id)
+        .cloned()
+        .collect();
+    let mut out = Vec::with_capacity(sessions.len());
+    for s in &sessions {
+        out.push(sess_snapshot(s).await);
+    }
+    out
+}
+
+/// Whether `caller` may reflow `window` right now, given the other live sessions.
+///
+/// 1. Any OTHER Local (TUI) session with a fresh focus beat on `window` denies it (TUI precedence).
+/// 2. Any OTHER Remote session with a fresh focus beat on `window` AND a `last_interaction` newer
+///    than the caller's denies it (remote-vs-remote last-interaction-wins).
+/// 3. Otherwise it is allowed; the handler stamps the caller's `last_interaction` on apply.
+/// 4. Self-refit is always allowed — the caller is excluded from `others`, so it never blocks
+///    itself.
+fn fit_allowed(
+    caller: &SessSnapshot,
+    others: &[SessSnapshot],
     window: &str,
     now: std::time::Instant,
 ) -> bool {
-    let Some((_, focused)) = focus else {
-        return false;
-    };
-    if focused != window {
-        return false;
+    for o in others {
+        // Does this other session hold a FRESH focus beat on the target window?
+        let focuses_window = o.focus.as_ref().is_some_and(|(_, w)| w == window);
+        let fresh = o
+            .focus_at
+            .is_some_and(|at| now.duration_since(at) < FOCUS_OWNED_TTL);
+        if !(focuses_window && fresh) {
+            continue;
+        }
+        if o.local {
+            return false; // rule 1: TUI precedence
+        }
+        // rule 2: a remote peer wins only if it drove the agent more recently than the caller.
+        let peer_newer = match (o.last_interaction, caller.last_interaction) {
+            (Some(peer), Some(mine)) => peer > mine,
+            (Some(_), None) => true, // peer has driven, caller never has → peer is newer
+            (None, _) => false,      // peer never drove → it doesn't outrank the caller
+        };
+        if peer_newer {
+            return false;
+        }
     }
-    focus_at.is_some_and(|at| now.duration_since(at) < FOCUS_OWNED_TTL)
+    true
 }
 
 /// How long a managed agent's pane must sit unchanged — with no dialog up and its turn not
@@ -3502,22 +3587,75 @@ fn write_orchestrator_mcp_config(
 mod tests {
     use super::*;
 
+    fn fit_snap(
+        local: bool,
+        focus_window: Option<&str>,
+        focus_at: Option<std::time::Instant>,
+        last_interaction: Option<std::time::Instant>,
+    ) -> SessSnapshot {
+        SessSnapshot {
+            local,
+            focus: focus_window.map(|w| (7i64, w.to_string())),
+            focus_at,
+            last_interaction,
+        }
+    }
+
     #[test]
-    fn fit_ownership_follows_the_live_viewport_focus() {
+    fn fit_arbitration_across_sessions() {
         let now = std::time::Instant::now();
         let fresh = Some(now - std::time::Duration::from_secs(2));
         let stale = Some(now - std::time::Duration::from_secs(30));
-        let focus = Some((7i64, "lane-7".to_string()));
+        let earlier = Some(now - std::time::Duration::from_secs(10));
+        let later = Some(now - std::time::Duration::from_secs(1));
 
-        // A live focus on the same window owns its size.
-        assert!(fit_owned(focus.as_ref(), fresh, "lane-7", now));
-        // A different window is free.
-        assert!(!fit_owned(focus.as_ref(), fresh, "lane-9", now));
-        // A crashed/closed TUI stops owning once the viewport beat goes stale.
-        assert!(!fit_owned(focus.as_ref(), stale, "lane-7", now));
-        assert!(!fit_owned(focus.as_ref(), None, "lane-7", now));
-        // No focus at all — nothing is owned.
-        assert!(!fit_owned(None, fresh, "lane-7", now));
+        // No contenders: a lone caller always gets its fit.
+        let caller = fit_snap(false, None, None, None);
+        assert!(fit_allowed(&caller, &[], "lane-7", now));
+
+        // Self-refit: the caller is never in `others`, so even holding a fresh focus itself it is
+        // allowed. (An empty `others` models exclusion of self.)
+        let self_focus = fit_snap(true, Some("lane-7"), fresh, later);
+        assert!(fit_allowed(&self_focus, &[], "lane-7", now));
+
+        // Rule 1: another Local (TUI) session with a fresh focus beat on the window denies, and
+        // beats a remote caller regardless of interaction recency.
+        let tui = fit_snap(true, Some("lane-7"), fresh, None);
+        let remote_caller = fit_snap(false, None, None, later);
+        assert!(!fit_allowed(&remote_caller, &[tui], "lane-7", now));
+
+        // A Local focus on a DIFFERENT window doesn't block this window.
+        let tui_other = fit_snap(true, Some("lane-9"), fresh, None);
+        assert!(fit_allowed(&remote_caller, &[tui_other], "lane-7", now));
+
+        // Stale beat releases ownership: a crashed/closed TUI no longer blocks.
+        let tui_stale = fit_snap(true, Some("lane-7"), stale, None);
+        assert!(fit_allowed(&remote_caller, &[tui_stale], "lane-7", now));
+        let tui_no_beat = fit_snap(true, Some("lane-7"), None, None);
+        assert!(fit_allowed(&remote_caller, &[tui_no_beat], "lane-7", now));
+
+        // Rule 2, order A: a remote peer that interacted MORE recently than the caller wins.
+        let peer_newer = fit_snap(false, Some("lane-7"), fresh, later);
+        let caller_old = fit_snap(false, None, None, earlier);
+        assert!(!fit_allowed(&caller_old, &[peer_newer], "lane-7", now));
+
+        // Rule 2, order B: a remote peer that interacted LESS recently than the caller yields.
+        let peer_older = fit_snap(false, Some("lane-7"), fresh, earlier);
+        let caller_new = fit_snap(false, None, None, later);
+        assert!(fit_allowed(&caller_new, &[peer_older], "lane-7", now));
+
+        // A remote peer that has never driven the agent never outranks the caller.
+        let peer_idle = fit_snap(false, Some("lane-7"), fresh, None);
+        assert!(fit_allowed(&caller_old, &[peer_idle], "lane-7", now));
+
+        // A peer that HAS driven still wins over a caller that never has.
+        let peer_any = fit_snap(false, Some("lane-7"), fresh, earlier);
+        let caller_never = fit_snap(false, None, None, None);
+        assert!(!fit_allowed(&caller_never, &[peer_any], "lane-7", now));
+
+        // A remote peer with a STALE focus beat doesn't arbitrate, however recent its interaction.
+        let peer_stale = fit_snap(false, Some("lane-7"), stale, later);
+        assert!(fit_allowed(&caller_old, &[peer_stale], "lane-7", now));
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1184,7 +1184,14 @@ pub async fn dispatch(
                 Some(window) => vec![window.clone()],
                 None => {
                     let map = ctx.bytes_watches.lock().await;
-                    let watched = sess.watched_bytes.lock().unwrap();
+                    let mut watched = sess.watched_bytes.lock().unwrap();
+                    // Purge names whose registry entry already died (EOF-cleaned: the window
+                    // closed). There is nothing left to unwatch, but they must not linger in
+                    // `watched_bytes` either — a later window-name reuse would otherwise deliver
+                    // bytes this session never asked for. Lane-independent on purpose: a dead
+                    // entry's lane is unknowable (the entry is gone), and a dead name is stale for
+                    // every lane.
+                    watched.retain(|w| map.contains_key(w));
                     watched
                         .iter()
                         .filter(|w| map.get(*w).is_some_and(|e| e.lane == p.lane_id))

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -7,7 +7,7 @@ use repomon_core::agent::{self, shell_quote};
 use repomon_core::git::{diff, reader};
 use repomon_core::model::{
     AgentChoice, AgentKind, AgentSession, AgentStatus, BrowseEntry, BrowseResult, Commit,
-    CreateLaneParams, Lane, RepoId, TimeRange,
+    CreateLaneParams, Lane, RemoteDevice, RepoId, TimeRange,
 };
 use repomon_core::protocol::RpcError;
 use repomon_core::{Indexer, TmuxRuntime, analytics, session};
@@ -28,6 +28,58 @@ fn parse<T: DeserializeOwned>(params: Option<Value>) -> Result<T, RpcError> {
 
 fn to_value<T: serde::Serialize>(v: T) -> Result<Value, RpcError> {
     serde_json::to_value(v).map_err(internal)
+}
+
+/// Rebuild [`Ctx::remote_tokens`] from the store's paired devices plus the legacy `[remote] token`
+/// from config (device name `None`). The single choke point for the auth cache: startup seeding
+/// and every pair/revoke funnel through here, so the handshake callback always reads a current set.
+pub async fn refresh_remote_tokens(ctx: &Ctx) -> Result<(), RpcError> {
+    let devices = ctx.store.remote_device_list().await.map_err(internal)?;
+    let config_token = ctx.config.read().await.remote.token.clone();
+    let mut tokens: Vec<(String, Option<String>)> = devices
+        .into_iter()
+        .map(|d| (d.token, Some(d.name)))
+        .collect();
+    if let Some(t) = config_token {
+        if !t.is_empty() {
+            tokens.push((t, None));
+        }
+    }
+    *ctx.remote_tokens.write().unwrap() = tokens;
+    Ok(())
+}
+
+/// The pairing URL the companion app scans: the same `repomon://<bind>#<token>` shape the legacy
+/// QR uses, with `&name=<urlencoded>` appended to the fragment so the app can label the connection.
+async fn remote_pair_url(ctx: &Ctx, dev: &RemoteDevice) -> String {
+    let bind = ctx
+        .config
+        .read()
+        .await
+        .remote
+        .bind
+        .clone()
+        .unwrap_or_default();
+    format!(
+        "repomon://{bind}#{}&name={}",
+        dev.token,
+        percent_encode(&dev.name)
+    )
+}
+
+/// Minimal percent-encoding for a device name spliced into a URL fragment. Keeps the unreserved
+/// set and escapes everything else; avoids a urlencoding dependency for one short field.
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
 }
 
 /// `agent.answer` found the pane in a different state than the client expected (dialog gone or
@@ -287,6 +339,14 @@ struct ConfigSet {
 #[derive(Deserialize)]
 struct PushDevice {
     device_token: String,
+}
+#[derive(Deserialize)]
+struct RemotePair {
+    name: String,
+}
+#[derive(Deserialize)]
+struct RemoteRevoke {
+    name: String,
 }
 #[derive(Deserialize)]
 struct SessionRename {
@@ -1463,6 +1523,47 @@ pub async fn dispatch(ctx: &Ctx, method: &str, params: Option<Value>) -> Result<
             to_value(items)
         }
         // Push-notification device registration (the iOS companion).
+        // ---- remote devices (LOCAL SOCKET ONLY — blocked over the bridge by the allowlist) ----
+        "remote.pair" => {
+            let p: RemotePair = parse(params)?;
+            let dev = ctx
+                .store
+                .remote_device_pair(&p.name)
+                .await
+                .map_err(internal)?;
+            // Refresh the auth cache so the freshly minted token authenticates immediately.
+            refresh_remote_tokens(ctx).await?;
+            let url = remote_pair_url(ctx, &dev).await;
+            Ok(json!({ "name": dev.name, "token": dev.token, "url": url }))
+        }
+        "remote.devices" => {
+            let devices = ctx.store.remote_device_list().await.map_err(internal)?;
+            // Never expose the token here — this is the listing surface.
+            let out: Vec<Value> = devices
+                .iter()
+                .map(|d| {
+                    json!({
+                        "name": d.name,
+                        "role": d.role,
+                        "created_at": d.created_at,
+                        "last_seen_at": d.last_seen_at,
+                    })
+                })
+                .collect();
+            Ok(Value::Array(out))
+        }
+        "remote.revoke" => {
+            let p: RemoteRevoke = parse(params)?;
+            let revoked = ctx
+                .store
+                .remote_device_revoke(&p.name)
+                .await
+                .map_err(internal)?;
+            // Drop the revoked token from the auth cache; live connections holding it are kicked
+            // on their next request (see `remote::handle_conn`).
+            refresh_remote_tokens(ctx).await?;
+            Ok(json!({ "revoked": revoked }))
+        }
         "push.register" => {
             let p: PushDevice = parse(params)?;
             ctx.store

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1635,6 +1635,18 @@ pub async fn dispatch(
         }
         "viewport.set" => {
             let mut p: ViewportSet = parse(params)?;
+            // Only real terminal windows are streamable extras — anything else is dropped so a
+            // client can't point the capture loop at arbitrary windows.
+            p.windows
+                .retain(|w| TmuxRuntime::parse_term_window(w).is_some());
+            // This handler is the single writer of the viewport fields, so it also rewrites the
+            // std-Mutex `output_filter` snapshot the event-forward loops read to filter
+            // `event.agent.output` (they must not await; see `ConnSession::output_filter`). Build
+            // it from the SAME values written to the tokio fields below so the two never diverge.
+            *sess.output_filter.lock().unwrap() = (
+                p.lane_ids.iter().copied().collect(),
+                p.windows.iter().cloned().collect(),
+            );
             // Per connection now: each device writes its OWN viewport/focus into its session, and
             // the capture loop streams the union across all live sessions. Wire shape unchanged.
             *sess.viewport.lock().await = p.lane_ids;
@@ -1643,10 +1655,6 @@ pub async fn dispatch(
             // this is fresh. A client re-asserts its viewport every few seconds, so a crashed
             // or closed client releases ownership when the beat stops.
             *sess.viewport_focus_at.lock().await = Some(std::time::Instant::now());
-            // Only real terminal windows are streamable extras — anything else is dropped so a
-            // client can't point the capture loop at arbitrary windows.
-            p.windows
-                .retain(|w| TmuxRuntime::parse_term_window(w).is_some());
             *sess.viewport_windows.lock().await = p.windows;
             Ok(Value::Null)
         }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -36,6 +36,13 @@ fn to_value<T: serde::Serialize>(v: T) -> Result<Value, RpcError> {
 /// Rebuild [`Ctx::remote_tokens`] from the store's paired devices plus the legacy `[remote] token`
 /// from config (device name `None`). The single choke point for the auth cache: startup seeding
 /// and every pair/revoke funnel through here, so the handshake callback always reads a current set.
+///
+/// **Concurrency:** this is read-then-write (read the store's device list, then overwrite the cache)
+/// and is NOT internally serialized. Two overlapping refreshes race — an auth-cache refresh race
+/// where a `remote.pair`'s post-mutation read lands after a concurrent `remote.revoke`'s write,
+/// re-adding a just-revoked token. Callers MUST hold [`Ctx::remote_mutate_lock`] across their store
+/// mutation and this refresh so the mutate+rebuild is atomic (see the `remote.pair`/`remote.revoke`
+/// handlers and the startup seed).
 pub async fn refresh_remote_tokens(ctx: &Ctx) -> Result<(), RpcError> {
     let devices = ctx.store.remote_device_list().await.map_err(internal)?;
     let config_token = ctx.config.read().await.remote.token.clone();
@@ -604,7 +611,16 @@ pub async fn dispatch(
             to_value(one.into_iter().next().unwrap())
         }
         "lane.create" => {
-            let p: CreateLaneParams = parse(params)?;
+            let mut p: CreateLaneParams = parse(params)?;
+            // Defense-in-depth: a remote caller must not pin the worktree to an arbitrary host path.
+            // The remote allowlist grants `lane.create` but deliberately withholds `fs.browse`, so a
+            // paired device has no legitimate way to have picked a path — it's expected to let the
+            // daemon derive the template worktree location. Strip any supplied `path` (rather than
+            // hard-erroring) so a harmless client that fills it in still succeeds, while a hostile
+            // one can't write outside the managed worktree root. The local Unix socket is unaffected.
+            if !sess.is_local() && p.path.take().is_some() {
+                tracing::warn!("remote lane.create supplied a path; ignoring it (deriving template)");
+            }
             let lane = ctx.lanes.create(p).await.map_err(internal)?;
             ctx.broadcast(crate::pubsub::topic::LANE_CREATED, json!({ "lane": lane }));
             ctx.invalidate_overlay().await;
@@ -1579,13 +1595,20 @@ pub async fn dispatch(
         // ---- remote devices (LOCAL SOCKET ONLY — blocked over the bridge by the allowlist) ----
         "remote.pair" => {
             let p: RemotePair = parse(params)?;
-            let dev = ctx
-                .store
-                .remote_device_pair(&p.name)
-                .await
-                .map_err(internal)?;
-            // Refresh the auth cache so the freshly minted token authenticates immediately.
-            refresh_remote_tokens(ctx).await?;
+            // Serialize the store mutation and the cache rebuild together (see
+            // `Ctx::remote_mutate_lock`): a concurrent `remote.revoke` must not interleave a stale
+            // refresh between our write and rebuild and resurrect a revoked token.
+            let dev = {
+                let _guard = ctx.remote_mutate_lock.lock().await;
+                let dev = ctx
+                    .store
+                    .remote_device_pair(&p.name)
+                    .await
+                    .map_err(internal)?;
+                // Refresh the auth cache so the freshly minted token authenticates immediately.
+                refresh_remote_tokens(ctx).await?;
+                dev
+            };
             let url = remote_pair_url(ctx, &dev).await;
             Ok(json!({ "name": dev.name, "token": dev.token, "url": url }))
         }
@@ -1607,14 +1630,20 @@ pub async fn dispatch(
         }
         "remote.revoke" => {
             let p: RemoteRevoke = parse(params)?;
-            let revoked = ctx
-                .store
-                .remote_device_revoke(&p.name)
-                .await
-                .map_err(internal)?;
-            // Drop the revoked token from the auth cache; live connections holding it are kicked
-            // on their next request (see `remote::handle_conn`).
-            refresh_remote_tokens(ctx).await?;
+            // Serialize the mutate+refresh pair against a concurrent `remote.pair` (see
+            // `Ctx::remote_mutate_lock`) so the revoked token can't survive in the auth cache.
+            let revoked = {
+                let _guard = ctx.remote_mutate_lock.lock().await;
+                let revoked = ctx
+                    .store
+                    .remote_device_revoke(&p.name)
+                    .await
+                    .map_err(internal)?;
+                // Drop the revoked token from the auth cache; live connections holding it are kicked
+                // on their next request (see `remote::handle_conn`) or next event forward.
+                refresh_remote_tokens(ctx).await?;
+                revoked
+            };
             Ok(json!({ "revoked": revoked }))
         }
         "push.register" => {

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1142,26 +1142,30 @@ pub async fn dispatch(
         }
         "agent.watch_bytes" => {
             // The embedded renderer's feed: stream one pane's raw PTY bytes as
-            // `event.agent.bytes`. Single-watch semantics — a new `on` replaces the previous
-            // watch, `off` just stops it.
+            // `event.agent.bytes`. Refcounted per window and per connection: a window has one
+            // shared pipe (tmux allows only one pipe-pane per pane), this session joins/leaves its
+            // readership, and delivery is filtered per connection at the forwarding loops. A new
+            // `on` NEVER stops another session's watch; `on:false` releases only THIS session's.
             let p: AgentWatchBytes = parse(params)?;
-            let window = p
-                .window
-                .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
-            crate::bytes_stream::stop(&ctx.tmux, &ctx.bytes_watch).await;
             if p.on {
-                crate::bytes_stream::start(
+                let window = p
+                    .window
+                    .clone()
+                    .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
+                crate::bytes_stream::watch(
                     ctx.tmux.clone(),
                     ctx.events.clone(),
-                    &ctx.bytes_watch,
+                    &ctx.bytes_watches,
                     p.lane_id,
                     window.clone(),
+                    sess.id,
                 )
                 .await
                 .map_err(internal)?;
+                sess.watched_bytes.lock().unwrap().insert(window.clone());
                 // The ack carries the pane's grid so a remote emulator renders at exactly
                 // this size instead of resizing the real pane (which would squeeze a
-                // simultaneously attached TUI's mediated view).
+                // simultaneously attached TUI's mediated view). Shape UNCHANGED (iOS depends on it).
                 let tmux = ctx.tmux.clone();
                 let dims = tokio::task::spawn_blocking(move || tmux.size_named(&window))
                     .await
@@ -1170,6 +1174,27 @@ pub async fn dispatch(
                     "cols": dims.map(|d| d.0),
                     "rows": dims.map(|d| d.1),
                 }));
+            }
+            // `on:false`. With an explicit window, release just that one. WITHOUT a window (the
+            // TUI's stop path always sends `{lane_id, on:false}` — even when it watched a
+            // non-default window), release every window THIS session watches that belongs to the
+            // lane, matched by the WatchEntry.lane field. Resolving a default window name here
+            // would orphan the real watch.
+            let targets: Vec<String> = match &p.window {
+                Some(window) => vec![window.clone()],
+                None => {
+                    let map = ctx.bytes_watches.lock().await;
+                    let watched = sess.watched_bytes.lock().unwrap();
+                    watched
+                        .iter()
+                        .filter(|w| map.get(*w).is_some_and(|e| e.lane == p.lane_id))
+                        .cloned()
+                        .collect()
+                }
+            };
+            for window in targets {
+                crate::bytes_stream::unwatch(&ctx.tmux, &ctx.bytes_watches, &window, sess.id).await;
+                sess.watched_bytes.lock().unwrap().remove(&window);
             }
             Ok(Value::Null)
         }
@@ -2451,11 +2476,18 @@ struct SessSnapshot {
 }
 
 async fn sess_snapshot(sess: &ConnSession) -> SessSnapshot {
+    // Bind each guard to its own local so it drops before the next lock: a struct literal would
+    // otherwise hold all three session guards live at once across the `.await`s (a lock-order
+    // footgun). Order doesn't matter here since they never overlap.
+    let local = sess.is_local();
+    let focus = sess.viewport_focus.lock().await.clone();
+    let focus_at = *sess.viewport_focus_at.lock().await;
+    let last_interaction = *sess.last_interaction.lock().await;
     SessSnapshot {
-        local: sess.is_local(),
-        focus: sess.viewport_focus.lock().await.clone(),
-        focus_at: *sess.viewport_focus_at.lock().await,
-        last_interaction: *sess.last_interaction.lock().await,
+        local,
+        focus,
+        focus_at,
+        last_interaction,
     }
 }
 

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -127,7 +127,14 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
             }
             event = events.recv() => match event {
                 Ok(value) => {
-                    if forwarding {
+                    // Per-connection filtering: `event.agent.bytes` reaches only the connections
+                    // that watch its window (the pipe is shared and broadcast to all); every other
+                    // topic forwards unchanged. Sync std-Mutex read — no await added on this path.
+                    let deliver = {
+                        let watched = sess.watched_bytes.lock().unwrap();
+                        crate::pubsub::deliver_to(&value, &watched)
+                    };
+                    if forwarding && deliver {
                         if let Ok(bytes) = serde_json::to_vec::<Value>(&value) {
                             if protocol::write_frame(&mut write_half, &bytes).await.is_err() {
                                 break;

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -128,11 +128,13 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
             event = events.recv() => match event {
                 Ok(value) => {
                     // Per-connection filtering: `event.agent.bytes` reaches only the connections
-                    // that watch its window (the pipe is shared and broadcast to all); every other
-                    // topic forwards unchanged. Sync std-Mutex read — no await added on this path.
+                    // that watch its window, and `event.agent.output` only the connections whose
+                    // viewport covers its lane/window (the bus broadcasts both to every subscriber);
+                    // every other topic forwards unchanged. Sync std-Mutex reads — no await added.
                     let deliver = {
                         let watched = sess.watched_bytes.lock().unwrap();
-                        crate::pubsub::deliver_to(&value, &watched)
+                        let out = sess.output_filter.lock().unwrap();
+                        crate::pubsub::deliver_to(&value, &watched, &out.0, &out.1)
                     };
                     if forwarding && deliver {
                         if let Ok(bytes) = serde_json::to_vec::<Value>(&value) {

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -80,6 +80,11 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
         }
     });
 
+    // This connection's per-device session (viewport/focus/fit state). The guard drops it from
+    // `ctx.sessions` on every exit path below (each `break`, plus a panic).
+    let sess = ctx.open_session(crate::conn::ConnKind::Local).await;
+    let _session_guard = crate::conn::SessionGuard::new(ctx.clone(), sess.id);
+
     // Every connection holds an event receiver, but only forwards once subscribed.
     let mut events = ctx.events.subscribe();
     let mut forwarding = false;
@@ -112,7 +117,7 @@ async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
                     forwarding = true;
                 }
                 let id = req.id;
-                let resp = match rpc::dispatch(&ctx, &req.method, req.params).await {
+                let resp = match rpc::dispatch(&ctx, &sess, &req.method, req.params).await {
                     Ok(value) => Response::ok(id, value),
                     Err(err) => Response::err(id, err),
                 };

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -494,3 +494,97 @@ async fn fit_arbitrates_between_two_remote_sessions() {
         .args(["-L", &session, "kill-server"])
         .output();
 }
+
+/// The `agent.watch_bytes` handler through real dispatch: `on:true` starts real pipes and records
+/// the windows in the session; `{lane_id, on:false}` with NO window (the TUI's stop path) releases
+/// exactly this session's watches on that lane — matched by the WatchEntry.lane field, so a
+/// non-default window is found too — while another lane's watch survives. Also covers the
+/// stale-name purge: a watched name whose registry entry already died is dropped from
+/// `watched_bytes` so later window-name reuse can't deliver unrequested bytes. tmux-gated (the
+/// on:true path runs mkfifo + pipe-pane against real windows).
+#[tokio::test]
+async fn watch_bytes_off_without_window_releases_only_that_lanes_watches() {
+    if !TmuxRuntime::available() {
+        eprintln!("tmux not available; skipping watch_bytes handler test");
+        return;
+    }
+    let session = format!("repomon-bytes-it-{}", std::process::id());
+    let config = Config {
+        tmux_session: session.clone(),
+        ..Default::default()
+    };
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, config, None);
+
+    // Real windows to pipe: two on lane 1 (default-named and a second slot), one on lane 2.
+    let cwd = std::env::temp_dir();
+    for w in ["lane-1", "lane-1-2", "lane-2"] {
+        ctx.tmux.spawn_named(w, &cwd, "sleep 30").expect("spawn window");
+    }
+
+    let sess = ctx.open_session(ConnKind::Local).await;
+
+    // Watch both lane-1 windows and the lane-2 window through the real handler.
+    for (lane, window) in [(1, "lane-1"), (1, "lane-1-2"), (2, "lane-2")] {
+        let ack = rpc::dispatch(
+            &ctx,
+            &sess,
+            "agent.watch_bytes",
+            Some(json!({ "lane_id": lane, "window": window, "on": true })),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("watch {window} errored: {e:?}"));
+        assert!(ack.get("cols").is_some(), "ack shape carries dims: {ack}");
+    }
+    {
+        let watched = sess.watched_bytes.lock().unwrap();
+        assert_eq!(watched.len(), 3, "on:true records each window: {watched:?}");
+    }
+    {
+        let map = ctx.bytes_watches.lock().await;
+        assert_eq!(map.len(), 3);
+        assert_eq!(map["lane-1"].lane, 1);
+        assert_eq!(map["lane-1-2"].lane, 1);
+        assert_eq!(map["lane-2"].lane, 2);
+        for w in ["lane-1", "lane-1-2", "lane-2"] {
+            assert!(map[w].refs.contains(&sess.id), "{w} holds this conn's ref");
+        }
+    }
+
+    // A stale name: watched by the session, but its registry entry already died (EOF-cleaned).
+    sess.watched_bytes
+        .lock()
+        .unwrap()
+        .insert("lane-ghost".to_string());
+
+    // The TUI's stop shape: no window. Releases BOTH lane-1 windows (lane matched by entry field,
+    // so the non-default lane-1-2 is found too), leaves lane-2 alone, and purges the dead name.
+    rpc::dispatch(
+        &ctx,
+        &sess,
+        "agent.watch_bytes",
+        Some(json!({ "lane_id": 1, "on": false })),
+    )
+    .await
+    .unwrap();
+
+    {
+        let map = ctx.bytes_watches.lock().await;
+        assert!(!map.contains_key("lane-1"), "lane 1's default window released");
+        assert!(!map.contains_key("lane-1-2"), "lane 1's second window released");
+        let survivor = map.get("lane-2").expect("lane 2's watch survives");
+        assert!(survivor.refs.contains(&sess.id));
+    }
+    {
+        let watched = sess.watched_bytes.lock().unwrap();
+        assert_eq!(
+            watched.iter().cloned().collect::<Vec<_>>(),
+            vec!["lane-2".to_string()],
+            "watched_bytes reflects the release, including the purged stale name"
+        );
+    }
+
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &session, "kill-server"])
+        .output();
+}

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -1,5 +1,6 @@
 //! End-to-end for the remote WebSocket bridge: token gate, RPC round-trip, event push.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -218,6 +219,51 @@ async fn bridge_kicks_a_revoked_token_mid_session() {
     assert!(closed, "the bridge closes the socket after a revoked request");
 }
 
+/// Passive revocation: a device that subscribes and watches, then is revoked while sending NO
+/// further requests, must stop receiving events. The request-arm revocation check never fires for
+/// a silent device, so the event-forward arm has to re-check the token itself and close the socket
+/// within one event delivery.
+#[tokio::test]
+async fn bridge_stops_events_to_a_silently_revoked_device() {
+    let (ctx, addr) = start_bridge("live-token").await;
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token=live-token"))
+        .await
+        .expect("authorized connect");
+
+    // Subscribe so the connection forwards events; drain the ack. (A byte-watch would be seeded the
+    // same way as the other bridge tests, but a plain topic exercises the same forward arm.)
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":1,"method":"subscribe"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    let _ack = recv_json(&mut ws).await;
+
+    // A pre-revocation broadcast is delivered — the stream is live.
+    ctx.broadcast("event.test", json!({ "n": 1 }));
+    let ev = recv_json(&mut ws).await;
+    assert_eq!(ev["method"], json!("event.test"));
+    assert_eq!(ev["params"]["n"], json!(1));
+
+    // Revoke by clearing the auth cache (what `remote.revoke` does via refresh). The device sends
+    // NO further request, so only the event-forward arm can notice.
+    ctx.remote_tokens.write().unwrap().clear();
+
+    // The next event must NOT reach the device: the forward arm re-checks the token, finds it gone,
+    // and closes the socket. The client sees a close (or EOF/err), never the event frame.
+    ctx.broadcast("event.test", json!({ "n": 2 }));
+    let closed = matches!(
+        tokio::time::timeout(Duration::from_secs(2), ws.next())
+            .await
+            .expect("the bridge acts within 2s"),
+        None | Some(Ok(Message::Close(_))) | Some(Err(_))
+    );
+    assert!(
+        closed,
+        "a silently-revoked device stops receiving events and the socket closes"
+    );
+}
+
 #[tokio::test]
 async fn remote_pair_list_revoke_round_trip_over_dispatch() {
     let store = Store::open_in_memory().unwrap();
@@ -264,6 +310,160 @@ async fn remote_pair_list_revoke_round_trip_over_dispatch() {
         .await
         .unwrap();
     assert_eq!(rev2["revoked"], json!(false));
+}
+
+/// Auth-cache refresh race (Finding 4): a `remote.pair` and a `remote.revoke` running at once must
+/// leave the cache consistent with the store. `refresh_remote_tokens` is read-then-write, so an
+/// unserialized pair could rebuild from a pre-revoke snapshot and resurrect the revoked token. With
+/// the mutate lock serializing each mutate+refresh, the final cache always mirrors the store — the
+/// revoked device is gone and the paired one is present, regardless of interleaving.
+#[tokio::test]
+async fn concurrent_pair_and_revoke_leave_the_cache_consistent() {
+    use std::collections::HashSet;
+
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let sess = ctx.open_session(ConnKind::Local).await;
+
+    // Start with device "a" paired and in the cache.
+    rpc::dispatch(&ctx, &sess, "remote.pair", Some(json!({ "name": "a" })))
+        .await
+        .unwrap();
+
+    // Concurrently pair "b" and revoke "a".
+    let (c1, s1) = (ctx.clone(), sess.clone());
+    let (c2, s2) = (ctx.clone(), sess.clone());
+    let pair = tokio::spawn(async move {
+        rpc::dispatch(&c1, &s1, "remote.pair", Some(json!({ "name": "b" })))
+            .await
+            .unwrap();
+    });
+    let revoke = tokio::spawn(async move {
+        rpc::dispatch(&c2, &s2, "remote.revoke", Some(json!({ "name": "a" })))
+            .await
+            .unwrap();
+    });
+    pair.await.unwrap();
+    revoke.await.unwrap();
+
+    // The auth cache must equal the store's live device set: "b" present, "a" absent.
+    let store_names: HashSet<String> = ctx
+        .store
+        .remote_device_list()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+    let cache_names: HashSet<String> = ctx
+        .remote_tokens
+        .read()
+        .unwrap()
+        .iter()
+        .filter_map(|(_, n)| n.clone())
+        .collect();
+    assert_eq!(
+        cache_names, store_names,
+        "auth cache must mirror the store after concurrent pair+revoke"
+    );
+    assert!(
+        !cache_names.contains("a"),
+        "a revoked device must never survive in the cache"
+    );
+    assert!(
+        cache_names.contains("b"),
+        "the concurrently paired device is present"
+    );
+}
+
+/// Run a git command in `dir`, asserting success (test setup for a real repo to branch from).
+fn git(dir: &Path, args: &[&str]) {
+    let ok = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap()
+        .status
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+/// Defense-in-depth (Finding 5): a remote `lane.create` must NOT honor a caller-supplied `path` —
+/// the bridge withholds `fs.browse`, so a paired device has no legitimate way to have chosen one.
+/// The daemon strips it and derives the template worktree location; a LOCAL caller is unaffected.
+#[tokio::test]
+async fn remote_lane_create_ignores_caller_path() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+
+    // A real repo with one commit on main (lane.create branches a worktree off it).
+    let repo_dir = tempfile::tempdir().unwrap();
+    git(repo_dir.path(), &["init", "-b", "main"]);
+    std::fs::write(repo_dir.path().join("README.md"), "hi\n").unwrap();
+    git(repo_dir.path(), &["add", "."]);
+    git(repo_dir.path(), &["commit", "-m", "init"]);
+    let repo = ctx.registry.add(repo_dir.path()).await.unwrap();
+
+    // A paired device tries to pin the worktree to an attacker-chosen host path.
+    let sess = ctx
+        .open_session(ConnKind::Remote {
+            device: Some("phone".into()),
+        })
+        .await;
+    let outside = tempfile::tempdir().unwrap();
+    // Canonicalize the base: the daemon returns canonical worktree paths, and on macOS the tempdir
+    // lives under a `/private` symlink, so a raw join wouldn't compare equal.
+    let outside_base = std::fs::canonicalize(outside.path()).unwrap();
+    let evil_path = outside_base.join("pwned");
+    let lane = rpc::dispatch(
+        &ctx,
+        &sess,
+        "lane.create",
+        Some(json!({
+            "repo_id": repo.id,
+            "branch": "feat/x",
+            "source_branch": "main",
+            "path": evil_path.to_string_lossy(),
+        })),
+    )
+    .await
+    .expect("remote lane.create still succeeds (path is stripped, not rejected)");
+
+    let created = PathBuf::from(lane["worktree"]["path"].as_str().unwrap());
+    assert_ne!(
+        created, evil_path,
+        "remote lane.create must not honor the caller-supplied path"
+    );
+    assert!(
+        !evil_path.exists(),
+        "nothing may be created at the attacker path"
+    );
+
+    // Sanity: a LOCAL caller's path IS honored — the strip is remote-only.
+    let local = ctx.open_session(ConnKind::Local).await;
+    let local_path = outside_base.join("local-ok");
+    let lane2 = rpc::dispatch(
+        &ctx,
+        &local,
+        "lane.create",
+        Some(json!({
+            "repo_id": repo.id,
+            "branch": "feat/y",
+            "source_branch": "main",
+            "path": local_path.to_string_lossy(),
+        })),
+    )
+    .await
+    .expect("local lane.create honors the path");
+    assert_eq!(
+        PathBuf::from(lane2["worktree"]["path"].as_str().unwrap()),
+        local_path,
+        "a local caller keeps full control of the worktree path"
+    );
 }
 
 /// Find the live session a named remote device connected as (polls; the session registers just

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -359,6 +359,87 @@ async fn bytes_events_are_delivered_per_connection() {
     assert_eq!(i2["method"], json!("event.repo.changed"));
 }
 
+/// Sibling of `bytes_events_are_delivered_per_connection` for A5: two connections with DIFFERENT
+/// viewports each receive ONLY their own lane's `event.agent.output`, a third connection that never
+/// asserted a viewport receives NONE, and every connection still gets a non-output topic. This is
+/// the per-connection output filter at the forwarding loop, end to end over the real bridge. We seed
+/// each session's `output_filter` snapshot directly (the same snapshot `viewport.set` writes) so the
+/// test needs no live tmux.
+///
+/// The no-viewport case is the whole point of A5: TODAY's shipping iPhone app never calls
+/// `viewport.set` and never consumes `event.agent.output` (it polls `agent.capture`), so filtering
+/// it to nothing wastes none of its bandwidth and drops nothing it relies on.
+#[tokio::test]
+async fn output_events_are_delivered_per_connection() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let phone = ctx.store.remote_device_pair("phone").await.unwrap();
+    let ipad = ctx.store.remote_device_pair("ipad").await.unwrap();
+    let laptop = ctx.store.remote_device_pair("laptop").await.unwrap();
+    {
+        let mut toks = ctx.remote_tokens.write().unwrap();
+        toks.push((phone.token.clone(), Some("phone".into())));
+        toks.push((ipad.token.clone(), Some("ipad".into())));
+        toks.push((laptop.token.clone(), Some("laptop".into())));
+    }
+    let addr = serve(ctx.clone()).await;
+
+    let (mut ws_p, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
+        .await
+        .expect("phone connects");
+    let (mut ws_i, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
+        .await
+        .expect("ipad connects");
+    let (mut ws_l, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", laptop.token))
+        .await
+        .expect("laptop connects");
+
+    // Phone's viewport covers lane 1, iPad's covers lane 2; laptop never asserts a viewport, so its
+    // `output_filter` stays at its empty session-creation zero-state.
+    session_for_device(&ctx, "phone").await.output_filter.lock().unwrap().0.insert(1);
+    session_for_device(&ctx, "ipad").await.output_filter.lock().unwrap().0.insert(2);
+
+    // Subscribe all three and drain the acks (forwarding is on once the ack returns).
+    for (ws, id) in [(&mut ws_p, 1u64), (&mut ws_i, 2u64), (&mut ws_l, 3u64)] {
+        ws.send(Message::text(
+            json!({"jsonrpc":"2.0","id":id,"method":"subscribe"}).to_string(),
+        ))
+        .await
+        .unwrap();
+        let ack = recv_json(ws).await;
+        assert_eq!(ack["id"], json!(id));
+    }
+
+    // Output for each lane, then a non-output topic that must reach everyone.
+    ctx.broadcast(
+        "event.agent.output",
+        json!({ "lane_id": 1, "window": "lane-1", "content": "one" }),
+    );
+    ctx.broadcast(
+        "event.agent.output",
+        json!({ "lane_id": 2, "window": "lane-2", "content": "two" }),
+    );
+    ctx.broadcast("event.repo.changed", json!({ "hello": true }));
+
+    // The phone sees ONLY lane 1's output (lane 2's is filtered out), then the shared event.
+    let p1 = recv_json(&mut ws_p).await;
+    assert_eq!(p1["method"], json!("event.agent.output"));
+    assert_eq!(p1["params"]["lane_id"], json!(1));
+    let p2 = recv_json(&mut ws_p).await;
+    assert_eq!(p2["method"], json!("event.repo.changed"));
+
+    // The iPad sees ONLY lane 2's output, then the shared event.
+    let i1 = recv_json(&mut ws_i).await;
+    assert_eq!(i1["method"], json!("event.agent.output"));
+    assert_eq!(i1["params"]["lane_id"], json!(2));
+    let i2 = recv_json(&mut ws_i).await;
+    assert_eq!(i2["method"], json!("event.repo.changed"));
+
+    // The laptop, with no viewport, sees NEITHER output event — its first frame is the shared event.
+    let l1 = recv_json(&mut ws_l).await;
+    assert_eq!(l1["method"], json!("event.repo.changed"));
+}
+
 /// A connection's byte watches die with it: `close_session` runs `unwatch_all`, which drops the
 /// windows the connection solely watched and releases it from shared ones (which survive). Observed
 /// directly on the shared registry.

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
 use repomon_core::{Config, Store};
+use repomon_daemon::conn::ConnKind;
 use repomon_daemon::{Ctx, remote, rpc};
 use serde_json::{Value, json};
 use tokio_tungstenite::tungstenite::Message;
@@ -220,9 +221,11 @@ async fn bridge_kicks_a_revoked_token_mid_session() {
 async fn remote_pair_list_revoke_round_trip_over_dispatch() {
     let store = Store::open_in_memory().unwrap();
     let ctx = Ctx::new(store, Config::default(), None);
+    // A session is required by the dispatch signature; these local-only RPCs don't touch it.
+    let sess = ctx.open_session(ConnKind::Local).await;
 
     // pair → {name, token, url}; seeds the auth cache.
-    let pair = rpc::dispatch(&ctx, "remote.pair", Some(json!({ "name": "phone" })))
+    let pair = rpc::dispatch(&ctx, &sess, "remote.pair", Some(json!({ "name": "phone" })))
         .await
         .unwrap();
     assert_eq!(pair["name"], json!("phone"));
@@ -235,28 +238,28 @@ async fn remote_pair_list_revoke_round_trip_over_dispatch() {
     assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
 
     // re-pair the same name is idempotent (same token, no second cache entry).
-    let again = rpc::dispatch(&ctx, "remote.pair", Some(json!({ "name": "phone" })))
+    let again = rpc::dispatch(&ctx, &sess, "remote.pair", Some(json!({ "name": "phone" })))
         .await
         .unwrap();
     assert_eq!(pair["token"], again["token"]);
     assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
 
     // devices lists the device WITHOUT the token.
-    let devices = rpc::dispatch(&ctx, "remote.devices", None).await.unwrap();
+    let devices = rpc::dispatch(&ctx, &sess, "remote.devices", None).await.unwrap();
     let d0 = &devices.as_array().unwrap()[0];
     assert_eq!(d0["name"], json!("phone"));
     assert_eq!(d0["role"], json!("full"));
     assert!(d0.get("token").is_none(), "the listing never exposes the token");
 
     // revoke → {revoked:true}, and the auth cache empties.
-    let rev = rpc::dispatch(&ctx, "remote.revoke", Some(json!({ "name": "phone" })))
+    let rev = rpc::dispatch(&ctx, &sess, "remote.revoke", Some(json!({ "name": "phone" })))
         .await
         .unwrap();
     assert_eq!(rev["revoked"], json!(true));
     assert!(ctx.remote_tokens.read().unwrap().is_empty());
 
     // revoking again → {revoked:false}.
-    let rev2 = rpc::dispatch(&ctx, "remote.revoke", Some(json!({ "name": "phone" })))
+    let rev2 = rpc::dispatch(&ctx, &sess, "remote.revoke", Some(json!({ "name": "phone" })))
         .await
         .unwrap();
     assert_eq!(rev2["revoked"], json!(false));

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
-use repomon_core::{Config, Store};
-use repomon_daemon::conn::ConnKind;
+use repomon_core::{Config, Store, TmuxRuntime};
+use repomon_daemon::bytes_stream::WatchEntry;
+use repomon_daemon::conn::{ConnKind, ConnSession};
 use repomon_daemon::{Ctx, remote, rpc};
 use serde_json::{Value, json};
 use tokio_tungstenite::tungstenite::Message;
@@ -263,4 +264,233 @@ async fn remote_pair_list_revoke_round_trip_over_dispatch() {
         .await
         .unwrap();
     assert_eq!(rev2["revoked"], json!(false));
+}
+
+/// Find the live session a named remote device connected as (polls; the session registers just
+/// after the handshake). Correlating by device name avoids depending on connection-id ordering.
+async fn session_for_device(ctx: &Ctx, device: &str) -> Arc<ConnSession> {
+    for _ in 0..200 {
+        {
+            let sessions = ctx.sessions.lock().await;
+            for s in sessions.values() {
+                if matches!(&s.kind, ConnKind::Remote { device: Some(d) } if d == device) {
+                    return s.clone();
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("no live session for device {device}");
+}
+
+/// Two connections, each byte-watching a DIFFERENT window, receive ONLY their own window's
+/// `event.agent.bytes` — while every non-bytes topic reaches both. This is the per-connection
+/// delivery filter at the forwarding loop, exercised end to end over the real bridge. (The pipe
+/// machinery itself is unit-tested; we seed each session's `watched_bytes` directly here so the
+/// test needs no live tmux.)
+#[tokio::test]
+async fn bytes_events_are_delivered_per_connection() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let phone = ctx.store.remote_device_pair("phone").await.unwrap();
+    let ipad = ctx.store.remote_device_pair("ipad").await.unwrap();
+    {
+        let mut toks = ctx.remote_tokens.write().unwrap();
+        toks.push((phone.token.clone(), Some("phone".into())));
+        toks.push((ipad.token.clone(), Some("ipad".into())));
+    }
+    let addr = serve(ctx.clone()).await;
+
+    let (mut ws_p, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
+        .await
+        .expect("phone connects");
+    let (mut ws_i, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
+        .await
+        .expect("ipad connects");
+
+    // Each connection watches a different window.
+    session_for_device(&ctx, "phone")
+        .await
+        .watched_bytes
+        .lock()
+        .unwrap()
+        .insert("lane-1".to_string());
+    session_for_device(&ctx, "ipad")
+        .await
+        .watched_bytes
+        .lock()
+        .unwrap()
+        .insert("lane-2".to_string());
+
+    // Subscribe both and drain the subscribe acks (forwarding is on once the ack returns).
+    for (ws, id) in [(&mut ws_p, 1u64), (&mut ws_i, 2u64)] {
+        ws.send(Message::text(
+            json!({"jsonrpc":"2.0","id":id,"method":"subscribe"}).to_string(),
+        ))
+        .await
+        .unwrap();
+        let ack = recv_json(ws).await;
+        assert_eq!(ack["id"], json!(id));
+    }
+
+    // Bytes for each window, then a non-bytes topic that must reach everyone.
+    ctx.broadcast(
+        "event.agent.bytes",
+        json!({ "lane_id": 1, "window": "lane-1", "data": "QQ==" }),
+    );
+    ctx.broadcast(
+        "event.agent.bytes",
+        json!({ "lane_id": 2, "window": "lane-2", "data": "Qg==" }),
+    );
+    ctx.broadcast("event.repo.changed", json!({ "hello": true }));
+
+    // The phone sees ONLY lane-1's bytes (lane-2's are filtered out), then the shared event.
+    let p1 = recv_json(&mut ws_p).await;
+    assert_eq!(p1["method"], json!("event.agent.bytes"));
+    assert_eq!(p1["params"]["window"], json!("lane-1"));
+    let p2 = recv_json(&mut ws_p).await;
+    assert_eq!(p2["method"], json!("event.repo.changed"));
+
+    // The iPad sees ONLY lane-2's bytes, then the shared event.
+    let i1 = recv_json(&mut ws_i).await;
+    assert_eq!(i1["method"], json!("event.agent.bytes"));
+    assert_eq!(i1["params"]["window"], json!("lane-2"));
+    let i2 = recv_json(&mut ws_i).await;
+    assert_eq!(i2["method"], json!("event.repo.changed"));
+}
+
+/// A connection's byte watches die with it: `close_session` runs `unwatch_all`, which drops the
+/// windows the connection solely watched and releases it from shared ones (which survive). Observed
+/// directly on the shared registry.
+#[tokio::test]
+async fn close_session_releases_only_this_connections_watches() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    let a = ctx.open_session(ConnKind::Local).await;
+    let b = ctx
+        .open_session(ConnKind::Remote {
+            device: Some("phone".into()),
+        })
+        .await;
+
+    {
+        let mut map = ctx.bytes_watches.lock().await;
+        // Shared window watched by both A and B.
+        map.insert(
+            "lane-1".to_string(),
+            WatchEntry {
+                lane: 1,
+                fifo: std::env::temp_dir().join("repomon-test-a4-1.fifo"),
+                refs: [a.id, b.id].into_iter().collect(),
+                generation: 0,
+            },
+        );
+        // A window only A watches.
+        map.insert(
+            "lane-2".to_string(),
+            WatchEntry {
+                lane: 2,
+                fifo: std::env::temp_dir().join("repomon-test-a4-2.fifo"),
+                refs: [a.id].into_iter().collect(),
+                generation: 1,
+            },
+        );
+    }
+
+    ctx.close_session(a.id).await;
+
+    let map = ctx.bytes_watches.lock().await;
+    assert!(
+        !map.contains_key("lane-2"),
+        "A's solo window is stopped when A disconnects"
+    );
+    let shared = map.get("lane-1").expect("B still watches the shared window");
+    assert_eq!(
+        shared.refs.iter().copied().collect::<Vec<_>>(),
+        vec![b.id],
+        "A is released from the shared window; B's ref remains"
+    );
+}
+
+/// `agent.fit` arbitration through real dispatch (covers the A3 wiring: interaction stamping +
+/// cross-session snapshots). Session B drives an agent (stamping its `last_interaction`) and holds
+/// a fresh focus on a window; session A's fit on that window is denied, while A's fit on an
+/// uncontested window applies. tmux-gated (the apply path resizes a real pane).
+#[tokio::test]
+async fn fit_arbitrates_between_two_remote_sessions() {
+    if !TmuxRuntime::available() {
+        eprintln!("tmux not available; skipping fit arbitration test");
+        return;
+    }
+    let session = format!("repomon-fit-it-{}", std::process::id());
+    let config = Config {
+        tmux_session: session.clone(),
+        ..Default::default()
+    };
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, config, None);
+
+    // A real, uncontested window for the apply case.
+    let cwd = std::env::temp_dir();
+    ctx.tmux
+        .spawn_named("lane-2", &cwd, "sleep 30")
+        .expect("spawn uncontested window");
+
+    let a = ctx
+        .open_session(ConnKind::Remote {
+            device: Some("a".into()),
+        })
+        .await;
+    let b = ctx
+        .open_session(ConnKind::Remote {
+            device: Some("b".into()),
+        })
+        .await;
+
+    // B "types" — dispatch stamps B's last_interaction before the handler runs, so the (absent
+    // "lane-1" window) tmux error is irrelevant to the arbitration under test.
+    let _ = rpc::dispatch(
+        &ctx,
+        &b,
+        "agent.send_input",
+        Some(json!({ "lane_id": 1, "window": "lane-1", "text": "x" })),
+    )
+    .await;
+    // ...and holds a fresh focus beat on the contested window.
+    *b.viewport_focus.lock().await = Some((1, "lane-1".to_string()));
+    *b.viewport_focus_at.lock().await = Some(std::time::Instant::now());
+
+    // A fits B's fresh-focus, more-recently-driven window → denied (last-interaction-wins).
+    let denied = rpc::dispatch(
+        &ctx,
+        &a,
+        "agent.fit",
+        Some(json!({ "lane_id": 1, "window": "lane-1", "cols": 100, "rows": 30 })),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        denied["applied"],
+        json!(false),
+        "A must not resize a window B freshly owns and drove"
+    );
+
+    // A fits the uncontested real window → applied.
+    let applied = rpc::dispatch(
+        &ctx,
+        &a,
+        "agent.fit",
+        Some(json!({ "lane_id": 2, "window": "lane-2", "cols": 100, "rows": 30 })),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        applied["applied"],
+        json!(true),
+        "A resizes a window nobody else owns"
+    );
+
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &session, "kill-server"])
+        .output();
 }

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
 use repomon_core::{Config, Store};
-use repomon_daemon::{Ctx, remote};
+use repomon_daemon::{Ctx, remote, rpc};
 use serde_json::{Value, json};
 use tokio_tungstenite::tungstenite::Message;
 
@@ -18,15 +18,14 @@ fn free_port() -> u16 {
         .port()
 }
 
-async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
-    let store = Store::open_in_memory().unwrap();
-    let ctx = Ctx::new(store, Config::default(), None);
+/// Serve a prepared `ctx` on a fresh localhost port and wait for the listener. Tokens must already
+/// be seeded into `ctx.remote_tokens` (that is now the auth source, not a serve_remote argument).
+async fn serve(ctx: Arc<Ctx>) -> String {
     let addr = format!("127.0.0.1:{}", free_port());
     {
         let ctx = ctx.clone();
         let addr = addr.clone();
-        let token = token.to_string();
-        tokio::spawn(async move { remote::serve_remote(ctx, &addr, token).await });
+        tokio::spawn(async move { remote::serve_remote(ctx, &addr).await });
     }
     // Wait for the listener to come up (connect attempts, not sleeps).
     for _ in 0..100 {
@@ -35,7 +34,27 @@ async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
+    addr
+}
+
+async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    // Seed a shared token (device name None) — the legacy config-token path.
+    ctx.remote_tokens
+        .write()
+        .unwrap()
+        .push((token.to_string(), None));
+    let addr = serve(ctx.clone()).await;
     (ctx, addr)
+}
+
+/// Read one JSON value from the socket (fails the test on a non-text or absent frame).
+async fn recv_json(ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin)) -> Value {
+    match ws.next().await.unwrap().unwrap() {
+        Message::Text(t) => serde_json::from_str(&t).unwrap(),
+        m => panic!("unexpected frame: {m:?}"),
+    }
 }
 
 #[tokio::test]
@@ -124,4 +143,121 @@ async fn bridge_rejects_bad_or_missing_token_before_upgrade() {
         missing.is_err(),
         "missing token must not complete the upgrade"
     );
+}
+
+#[tokio::test]
+async fn bridge_authenticates_a_named_device_and_stamps_last_seen() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    // Pair a device, seed its token into the auth cache with the device name.
+    let dev = ctx.store.remote_device_pair("phone").await.unwrap();
+    ctx.remote_tokens
+        .write()
+        .unwrap()
+        .push((dev.token.clone(), Some("phone".into())));
+    let addr = serve(ctx.clone()).await;
+
+    let (mut ws, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", dev.token))
+            .await
+            .expect("named-device token authorizes");
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":1,"method":"ping"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(recv_json(&mut ws).await["result"], json!("pong"));
+
+    // The handshake stamps last_seen_at for the named device (poll — it happens in the handler).
+    let mut stamped = false;
+    for _ in 0..100 {
+        let d = &ctx.store.remote_device_list().await.unwrap()[0];
+        if d.last_seen_at.is_some() {
+            stamped = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(stamped, "a named device's last_seen_at is stamped on connect");
+}
+
+#[tokio::test]
+async fn bridge_kicks_a_revoked_token_mid_session() {
+    let (ctx, addr) = start_bridge("live-token").await;
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token=live-token"))
+        .await
+        .expect("authorized connect");
+
+    // A request works while the token is live.
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":1,"method":"ping"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(recv_json(&mut ws).await["result"], json!("pong"));
+
+    // Revoke: drop the token from the auth cache (what `remote.revoke` does via refresh).
+    ctx.remote_tokens.write().unwrap().clear();
+
+    // The next request is refused with -32000 "device revoked", then the socket closes.
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":2,"method":"ping"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    let resp = recv_json(&mut ws).await;
+    assert_eq!(resp["error"]["code"], json!(-32000));
+    assert_eq!(resp["error"]["message"], json!("device revoked"));
+    // Server closed the connection after the error.
+    let closed = matches!(
+        ws.next().await,
+        None | Some(Ok(Message::Close(_))) | Some(Err(_))
+    );
+    assert!(closed, "the bridge closes the socket after a revoked request");
+}
+
+#[tokio::test]
+async fn remote_pair_list_revoke_round_trip_over_dispatch() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+
+    // pair → {name, token, url}; seeds the auth cache.
+    let pair = rpc::dispatch(&ctx, "remote.pair", Some(json!({ "name": "phone" })))
+        .await
+        .unwrap();
+    assert_eq!(pair["name"], json!("phone"));
+    assert!(pair["token"].as_str().unwrap().len() >= 32);
+    assert!(pair["url"].as_str().unwrap().starts_with("repomon://"));
+    assert!(
+        pair["url"].as_str().unwrap().contains("&name=phone"),
+        "the pairing url carries the device name"
+    );
+    assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
+
+    // re-pair the same name is idempotent (same token, no second cache entry).
+    let again = rpc::dispatch(&ctx, "remote.pair", Some(json!({ "name": "phone" })))
+        .await
+        .unwrap();
+    assert_eq!(pair["token"], again["token"]);
+    assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
+
+    // devices lists the device WITHOUT the token.
+    let devices = rpc::dispatch(&ctx, "remote.devices", None).await.unwrap();
+    let d0 = &devices.as_array().unwrap()[0];
+    assert_eq!(d0["name"], json!("phone"));
+    assert_eq!(d0["role"], json!("full"));
+    assert!(d0.get("token").is_none(), "the listing never exposes the token");
+
+    // revoke → {revoked:true}, and the auth cache empties.
+    let rev = rpc::dispatch(&ctx, "remote.revoke", Some(json!({ "name": "phone" })))
+        .await
+        .unwrap();
+    assert_eq!(rev["revoked"], json!(true));
+    assert!(ctx.remote_tokens.read().unwrap().is_empty());
+
+    // revoking again → {revoked:false}.
+    let rev2 = rpc::dispatch(&ctx, "remote.revoke", Some(json!({ "name": "phone" })))
+        .await
+        .unwrap();
+    assert_eq!(rev2["revoked"], json!(false));
 }

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -112,8 +112,18 @@ pub enum RemoteCmd {
         #[arg(long)]
         rotate_token: bool,
     },
-    /// Show a QR code for the companion app to scan (encodes address + token).
-    Pair,
+    /// Show a QR code for the companion app to scan (encodes address + token). With `--name`,
+    /// mints a named, individually-revocable per-device token via the daemon instead of encoding
+    /// the shared config token.
+    Pair {
+        /// Pair this named device with its own revocable token (via the daemon).
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// List paired remote devices (name, role, created, last-seen).
+    Devices,
+    /// Revoke a paired device's token by name.
+    Revoke { name: String },
     /// Show the remote-access configuration (token masked).
     Status,
     /// Turn the bridge off (keeps the token for re-enabling).
@@ -188,7 +198,7 @@ pub async fn handle(cmd: Command, config: &Config, socket: Option<PathBuf>) -> R
         }
         Command::Lane { cmd } => handle_lane(cmd, config, socket).await?,
         Command::Daemon { cmd } => handle_daemon(cmd, config, socket).await?,
-        Command::Remote { cmd } => handle_remote(cmd)?,
+        Command::Remote { cmd } => handle_remote(cmd, config, socket).await?,
         Command::Orchestrate {
             agent,
             autonomy,
@@ -210,9 +220,22 @@ pub async fn handle(cmd: Command, config: &Config, socket: Option<PathBuf>) -> R
     Ok(())
 }
 
-/// `repomon remote …` — manage the companion-app bridge. These edit the config *file* (the
-/// token never crosses the RPC surface); the daemon picks changes up on restart.
-fn handle_remote(cmd: RemoteCmd) -> Result<()> {
+/// `repomon remote …` — manage the companion-app bridge. Enable/Disable/Status and an un-named
+/// Pair edit the config *file* (the shared token never crosses the RPC surface); the daemon picks
+/// those up on restart. The per-device flows (`pair --name`, `devices`, `revoke`) instead talk to
+/// the running daemon over the local socket, since device tokens live in the store.
+async fn handle_remote(cmd: RemoteCmd, config: &Config, socket: Option<PathBuf>) -> Result<()> {
+    match cmd {
+        RemoteCmd::Pair { name: Some(name) } => remote_pair_named(config, socket, name).await,
+        RemoteCmd::Devices => remote_devices(config, socket).await,
+        RemoteCmd::Revoke { name } => remote_revoke(config, socket, name).await,
+        // Enable/Disable/Status and un-named Pair keep editing the config file directly.
+        other => handle_remote_config(other),
+    }
+}
+
+/// The config-file half of `repomon remote …` (Enable/Disable/Status, and an un-named Pair).
+fn handle_remote_config(cmd: RemoteCmd) -> Result<()> {
     let path = config::config_path();
     let mut cfg = Config::load().unwrap_or_default();
     match cmd {
@@ -244,7 +267,8 @@ fn handle_remote(cmd: RemoteCmd) -> Result<()> {
             cfg.save_to(&path)?;
             println!("remote bridge disabled (token kept) — repomon daemon restart to apply");
         }
-        RemoteCmd::Pair => {
+        RemoteCmd::Pair { name: _ } => {
+            // Only the un-named Pair reaches here (the `--name` case is daemon-backed above).
             let (Some(bind), Some(token), true) =
                 (&cfg.remote.bind, &cfg.remote.token, cfg.remote.enabled)
             else {
@@ -253,14 +277,7 @@ fn handle_remote(cmd: RemoteCmd) -> Result<()> {
                 ));
             };
             let url = format!("repomon://{bind}#{token}");
-            let code = qrcode::QrCode::new(url.as_bytes())?;
-            let art = code
-                .render::<qrcode::render::unicode::Dense1x2>()
-                .quiet_zone(true)
-                .build();
-            println!("{art}");
-            println!("scan with the repomon iOS app · {url}");
-            println!("(anyone with this QR can drive your agents — share it with no one)");
+            render_pair_qr(&url)?;
         }
         RemoteCmd::Status => {
             let state = if cfg.remote.enabled {
@@ -290,6 +307,90 @@ fn handle_remote(cmd: RemoteCmd) -> Result<()> {
                 }
             );
         }
+        // Routed to the daemon-backed handlers by `handle_remote`; never reach the config path.
+        RemoteCmd::Devices | RemoteCmd::Revoke { .. } => unreachable!(),
+    }
+    Ok(())
+}
+
+/// Render a pairing URL as a scannable QR plus the URL and the sharing warning. Shared by the
+/// legacy config-token pair and the per-device `pair --name` flow so both print identically.
+fn render_pair_qr(url: &str) -> Result<()> {
+    let code = qrcode::QrCode::new(url.as_bytes())?;
+    let art = code
+        .render::<qrcode::render::unicode::Dense1x2>()
+        .quiet_zone(true)
+        .build();
+    println!("{art}");
+    println!("scan with the repomon iOS app · {url}");
+    println!("(anyone with this QR can drive your agents — share it with no one)");
+    Ok(())
+}
+
+/// `repomon remote pair --name <device>` — mint (or re-show) this device's own revocable token via
+/// the daemon and print its QR.
+async fn remote_pair_named(config: &Config, socket: Option<PathBuf>, name: String) -> Result<()> {
+    let client = crate::ensure_daemon(config, socket).await?;
+    let resp = client
+        .call("remote.pair", Some(json!({ "name": name })))
+        .await?;
+    let url = resp
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("daemon returned no pairing url"))?;
+    render_pair_qr(url)?;
+    println!("paired device '{name}'. revoke with `repomon remote revoke {name}`");
+    Ok(())
+}
+
+/// `repomon remote devices` — list paired devices in aligned rows, then the legacy shared token.
+async fn remote_devices(config: &Config, socket: Option<PathBuf>) -> Result<()> {
+    let client = crate::ensure_daemon(config, socket).await?;
+    let resp = client.call("remote.devices", None).await?;
+    let devices = resp.as_array().cloned().unwrap_or_default();
+    if devices.is_empty() {
+        println!("no paired devices");
+    } else {
+        let str_field = |d: &Value, k: &str| d.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let name_w = devices
+            .iter()
+            .map(|d| str_field(d, "name").len())
+            .max()
+            .unwrap_or(4)
+            .max(4);
+        for d in &devices {
+            let name = str_field(d, "name");
+            let role = str_field(d, "role");
+            let created = str_field(d, "created_at");
+            let seen = d
+                .get("last_seen_at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("never");
+            println!("{name:<name_w$}  {role:<6}  created {created}  seen {seen}");
+        }
+    }
+    // The shared config token (if configured) isn't a listed device — call it out so it isn't
+    // mistaken for gone. It's retired by rotating it: `repomon remote enable --rotate-token`.
+    if config.remote.token.is_some() {
+        println!("(config token - shared; repomon remote enable --rotate-token to retire)");
+    }
+    Ok(())
+}
+
+/// `repomon remote revoke <name>` — revoke a device's token via the daemon.
+async fn remote_revoke(config: &Config, socket: Option<PathBuf>, name: String) -> Result<()> {
+    let client = crate::ensure_daemon(config, socket).await?;
+    let resp = client
+        .call("remote.revoke", Some(json!({ "name": name })))
+        .await?;
+    let revoked = resp
+        .get("revoked")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if revoked {
+        println!("revoked device '{name}'; its token no longer connects");
+    } else {
+        println!("no paired device named '{name}'");
     }
     Ok(())
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -67,7 +67,8 @@ restart).
   this connection watches for the lane.
 - **Fit arbitration.** A local (TUI) session's fresh viewport focus always owns a window's
   size. Among remote sessions actively focused on the same window, the one that most recently
-  drove the agent (`agent.send_input`/`key`/`scroll`/`answer`, or an applied `agent.fit`) wins.
+  drove the agent (`agent.send_input`/`signal`/`key`/`scroll`/`answer`, or an applied
+  `agent.fit`) wins.
   Both kinds of ownership decay: the TUI heartbeats its viewport every ~5s and a focus lapses
   15s after the last beat, so a crashed or closed client's hold releases within seconds. The
   unconditional `agent.resize` stays local-only regardless of who's connected.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -16,28 +16,61 @@ CLI which speaks this protocol.
 
 Companion apps (the iOS client) reach the daemon over a **WebSocket bridge** speaking the
 exact same JSON-RPC envelopes — one WS *text frame* per message, no length prefix. Disabled by
-default; `repomon remote enable` generates a bearer token, detects the Tailscale address, and
-writes `[remote] enabled/bind/token` to the config (apply with a daemon restart; pair a phone
-with `repomon remote pair`, which renders a `repomon://<host:port>#<token>` QR).
+default; `repomon remote enable` generates the legacy shared bearer token, detects the
+Tailscale address, and writes `[remote] enabled/bind/token` to the config (apply with a daemon
+restart).
 
-- **Auth:** checked before the upgrade completes — `Authorization: Bearer <token>` header or a
+- **Auth: per-device tokens.** `repomon remote pair --name <device>` mints that device its own
+  named, individually revocable token (re-running it for the same name re-shows the same
+  token rather than minting a second one; capped at 16 paired devices) and renders a
+  `repomon://<host:port>#<token>&name=<device>` QR. `repomon remote devices` lists paired
+  devices (name, role, created/last-seen — never the token); `repomon remote revoke <name>`
+  revokes one, and a live connection authenticated with that token is kicked on its very next
+  request with `-32000` `"device revoked"`. The legacy shared `[remote] token` from config
+  still authenticates exactly as before (it isn't a row in `remote.devices`'s list — the CLI
+  calls it out separately as the shared config token). `remote.pair`, `remote.devices`, and
+  `remote.revoke` are themselves local-socket only: no client can mint or enumerate tokens
+  over the same network it authenticates onto.
+- **Checked before the WS upgrade completes** — `Authorization: Bearer <token>` header or a
   `?token=<token>` query parameter; anything else gets a 401 and no connection.
-- **Bind it privately** (the Tailscale IP). The bridge is full-control: anyone holding the
-  token can read panes and type into agents.
+- **Bind it privately** (the Tailscale IP). Any paired device's token exercises the full
+  allowlist below.
 - `ping` → `"pong"` serves as an application-level keep-alive; events flow after `subscribe`
   exactly as on the Unix socket.
-- **Method allowlist (default-deny):** the bridge only dispatches reads and
-  interaction-with-existing-agents — anything else (host management, spawning, config,
-  terminal open/close, filesystem) answers `-32601` `"not permitted over remote bridge"`.
-  Since v0.4.1 that includes `agent.prompt`, `agent.answer` (verified dialog steering,
-  strictly safer than the blind `agent.key` it complements), `agent.watch_bytes`, and
-  `terminal.list_all`; since v0.4.2 `agent.fit` replaces `agent.resize` over the bridge —
-  the unconditional resize is local-only (a blind remote resize is exactly what squeezed
-  the TUI's mediated view), and `agent.fit` reflows the shared pane only while no live
-  TUI viewport owns it. Events themselves are forwarded unfiltered after `subscribe`. Note
-  `agent.watch_bytes` is single-watch daemon-wide: a remote client and a local TUI Focus view
-  contend for the one byte stream, last writer wins — the loser should fall back to
-  capture-based polling.
+- **Method allowlist (default-deny), full fleet control:** paired devices can read the fleet,
+  drive existing agents, AND spawn/stop/adopt agents and create/delete/merge lanes
+  (`agent.spawn`, `agent.stop`, `agent.adopt`, `agent.detect`, `lane.create`, `lane.delete`,
+  `lane.merge`, `lane.focus`, `lane.diff`), on top of everything previously allowed: reads,
+  `agent.prompt`/`agent.answer` (verified dialog steering), `agent.watch_bytes`,
+  `terminal.list_all`, `agent.fit`, and the orchestrator's status/transcript/send_input/key.
+  Still blocked: daemon lifecycle (`daemon.shutdown`), config/secrets (`config.get`,
+  `config.set`), host terminal + filesystem access (`terminal.open/close/target`,
+  `fs.browse`), the blind `agent.resize` (only the arbitrated `agent.fit` is reachable
+  remotely — an unconditional remote resize is exactly what squeezed the TUI's mediated
+  view), the orchestrator's `start`/`stop`/`watch`/`resize` (spawning/killing repomind and its
+  pane geometry stay local), and credential minting (`remote.*`). Anything else answers
+  `-32601` `"not permitted over remote bridge"`.
+- **Per-connection viewports and byte watches.** Each connection (Unix socket or WebSocket)
+  owns its own `viewport.set` state and its own `agent.watch_bytes` windows — an iPhone, an
+  iPad, and the Mac TUI can each hold a different view (or watch the same window) at once
+  without clobbering one another. The daemon polls and streams the *union* of every live
+  connection's viewport. `event.agent.bytes` is delivered only to the connections watching
+  that window; `event.agent.output` only to connections whose viewport covers the event's
+  lane, or names its terminal window — a connection that never calls `viewport.set` receives
+  no `event.agent.output` at all.
+- **`agent.watch_bytes` is per-window and refcounted, not single-watch.** `on:true` starts (or
+  joins) the shared pipe for that window and always acks with `{ cols, rows }`, the pane's
+  current grid. A connection may hold several windows at once; the same window watched by
+  several connections shares one underlying `pipe-pane` (tmux allows only one per pane), and
+  the pipe itself stops only once its last watcher leaves. `on:false` with a `window` releases
+  just that window for this connection; `on:false` without a `window` releases every window
+  this connection watches for the lane.
+- **Fit arbitration.** A local (TUI) session's fresh viewport focus always owns a window's
+  size. Among remote sessions actively focused on the same window, the one that most recently
+  drove the agent (`agent.send_input`/`key`/`scroll`/`answer`, or an applied `agent.fit`) wins.
+  Both kinds of ownership decay: the TUI heartbeats its viewport every ~5s and a focus lapses
+  15s after the last beat, so a crashed or closed client's hold releases within seconds. The
+  unconditional `agent.resize` stays local-only regardless of who's connected.
 
 ## Envelope
 
@@ -87,7 +120,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.send_input` | `{ lane_id, text, enter=true, window? }` | `null` (types text, then Enter unless `enter=false`; `window` targets one agent in a multi-agent lane) |
 | `agent.key` | `{ lane_id, key, literal=false, window? }` | `null` (one keystroke: literal char or key name; `window` targets one agent in a multi-agent lane) |
 | `agent.signal` | `{ lane_id, key, window? }` | `null` |
-| `agent.watch_bytes` | `{ lane_id, window?, on }` | on `on: true`, `{ cols, rows }` — the pane's current grid (`null`s when the window is gone); `null` on `off`. Streams the pane's raw PTY bytes (tmux `pipe-pane`) as `event.agent.bytes`. Single-watch: a new `on` replaces the previous watch. Render your emulator at the authoritative grid — the ack's, or the one `agent.fit` answers with: the pane is shared, and only `agent.fit` may reflow it remotely (a local TUI re-asserts its own size within seconds). The capture-based `viewport.set` streaming is unaffected. |
+| `agent.watch_bytes` | `{ lane_id, window?, on }` | on `on: true`, `{ cols, rows }` — the pane's current grid (`null`s when the window is gone); `null` on `off`. Streams the pane's raw PTY bytes (tmux `pipe-pane`) as `event.agent.bytes`, delivered only to connections watching that window. Per-connection and refcounted, not single-watch: a window has one shared pipe no matter how many connections watch it (tmux allows only one `pipe-pane` per pane); this connection may watch several windows at once. `on:false` with a `window` releases just that one; `on:false` without a `window` releases every window THIS connection watches for the lane. Render your emulator at the authoritative grid — the ack's, or the one `agent.fit` answers with: the pane is shared, and only `agent.fit` may reflow it remotely (a local TUI re-asserts its own size within seconds). The capture-based `viewport.set` streaming is unaffected. |
 | `agent.prompt` | `{ lane_id, window? }` | `{ dialog: PendingDialog\|null }` — fresh pane capture parsed for the interactive dialog actually on screen right now (never the sniff cache). `PendingDialog` = `{ title?, question, body?: [String], options: [{ number?, text }], selected? }`; `lane.list` carries the same object on `AgentSession.pending_dialog` alongside the `pending_prompt` summary. |
 | `agent.answer` | `{ lane_id, choice, window?, expect_summary? }` | `{ answered, sent }` — re-captures the pane, verifies a dialog is still up (and, when `expect_summary` is set, that it still summarizes to that string), then steers to `choice` (0-based) and confirms. On a stale view it does NOT send anything: error `-32010` (`no pending dialog` / `dialog changed`) with `error.data.dialog` carrying what's actually on screen (possibly `null`) so the client re-renders instead of re-fetching. Any input path (`send_input`/`key`/`signal`/`answer`) drops the window's sniff-cache entry, so an answered dialog can't be re-advertised for the rest of its TTL. |
 | `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
@@ -95,7 +128,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `session.rename` | `{ session_id, label? }` | `null` (set/clear a user label for a session, keyed by its durable transcript id; empty/absent `label` clears it; overlaid onto `AgentSession.custom_label`) |
 | `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
 | `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
-| `agent.fit` | `{ lane_id, cols, rows, window? }` | `{ applied, cols, rows }` — the arbitrated resize for remote viewers: reflows the shared pane to the caller's grid ONLY while no live local viewport focus owns the window (the TUI heartbeats its viewport every ~5s; ownership lapses 15s after the last beat, and a clean TUI quit releases it immediately). Refused (`applied: false`) it answers with the pane's current grid so the caller renders pinned at the shared size instead of fighting. Poll it (~10s) to adapt when the TUI starts or stops viewing. |
+| `agent.fit` | `{ lane_id, cols, rows, window? }` | `{ applied, cols, rows }` — the arbitrated resize for remote viewers: reflows the shared pane to the caller's grid ONLY while no live local viewport focus owns the window (the TUI heartbeats its viewport every ~5s; ownership lapses 15s after the last beat, and a clean TUI quit releases it immediately) AND no other remote session that's also focused on this window right now drove the agent more recently than the caller (last-interaction-wins among remotes; an applied fit counts as an interaction). Refused (`applied: false`) it answers with the pane's current grid so the caller renders pinned at the shared size instead of fighting. Poll it (~10s) to adapt when the TUI starts or stops viewing. |
 | `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |
 | `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
@@ -103,9 +136,12 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `terminal.close` | `{ id }` | `null` |
 | `terminal.target` | `{ id }` | `{ target, available }` |
 | `fs.browse` | `{ path? }` | `BrowseResult` (subdirs, repos, added flags) |
-| `viewport.set` | `{ lane_ids, focus_lane?, focus_window?, windows? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot. `windows` names plain-terminal windows — `term-{lane}-{n}` — to stream as extra panes alongside the lanes, e.g. the Grid's shell tiles; non-terminal names are ignored) |
+| `viewport.set` | `{ lane_ids, focus_lane?, focus_window?, windows? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot. `windows` names plain-terminal windows — `term-{lane}-{n}` — to stream as extra panes alongside the lanes, e.g. the Grid's shell tiles; non-terminal names are ignored. Per-connection: each connection owns its own viewport and focus; the capture loop streams the union across every live connection, and `event.agent.output` is filtered to the connections whose viewport actually covers it) |
 | `subscribe` | `{ topics? }` | `null` |
 | `ping` | — | `"pong"` (remote keep-alive / connectivity probe) |
+| `remote.pair` | `{ name }` | `{ name, token, url }` — mints (or, for a name already paired, re-shows) that device's own revocable token and its `repomon://` pairing URL. Capped at 16 paired devices. Local socket only. |
+| `remote.devices` | — | `[{ name, role, created_at, last_seen_at? }]` — never includes the token. Local socket only. |
+| `remote.revoke` | `{ name }` | `{ revoked }` — `true` if a device by that name existed; drops it from the auth cache so live connections holding its token are kicked on their next request. Local socket only. |
 | `push.register` | `{ device_token }` | `null` (register an APNs device for push; idempotent) |
 | `push.unregister` | `{ device_token }` | `null` |
 | `daemon.status` | — | `{ uptime_secs, repos, lanes, db_size_bytes, version }` |

--- a/docs/superpowers/specs/2026-07-17-ipad-multi-device-design.md
+++ b/docs/superpowers/specs/2026-07-17-ipad-multi-device-design.md
@@ -1,0 +1,63 @@
+# iPad mission control + multi-device remote — design
+
+Approved 2026-07-17. Companion implementation plan: repomon PRs per workstream (A1–A6 below)
+and repomon-ios milestones (B1–B7, tracked in that repo).
+
+## Decisions
+
+1. **iPad experience: mission-control dashboard.** Persistent fleet sidebar, a grid of live
+   agent terminal tiles, a detail/chat inspector for the focused agent, hardware-keyboard
+   typing into agents. The iPhone flow is unchanged; one universal target switches on size
+   class.
+2. **Remote power: full fleet control.** Paired devices may spawn/stop/adopt agents and
+   create/merge/delete lanes. Enabled by per-device named tokens with individual revocation;
+   the legacy shared config token keeps working.
+3. **Streaming: hybrid, per connection.** Grid tiles ride per-connection viewport capture
+   deltas (~1s, the Mac TUI fleet model). The focused/expanded terminal gets the true PTY
+   byte stream. Byte watches are refcounted per window so the Mac TUI, an iPhone, and an
+   iPad can stream concurrently, including the same window.
+
+## Daemon architecture (repomon)
+
+- **ConnSession** replaces the daemon-global viewport/focus/watch slots: every connection
+  (Unix socket or WebSocket) registers one and `rpc::dispatch` receives it. The capture poll
+  loop streams the **union** of live sessions' viewports; focused windows (any fresh session)
+  get the fast cadence and cursor capture. Single-connection behavior is unchanged, so
+  existing clients are wire-compatible.
+- **Byte watches**: `HashMap<window, WatchEntry{refs, fifo, generation}>`. One tmux
+  `pipe-pane` per window shared by all watchers via the broadcast bus; last unref stops the
+  pipe; connection drop unrefs everything; EOF self-cleanup is generation-guarded.
+  `event.agent.bytes` is forwarded only to connections watching that window.
+- **Fit arbitration**: a local session with a fresh focus beat owns its window (TUI
+  precedence, unchanged); among remotes the freshest `last_interaction` wins — the device
+  you last typed on. `agent.resize` stays local-only.
+- **Per-device tokens**: `remote_devices` table (name, token, role='full', created/last-seen,
+  capped). Sync `Ctx.remote_tokens` cache (std RwLock — the WS handshake callback is
+  synchronous) seeded from store + legacy config token. Local-only RPCs `remote.pair` /
+  `remote.devices` / `remote.revoke`; CLI `repomon remote pair --name ipad`, `devices`,
+  `revoke`. Revocation kicks live connections on their next request.
+- **Allowlist**: expands to full control; still blocked: daemon lifecycle, config/secrets,
+  host terminal + filesystem, `agent.resize`, orchestrator start/stop, `remote.*`.
+
+## App architecture (repomon-ios)
+
+- Universal target (`TARGETED_DEVICE_FAMILY "1,2"`); `RootView` branches on
+  `horizontalSizeClass`: compact → existing TabView, regular → `NavigationSplitView`
+  (fleet sidebar / dashboard grid) + `.inspector` (focused agent chat/dialog/approve).
+- Tiles render ANSI-parsed capture deltas (extracted `CapturePaneText`); exactly one focused
+  tile holds a live SwiftTerm byte stream pinned to the pane's true grid; only the expanded
+  overlay negotiates `agent.fit`. Tiles never call fit.
+- Hardware keyboard: focused terminal is first responder; raw bytes translate through a pure
+  `TerminalInput` mapper to `agent.send_input`/`agent.key`; Cmd-chords stay SwiftUI shortcuts.
+- `DaemonFeatures` (from `daemon.status.version`) gates everything so the app degrades
+  cleanly against older daemons (polling tiles, single-watch rules, hidden management UI).
+
+## Wire-compat contract
+
+- No envelope changes. `viewport.set` and `agent.watch_bytes` keep their shapes; semantics
+  become per-connection (a strict superset for single-connection clients).
+- `agent.watch_bytes {on:false}` without `window` unwatches all of the session's watches for
+  the lane (the TUI's stop path depends on this).
+- New local-only methods: `remote.pair`, `remote.devices`, `remote.revoke`.
+- Version gates: the daemon release shipping A1–A4 is the floor for
+  per-connection viewports, multi-watch, remote fleet control, and multi-remote fit.


### PR DESCRIPTION
## What

The remote bridge grows from "one phone, one viewer" to true multi-device: a Mac TUI, an iPhone, and an iPad can be connected simultaneously, each independently viewing and driving the fleet. Companion PR: the repomon-ios iPad mission-control app.

Design spec: `docs/superpowers/specs/2026-07-17-ipad-multi-device-design.md` (in this diff).

## Changes

- **Per-device tokens** (`remote_devices` table, migration 0006): `repomon remote pair --name ipad` mints a named token; `remote devices` lists; `remote revoke` kicks live connections, including silent ones, and 401s future handshakes. The legacy shared config token keeps working. Credential minting RPCs are local-socket-only.
- **Per-connection sessions** (`ConnSession`): viewport, focus, byte watches, and last-interaction move from daemon globals to per-connection state. The capture poll loop streams the union of live viewports; single-connection behavior is provably identical to before, so existing clients are wire-compatible.
- **Refcounted byte watches**: one tmux pipe-pane per window shared by all watchers, generation-unique fifo paths (kills a stop/restart unlink race), per-connection delivery of `event.agent.bytes` and `event.agent.output`. The TUI and a device can stream different panes, or the same pane, concurrently.
- **Fit arbitration**: the local TUI's fresh focus still owns pane sizing; among remote devices, the one you last typed on wins. `agent.resize` stays local-only.
- **Full-control allowlist**: paired devices can now spawn/stop/adopt agents and create/merge/delete lanes. Still blocked: daemon lifecycle, config/secrets, host terminal and filesystem, credential minting. `lane.create` over the bridge strips caller-supplied paths (defense in depth).
- **Client**: the TUI's RPC client re-asserts its active byte watch on reconnect (watches are per-connection now).
- Workspace version bumped to 0.5.0: `daemon.status.version` is the iOS feature gate.
- `docs/protocol.md` Remote transport section rewritten.

## Testing

- 350+ workspace tests incl. new unit suites (fit arbitration table, watch refcount/generation, delivery filtering, device store) and bridge integration tests (two devices with distinct tokens receiving only their windows' bytes; silent-device revocation; concurrent pair/revoke cache coherence; remote path-strip; reconnect watch replay).
- Live end-to-end on an isolated instance (own socket/DB/config/tmux server): 8/8 scenarios passed, including concurrent TUI + device streaming with correct isolation, revocation kick, and legacy-token auth. Real fleet untouched.
- Adversarial multi-agent review: every workstream task-reviewed, then two whole-branch reviews; all Critical/Important findings fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)