### PR TITLE
fix(daemon): pairing URL name as query item; retry the remote bridge bind

### DIFF
--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -158,8 +158,22 @@ async fn main() {
                     }
                     let ctx_r = ctx.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = repomon_daemon::remote::serve_remote(ctx_r, &bind).await {
-                            tracing::error!("remote bridge failed: {e}");
+                        // Keep retrying, not just at startup: the bind is typically a Tailscale
+                        // IP, which isn't assignable until the tailnet interface is up — a
+                        // daemon started at login (or a Mac waking from sleep) raced it and the
+                        // bridge stayed dead until the next manual restart. Ok(()) means a
+                        // clean shutdown; any Err waits out a short delay and binds again.
+                        loop {
+                            match repomon_daemon::remote::serve_remote(ctx_r.clone(), &bind).await {
+                                Ok(()) => break,
+                                Err(e) => {
+                                    tracing::warn!("remote bridge failed (retrying in 15s): {e}");
+                                }
+                            }
+                            tokio::select! {
+                                _ = ctx_r.shutdown.notified() => break,
+                                _ = tokio::time::sleep(std::time::Duration::from_secs(15)) => {}
+                            }
                         }
                     });
                 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -59,8 +59,10 @@ pub async fn refresh_remote_tokens(ctx: &Ctx) -> Result<(), RpcError> {
     Ok(())
 }
 
-/// The pairing URL the companion app scans: the same `repomon://<bind>#<token>` shape the legacy
-/// QR uses, with `&name=<urlencoded>` appended to the fragment so the app can label the connection.
+/// The pairing URL the companion app scans: `repomon://<bind>?name=<urlencoded>#<token>`. The
+/// device name is a QUERY item and the fragment is the bare token — both the current app and
+/// the legacy phone build take the entire fragment as the token, so splicing `&name=` into the
+/// fragment corrupted the stored token and every named pairing 401'd at the handshake.
 async fn remote_pair_url(ctx: &Ctx, dev: &RemoteDevice) -> String {
     let bind = ctx
         .config
@@ -71,9 +73,9 @@ async fn remote_pair_url(ctx: &Ctx, dev: &RemoteDevice) -> String {
         .clone()
         .unwrap_or_default();
     format!(
-        "repomon://{bind}#{}&name={}",
+        "repomon://{bind}?name={}#{}",
+        percent_encode(&dev.name),
         dev.token,
-        percent_encode(&dev.name)
     )
 }
 

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -283,12 +283,15 @@ async fn remote_pair_list_revoke_round_trip_over_dispatch() {
         .await
         .unwrap();
     assert_eq!(pair["name"], json!("phone"));
-    assert!(pair["token"].as_str().unwrap().len() >= 32);
-    assert!(pair["url"].as_str().unwrap().starts_with("repomon://"));
-    assert!(
-        pair["url"].as_str().unwrap().contains("&name=phone"),
-        "the pairing url carries the device name"
-    );
+    let token = pair["token"].as_str().unwrap();
+    assert!(token.len() >= 32);
+    // The app parses the token as the ENTIRE fragment and the device name from a `?name=`
+    // query item; the shipped phone build knows only the fragment. So the name must ride as
+    // a query item BEFORE the fragment, and the fragment must be the bare token — appending
+    // `&name=` inside the fragment corrupted the token every named pairing stored (seen live:
+    // the iPad 401'd on every handshake with "seen never").
+    let url = pair["url"].as_str().unwrap();
+    assert_eq!(url, &format!("repomon://?name=phone#{token}"));
     assert_eq!(ctx.remote_tokens.read().unwrap().len(), 1);
 
     // re-pair the same name is idempotent (same token, no second cache entry).


### PR DESCRIPTION
Found while pairing a real iPad: it stored `<token>&name=ipad` as its bearer token because the pair URL spliced the device name into the fragment, while the app (and the shipped phone build) parse the ENTIRE fragment as the token. Every handshake 401'd ("There was a bad response from the server", device `seen never`). The name now rides as a `?name=` query item ahead of a bare-token fragment, which the current app already parses and the legacy parser safely ignores.

Also fixes the bridge staying dead when the bind address isn't assignable at startup (Tailscale IP not up yet; three occurrences in today's logs): the serve task now retries every 15s until clean shutdown.

Exact-shape URL assertion added to the pair round-trip test (was RED against the old format); workspace tests, clippy, and fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)