### PR TITLE
chore: apply rustfmt across the workspace

### DIFF
--- a/crates/repomon-core/src/client.rs
+++ b/crates/repomon-core/src/client.rs
@@ -367,8 +367,8 @@ mod tests {
                         while let Ok(Some(frame)) = read_frame(&mut rd).await {
                             if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
                                 latest.lock().unwrap().push(req.method.clone());
-                                let _ =
-                                    write_message(&mut wr, &Response::ok(req.id, Value::Null)).await;
+                                let _ = write_message(&mut wr, &Response::ok(req.id, Value::Null))
+                                    .await;
                             }
                         }
                     });
@@ -439,8 +439,8 @@ mod tests {
                         while let Ok(Some(frame)) = read_frame(&mut rd).await {
                             if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
                                 latest.lock().unwrap().push(req.method.clone());
-                                let _ =
-                                    write_message(&mut wr, &Response::ok(req.id, Value::Null)).await;
+                                let _ = write_message(&mut wr, &Response::ok(req.id, Value::Null))
+                                    .await;
                             }
                         }
                     });

--- a/crates/repomon-core/src/store/mod.rs
+++ b/crates/repomon-core/src/store/mod.rs
@@ -899,7 +899,10 @@ mod tests {
     async fn remote_device_revoke_true_then_false() {
         let s = store().await;
         s.remote_device_pair("phone").await.unwrap();
-        assert!(s.remote_device_revoke("phone").await.unwrap(), "first revoke removes it");
+        assert!(
+            s.remote_device_revoke("phone").await.unwrap(),
+            "first revoke removes it"
+        );
         assert!(
             !s.remote_device_revoke("phone").await.unwrap(),
             "revoking a gone device is false"
@@ -911,10 +914,16 @@ mod tests {
     async fn remote_device_seen_stamps_last_seen() {
         let s = store().await;
         s.remote_device_pair("phone").await.unwrap();
-        assert!(s.remote_device_list().await.unwrap()[0].last_seen_at.is_none());
+        assert!(
+            s.remote_device_list().await.unwrap()[0]
+                .last_seen_at
+                .is_none()
+        );
         s.remote_device_seen("phone").await.unwrap();
         assert!(
-            s.remote_device_list().await.unwrap()[0].last_seen_at.is_some(),
+            s.remote_device_list().await.unwrap()[0]
+                .last_seen_at
+                .is_some(),
             "last_seen_at is stamped"
         );
         // Stamping an unknown device is a harmless no-op (no error).

--- a/crates/repomon-daemon/src/auto_continue.rs
+++ b/crates/repomon-daemon/src/auto_continue.rs
@@ -201,8 +201,7 @@ pub async fn auto_continue_watcher(ctx: Arc<Ctx>) {
         for (window, lane) in windows {
             let tmuxc = ctx.tmux.clone();
             let win = window.clone();
-            let capture =
-                tokio::task::spawn_blocking(move || tmuxc.capture_named(&win, Some(120)));
+            let capture = tokio::task::spawn_blocking(move || tmuxc.capture_named(&win, Some(120)));
             // Bound the capture so one wedged pane can't freeze the serialized per-window scan
             // and stall auto-continue for every other agent. On timeout (or any error) skip this
             // window this tick and try again next time.

--- a/crates/repomon-daemon/src/bytes_stream.rs
+++ b/crates/repomon-daemon/src/bytes_stream.rs
@@ -84,11 +84,7 @@ fn release_ref(entry: &mut WatchEntry, conn_id: u64) -> bool {
 
 /// Whether the reader that started at `generation` still owns `window`'s entry — the EOF-cleanup
 /// guard. False if the entry is gone or has been superseded by a newer pipe. Pure.
-fn eof_entry_is_current(
-    map: &HashMap<String, WatchEntry>,
-    window: &str,
-    generation: u64,
-) -> bool {
+fn eof_entry_is_current(map: &HashMap<String, WatchEntry>, window: &str, generation: u64) -> bool {
     map.get(window).is_some_and(|e| e.generation == generation)
 }
 
@@ -213,7 +209,9 @@ pub async fn unwatch(tmux: &TmuxRuntime, watches: &Watches, window: &str, conn_i
     if !release_ref(entry, conn_id) {
         return; // other connections still share this window's pipe
     }
-    let entry = map.remove(window).expect("entry present under the same lock");
+    let entry = map
+        .remove(window)
+        .expect("entry present under the same lock");
     drop(map);
     let t = tmux.clone();
     let win = window.to_string();

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -768,9 +768,7 @@ mod stream_tests {
         *a.viewport_focus.lock().await = Some((7, "lane-7".to_string()));
         *a.viewport_focus_at.lock().await = Some(Instant::now());
 
-        let b = ctx
-            .open_session(ConnKind::Remote { device: None })
-            .await;
+        let b = ctx.open_session(ConnKind::Remote { device: None }).await;
         *b.viewport.lock().await = vec![9, 12]; // 9 overlaps with A
         *b.viewport_focus.lock().await = Some((12, "lane-12".to_string()));
         *b.viewport_focus_at.lock().await = Some(Instant::now());

--- a/crates/repomon-daemon/src/pubsub.rs
+++ b/crates/repomon-daemon/src/pubsub.rs
@@ -112,7 +112,8 @@ mod tests {
 
     #[test]
     fn bytes_forward_only_to_watchers_of_that_window() {
-        let ev = json!({ "method": topic::AGENT_BYTES, "params": { "window": "lane-1", "data": "x" } });
+        let ev =
+            json!({ "method": topic::AGENT_BYTES, "params": { "window": "lane-1", "data": "x" } });
         let (_, ol, ow) = nothing();
         assert!(deliver_to(&ev, &windows(&["lane-1"]), &ol, &ow));
         assert!(deliver_to(&ev, &windows(&["lane-1", "lane-2"]), &ol, &ow));

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -154,8 +154,7 @@ async fn handle_conn(
             }
             None => {
                 let mut deny = ErrorResponse::new(Some("unauthorized".into()));
-                *deny.status_mut() =
-                    tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
+                *deny.status_mut() = tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
                 Err(deny)
             }
         },
@@ -163,8 +162,7 @@ async fn handle_conn(
     )
     .await?;
     // Present because the handshake only completes on a match.
-    let (conn_token, device_name) =
-        identity.expect("authorized handshake must record an identity");
+    let (conn_token, device_name) = identity.expect("authorized handshake must record an identity");
     let (mut sink, mut source) = ws.split();
 
     // This connection's per-device session, carrying its identity (device name) and its own

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -619,7 +619,9 @@ pub async fn dispatch(
             // hard-erroring) so a harmless client that fills it in still succeeds, while a hostile
             // one can't write outside the managed worktree root. The local Unix socket is unaffected.
             if !sess.is_local() && p.path.take().is_some() {
-                tracing::warn!("remote lane.create supplied a path; ignoring it (deriving template)");
+                tracing::warn!(
+                    "remote lane.create supplied a path; ignoring it (deriving template)"
+                );
             }
             let lane = ctx.lanes.create(p).await.map_err(internal)?;
             ctx.broadcast(crate::pubsub::topic::LANE_CREATED, json!({ "lane": lane }));

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -53,7 +53,9 @@ async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
 }
 
 /// Read one JSON value from the socket (fails the test on a non-text or absent frame).
-async fn recv_json(ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin)) -> Value {
+async fn recv_json(
+    ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin),
+) -> Value {
     match ws.next().await.unwrap().unwrap() {
         Message::Text(t) => serde_json::from_str(&t).unwrap(),
         m => panic!("unexpected frame: {m:?}"),
@@ -160,10 +162,9 @@ async fn bridge_authenticates_a_named_device_and_stamps_last_seen() {
         .push((dev.token.clone(), Some("phone".into())));
     let addr = serve(ctx.clone()).await;
 
-    let (mut ws, _) =
-        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", dev.token))
-            .await
-            .expect("named-device token authorizes");
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", dev.token))
+        .await
+        .expect("named-device token authorizes");
     ws.send(Message::text(
         json!({"jsonrpc":"2.0","id":1,"method":"ping"}).to_string(),
     ))
@@ -181,7 +182,10 @@ async fn bridge_authenticates_a_named_device_and_stamps_last_seen() {
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    assert!(stamped, "a named device's last_seen_at is stamped on connect");
+    assert!(
+        stamped,
+        "a named device's last_seen_at is stamped on connect"
+    );
 }
 
 #[tokio::test]
@@ -216,7 +220,10 @@ async fn bridge_kicks_a_revoked_token_mid_session() {
         ws.next().await,
         None | Some(Ok(Message::Close(_))) | Some(Err(_))
     );
-    assert!(closed, "the bridge closes the socket after a revoked request");
+    assert!(
+        closed,
+        "the bridge closes the socket after a revoked request"
+    );
 }
 
 /// Passive revocation: a device that subscribes and watches, then is revoked while sending NO
@@ -292,23 +299,38 @@ async fn remote_pair_list_revoke_round_trip_over_dispatch() {
     assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
 
     // devices lists the device WITHOUT the token.
-    let devices = rpc::dispatch(&ctx, &sess, "remote.devices", None).await.unwrap();
+    let devices = rpc::dispatch(&ctx, &sess, "remote.devices", None)
+        .await
+        .unwrap();
     let d0 = &devices.as_array().unwrap()[0];
     assert_eq!(d0["name"], json!("phone"));
     assert_eq!(d0["role"], json!("full"));
-    assert!(d0.get("token").is_none(), "the listing never exposes the token");
+    assert!(
+        d0.get("token").is_none(),
+        "the listing never exposes the token"
+    );
 
     // revoke → {revoked:true}, and the auth cache empties.
-    let rev = rpc::dispatch(&ctx, &sess, "remote.revoke", Some(json!({ "name": "phone" })))
-        .await
-        .unwrap();
+    let rev = rpc::dispatch(
+        &ctx,
+        &sess,
+        "remote.revoke",
+        Some(json!({ "name": "phone" })),
+    )
+    .await
+    .unwrap();
     assert_eq!(rev["revoked"], json!(true));
     assert!(ctx.remote_tokens.read().unwrap().is_empty());
 
     // revoking again → {revoked:false}.
-    let rev2 = rpc::dispatch(&ctx, &sess, "remote.revoke", Some(json!({ "name": "phone" })))
-        .await
-        .unwrap();
+    let rev2 = rpc::dispatch(
+        &ctx,
+        &sess,
+        "remote.revoke",
+        Some(json!({ "name": "phone" })),
+    )
+    .await
+    .unwrap();
     assert_eq!(rev2["revoked"], json!(false));
 }
 
@@ -501,12 +523,14 @@ async fn bytes_events_are_delivered_per_connection() {
     }
     let addr = serve(ctx.clone()).await;
 
-    let (mut ws_p, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
-        .await
-        .expect("phone connects");
-    let (mut ws_i, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
-        .await
-        .expect("ipad connects");
+    let (mut ws_p, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
+            .await
+            .expect("phone connects");
+    let (mut ws_i, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
+            .await
+            .expect("ipad connects");
 
     // Each connection watches a different window.
     session_for_device(&ctx, "phone")
@@ -584,20 +608,35 @@ async fn output_events_are_delivered_per_connection() {
     }
     let addr = serve(ctx.clone()).await;
 
-    let (mut ws_p, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
-        .await
-        .expect("phone connects");
-    let (mut ws_i, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
-        .await
-        .expect("ipad connects");
-    let (mut ws_l, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", laptop.token))
-        .await
-        .expect("laptop connects");
+    let (mut ws_p, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", phone.token))
+            .await
+            .expect("phone connects");
+    let (mut ws_i, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", ipad.token))
+            .await
+            .expect("ipad connects");
+    let (mut ws_l, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/?token={}", laptop.token))
+            .await
+            .expect("laptop connects");
 
     // Phone's viewport covers lane 1, iPad's covers lane 2; laptop never asserts a viewport, so its
     // `output_filter` stays at its empty session-creation zero-state.
-    session_for_device(&ctx, "phone").await.output_filter.lock().unwrap().0.insert(1);
-    session_for_device(&ctx, "ipad").await.output_filter.lock().unwrap().0.insert(2);
+    session_for_device(&ctx, "phone")
+        .await
+        .output_filter
+        .lock()
+        .unwrap()
+        .0
+        .insert(1);
+    session_for_device(&ctx, "ipad")
+        .await
+        .output_filter
+        .lock()
+        .unwrap()
+        .0
+        .insert(2);
 
     // Subscribe all three and drain the acks (forwarding is on once the ack returns).
     for (ws, id) in [(&mut ws_p, 1u64), (&mut ws_i, 2u64), (&mut ws_l, 3u64)] {
@@ -685,7 +724,9 @@ async fn close_session_releases_only_this_connections_watches() {
         !map.contains_key("lane-2"),
         "A's solo window is stopped when A disconnects"
     );
-    let shared = map.get("lane-1").expect("B still watches the shared window");
+    let shared = map
+        .get("lane-1")
+        .expect("B still watches the shared window");
     assert_eq!(
         shared.refs.iter().copied().collect::<Vec<_>>(),
         vec![b.id],
@@ -800,7 +841,9 @@ async fn watch_bytes_off_without_window_releases_only_that_lanes_watches() {
     // Real windows to pipe: two on lane 1 (default-named and a second slot), one on lane 2.
     let cwd = std::env::temp_dir();
     for w in ["lane-1", "lane-1-2", "lane-2"] {
-        ctx.tmux.spawn_named(w, &cwd, "sleep 30").expect("spawn window");
+        ctx.tmux
+            .spawn_named(w, &cwd, "sleep 30")
+            .expect("spawn window");
     }
 
     let sess = ctx.open_session(ConnKind::Local).await;
@@ -851,8 +894,14 @@ async fn watch_bytes_off_without_window_releases_only_that_lanes_watches() {
 
     {
         let map = ctx.bytes_watches.lock().await;
-        assert!(!map.contains_key("lane-1"), "lane 1's default window released");
-        assert!(!map.contains_key("lane-1-2"), "lane 1's second window released");
+        assert!(
+            !map.contains_key("lane-1"),
+            "lane 1's default window released"
+        );
+        assert!(
+            !map.contains_key("lane-1-2"),
+            "lane 1's second window released"
+        );
         let survivor = map.get("lane-2").expect("lane 2's watch survives");
         assert!(survivor.refs.contains(&sess.id));
     }

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -351,7 +351,8 @@ async fn remote_devices(config: &Config, socket: Option<PathBuf>) -> Result<()> 
     if devices.is_empty() {
         println!("no paired devices");
     } else {
-        let str_field = |d: &Value, k: &str| d.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let str_field =
+            |d: &Value, k: &str| d.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
         let name_w = devices
             .iter()
             .map(|d| str_field(d, "name").len())


### PR DESCRIPTION
Unbreaks CI on main: the multi-device merges (#55, #57, #58) landed rustfmt-non-conformant code because local verification ran tests and clippy but not fmt. Formatting only, no semantic changes; full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)