### PR TITLE
fix(daemon): CFNetwork-compatible websocket handshake with a read deadline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "httparse",
  "repomon-core",
  "repomon-mcp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-tungstenite = "0.29"
+httparse = "1"
 a2 = { version = "0.10", default-features = false, features = ["ring"] }
 futures = "0.3"
 plist = "1"

--- a/crates/repomon-daemon/Cargo.toml
+++ b/crates/repomon-daemon/Cargo.toml
@@ -21,6 +21,7 @@ repomon-core = { workspace = true }
 repomon-mcp = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
+httparse = { workspace = true }
 a2 = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -13,11 +13,14 @@ use std::time::{Duration, Instant};
 
 use futures::{SinkExt, StreamExt};
 use repomon_core::protocol::{MAX_FRAME_BYTES, Request, Response, RpcError};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast::error::RecvError;
+use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request as HsRequest};
-use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+use tokio_tungstenite::tungstenite::http;
+use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
 
 use crate::{Ctx, rpc};
 
@@ -103,6 +106,13 @@ fn remote_method_allowed(method: &str) -> bool {
 pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str) -> std::io::Result<()> {
     let listener = TcpListener::bind(bind).await?;
     tracing::info!("remote bridge listening on ws://{bind}");
+    serve_remote_on(ctx, listener).await
+}
+
+/// Serve the WebSocket bridge on an already-bound listener. Split out from `serve_remote` so tests
+/// can bind an exclusive ephemeral port and hand the live listener in — with no bind-then-rebind
+/// window for a concurrent test to race on.
+pub async fn serve_remote_on(ctx: Arc<Ctx>, listener: TcpListener) -> std::io::Result<()> {
     let conns = Arc::new(AtomicUsize::new(0));
 
     loop {
@@ -134,35 +144,72 @@ pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str) -> std::io::Result<()> {
 /// How often a live connection re-stamps its device's `last_seen_at` (throttled, per connection).
 const LAST_SEEN_THROTTLE: Duration = Duration::from_secs(60);
 
-// `result_large_err`: the auth closure's Err type (a full http::Response) is dictated by
-// tungstenite's `Callback` contract — nothing to box here.
-#[allow(clippy::result_large_err)]
+/// Upper bound on the handshake request head we'll buffer before giving up — a WS upgrade request
+/// is a few hundred bytes; anything past this is not a client we serve.
+const MAX_HANDSHAKE_BYTES: usize = 16 * 1024;
+
 async fn handle_conn(
     ctx: Arc<Ctx>,
-    stream: TcpStream,
+    mut stream: TcpStream,
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
-    // Check the token during the handshake — an unauthorized client never completes the upgrade
-    // and learns nothing but "401". The matching entry's identity (device name, `None` for the
-    // legacy shared token) and the token itself are captured out of the callback.
-    let mut identity: Option<(String, Option<String>)> = None;
-    let ws = tokio_tungstenite::accept_hdr_async_with_config(
-        stream,
-        |req: &HsRequest, resp| match authorize(req, &ctx) {
-            Some(hit) => {
-                identity = Some(hit);
-                Ok(resp)
-            }
-            None => {
-                let mut deny = ErrorResponse::new(Some("unauthorized".into()));
-                *deny.status_mut() = tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
-                Err(deny)
-            }
-        },
-        Some(remote_ws_config()),
-    )
-    .await?;
-    // Present because the handshake only completes on a match.
-    let (conn_token, device_name) = identity.expect("authorized handshake must record an identity");
+    // Hand-rolled handshake so the 101 response uses Title-Case header names (`Connection`,
+    // `Upgrade`, `Sec-WebSocket-Accept`). tokio-tungstenite's server path serializes them through
+    // the `http` crate's `HeaderMap`, which canonicalizes names to lowercase; iOS 27's CFNetwork
+    // rejects that lowercase 101 outright ("bad response from the server"), so we emit the bytes
+    // ourselves and only then hand the raw socket to tungstenite for the framed protocol.
+    //
+    // Read the request head (bounded), then authenticate BEFORE any upgrade — an unauthorized
+    // client gets a 401 and a closed socket, never a WebSocket and never any connection state.
+    let head = match read_handshake_head(&mut stream).await {
+        Ok(head) => head,
+        // Malformed, oversized, or a peer that hung up mid-handshake: drop it quietly.
+        Err(_) => return Ok(()),
+    };
+    let req = match parse_request(&head) {
+        Some(req) => req,
+        None => {
+            let _ = write_simple_response(&mut stream, 400, "Bad Request").await;
+            return Ok(());
+        }
+    };
+
+    // Constant-time token check, before the upgrade. The matching entry's identity (device name,
+    // `None` for the legacy shared token) and the token itself are captured for the session below.
+    let (conn_token, device_name) = match authorize(&req, &ctx) {
+        Some(hit) => hit,
+        None => {
+            // 401 with Title-Case headers, then terminate the connection.
+            let _ = write_simple_response(&mut stream, 401, "Unauthorized").await;
+            return Ok(());
+        }
+    };
+
+    // Validate the WebSocket upgrade and derive the accept key. A malformed upgrade (missing
+    // Upgrade/Connection/Version/Key) never reaches this authenticated client's session.
+    let accept = match ws_accept_key(&req) {
+        Some(accept) => accept,
+        None => {
+            let _ = write_simple_response(&mut stream, 400, "Bad Request").await;
+            return Ok(());
+        }
+    };
+
+    // Emit the Title-Case 101. `permessage-deflate` is deliberately NOT negotiated: we omit
+    // `Sec-WebSocket-Extensions` entirely, so no compression is agreed (matching the reference
+    // server iOS 27 accepts).
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Accept: {accept}\r\n\
+         \r\n"
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.flush().await?;
+
+    // Hand the post-handshake socket to tungstenite for the framed protocol, keeping the same
+    // MAX_FRAME_BYTES bounds the previous accept path applied.
+    let ws = WebSocketStream::from_raw_socket(stream, Role::Server, Some(remote_ws_config())).await;
     let (mut sink, mut source) = ws.split();
 
     // This connection's per-device session, carrying its identity (device name) and its own
@@ -290,10 +337,119 @@ where
     sink.send(Message::text(text)).await
 }
 
+/// Read the HTTP request head (up to and including the terminating CRLFCRLF) from a freshly
+/// accepted socket, bounded by `MAX_HANDSHAKE_BYTES`. A WebSocket client sends nothing before the
+/// 101, so a well-behaved peer never writes bytes past the head; if it does, that's a protocol
+/// violation and we error (there's no way to feed a tail to `from_raw_socket`, and tungstenite's
+/// own server rejects junk-after-request identically).
+async fn read_handshake_head(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "eof during handshake",
+            ));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(end) = find_headers_end(&buf) {
+            if end != buf.len() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "junk after handshake request",
+                ));
+            }
+            return Ok(buf);
+        }
+        if buf.len() > MAX_HANDSHAKE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "handshake request head too large",
+            ));
+        }
+    }
+}
+
+/// Index just past the `\r\n\r\n` that ends an HTTP head, if present.
+fn find_headers_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
+}
+
+/// Parse a raw HTTP request head into an `http::Request<()>` so the existing token-auth path can
+/// read its headers and query. Returns `None` for anything that isn't a complete `GET` request.
+fn parse_request(head: &[u8]) -> Option<http::Request<()>> {
+    let mut headers = [httparse::EMPTY_HEADER; 64];
+    let mut parsed = httparse::Request::new(&mut headers);
+    match parsed.parse(head) {
+        Ok(httparse::Status::Complete(_)) => {}
+        _ => return None,
+    }
+    // WebSocket upgrades are always GET; reject anything else outright.
+    if !parsed.method.is_some_and(|m| m.eq_ignore_ascii_case("GET")) {
+        return None;
+    }
+    let mut builder = http::Request::builder()
+        .method(http::Method::GET)
+        .uri(parsed.path?);
+    for h in parsed.headers.iter() {
+        builder = builder.header(h.name, h.value);
+    }
+    builder.body(()).ok()
+}
+
+/// Validate the WebSocket upgrade request (case-insensitively, per RFC 9110) and, if valid, return
+/// the `Sec-WebSocket-Accept` value for the client's key. Mirrors the checks tungstenite's server
+/// performs before it would have produced a 101.
+fn ws_accept_key(req: &http::Request<()>) -> Option<String> {
+    let headers = req.headers();
+    let upgrade_ok = headers
+        .get("Upgrade")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+    let connection_ok = headers
+        .get("Connection")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| {
+            v.split([' ', ','])
+                .any(|p| p.trim().eq_ignore_ascii_case("Upgrade"))
+        });
+    let version_ok = headers
+        .get("Sec-WebSocket-Version")
+        .is_some_and(|v| v == "13");
+    if !(upgrade_ok && connection_ok && version_ok) {
+        return None;
+    }
+    let key = headers.get("Sec-WebSocket-Key")?;
+    Some(derive_accept_key(key.as_bytes()))
+}
+
+/// Write a minimal Title-Case HTTP response (used for the 401 and 400 pre-upgrade refusals) and
+/// signal connection close. Best-effort: the caller drops the socket right after.
+async fn write_simple_response(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+) -> std::io::Result<()> {
+    let body = reason;
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Connection: close\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {len}\r\n\
+         \r\n{body}",
+        len = body.len(),
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.flush().await?;
+    stream.shutdown().await
+}
+
 /// Match the handshake's presented token against the auth cache. On a hit, returns
 /// `Some((token, device_name))` — `device_name` is `None` for the legacy shared config token — so
 /// the connection learns the identity it authenticated as. `None` means no valid token (→ 401).
-fn authorize(req: &HsRequest, ctx: &Ctx) -> Option<(String, Option<String>)> {
+fn authorize(req: &http::Request<()>, ctx: &Ctx) -> Option<(String, Option<String>)> {
     let presented = presented_token(req)?;
     let tokens = ctx.remote_tokens.read().unwrap();
     for (tok, name) in tokens.iter() {
@@ -315,7 +471,7 @@ fn token_present(ctx: &Ctx, token: &str) -> bool {
 
 /// The token a handshake request carries: `Authorization: Bearer <token>` or a `token=<token>`
 /// query parameter (for clients that can't set headers on a WS dial).
-fn presented_token(req: &HsRequest) -> Option<String> {
+fn presented_token(req: &http::Request<()>) -> Option<String> {
     req.headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -113,6 +113,16 @@ pub async fn serve_remote(ctx: Arc<Ctx>, bind: &str) -> std::io::Result<()> {
 /// can bind an exclusive ephemeral port and hand the live listener in — with no bind-then-rebind
 /// window for a concurrent test to race on.
 pub async fn serve_remote_on(ctx: Arc<Ctx>, listener: TcpListener) -> std::io::Result<()> {
+    serve_remote_on_with_timeout(ctx, listener, HANDSHAKE_TIMEOUT).await
+}
+
+/// As `serve_remote_on`, but with an explicit pre-upgrade handshake deadline. Exposed so tests can
+/// drive a short deadline deterministically; production always uses `HANDSHAKE_TIMEOUT`.
+pub async fn serve_remote_on_with_timeout(
+    ctx: Arc<Ctx>,
+    listener: TcpListener,
+    handshake_timeout: Duration,
+) -> std::io::Result<()> {
     let conns = Arc::new(AtomicUsize::new(0));
 
     loop {
@@ -129,7 +139,7 @@ pub async fn serve_remote_on(ctx: Arc<Ctx>, listener: TcpListener) -> std::io::R
                     let ctx = ctx.clone();
                     tokio::spawn(async move {
                         let _guard = guard;
-                        if let Err(e) = handle_conn(ctx, stream).await {
+                        if let Err(e) = handle_conn(ctx, stream, handshake_timeout).await {
                             tracing::debug!("remote conn {addr}: {e}");
                         }
                     });
@@ -148,64 +158,27 @@ const LAST_SEEN_THROTTLE: Duration = Duration::from_secs(60);
 /// is a few hundred bytes; anything past this is not a client we serve.
 const MAX_HANDSHAKE_BYTES: usize = 16 * 1024;
 
+/// Deadline for the entire pre-upgrade handshake (head read through the 101 write). Auth precedes
+/// the upgrade, so a peer that connects and then dribbles or stays silent would otherwise hold its
+/// `MAX_REMOTE_CONNS` slot forever without ever authenticating; the deadline drops it so a burst of
+/// idle connections can't starve the cap.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 async fn handle_conn(
     ctx: Arc<Ctx>,
     mut stream: TcpStream,
+    handshake_timeout: Duration,
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
-    // Hand-rolled handshake so the 101 response uses Title-Case header names (`Connection`,
-    // `Upgrade`, `Sec-WebSocket-Accept`). tokio-tungstenite's server path serializes them through
-    // the `http` crate's `HeaderMap`, which canonicalizes names to lowercase; iOS 27's CFNetwork
-    // rejects that lowercase 101 outright ("bad response from the server"), so we emit the bytes
-    // ourselves and only then hand the raw socket to tungstenite for the framed protocol.
-    //
-    // Read the request head (bounded), then authenticate BEFORE any upgrade — an unauthorized
-    // client gets a 401 and a closed socket, never a WebSocket and never any connection state.
-    let head = match read_handshake_head(&mut stream).await {
-        Ok(head) => head,
-        // Malformed, oversized, or a peer that hung up mid-handshake: drop it quietly.
-        Err(_) => return Ok(()),
+    // Bound the whole pre-upgrade handshake (read + auth + 101). On elapse we return, dropping the
+    // socket and decrementing the connection guard, so a silent/dribbling peer can't hold its slot.
+    let identity = match tokio::time::timeout(handshake_timeout, negotiate(&ctx, &mut stream)).await
+    {
+        Ok(Ok(Some(identity))) => identity,
+        // A refusal (400/401/426) was already written, or a malformed/oversized/EOF handshake, or
+        // the deadline elapsed: in every case just drop the connection quietly.
+        Ok(Ok(None)) | Ok(Err(_)) | Err(_) => return Ok(()),
     };
-    let req = match parse_request(&head) {
-        Some(req) => req,
-        None => {
-            let _ = write_simple_response(&mut stream, 400, "Bad Request").await;
-            return Ok(());
-        }
-    };
-
-    // Constant-time token check, before the upgrade. The matching entry's identity (device name,
-    // `None` for the legacy shared token) and the token itself are captured for the session below.
-    let (conn_token, device_name) = match authorize(&req, &ctx) {
-        Some(hit) => hit,
-        None => {
-            // 401 with Title-Case headers, then terminate the connection.
-            let _ = write_simple_response(&mut stream, 401, "Unauthorized").await;
-            return Ok(());
-        }
-    };
-
-    // Validate the WebSocket upgrade and derive the accept key. A malformed upgrade (missing
-    // Upgrade/Connection/Version/Key) never reaches this authenticated client's session.
-    let accept = match ws_accept_key(&req) {
-        Some(accept) => accept,
-        None => {
-            let _ = write_simple_response(&mut stream, 400, "Bad Request").await;
-            return Ok(());
-        }
-    };
-
-    // Emit the Title-Case 101. `permessage-deflate` is deliberately NOT negotiated: we omit
-    // `Sec-WebSocket-Extensions` entirely, so no compression is agreed (matching the reference
-    // server iOS 27 accepts).
-    let response = format!(
-        "HTTP/1.1 101 Switching Protocols\r\n\
-         Connection: Upgrade\r\n\
-         Upgrade: websocket\r\n\
-         Sec-WebSocket-Accept: {accept}\r\n\
-         \r\n"
-    );
-    stream.write_all(response.as_bytes()).await?;
-    stream.flush().await?;
+    let (conn_token, device_name) = identity;
 
     // Hand the post-handshake socket to tungstenite for the framed protocol, keeping the same
     // MAX_FRAME_BYTES bounds the previous accept path applied.
@@ -337,6 +310,71 @@ where
     sink.send(Message::text(text)).await
 }
 
+/// Run the entire pre-upgrade handshake: read the bounded request head, authenticate (constant
+/// time, BEFORE any upgrade), validate the WebSocket upgrade, and write the Title-Case 101. Returns
+/// `Ok(Some(identity))` on success; `Ok(None)` when the client was cleanly refused (a 400/401/426
+/// was written here); `Err` on an I/O error, malformed/oversized head, or EOF. The caller wraps
+/// this in a deadline and drops the socket for any non-`Some` outcome.
+///
+/// Hand-rolled (rather than tokio-tungstenite's server path) so the 101 uses Title-Case header
+/// names (`Connection`, `Upgrade`, `Sec-WebSocket-Accept`): tungstenite serializes them through the
+/// `http` crate's `HeaderMap`, which canonicalizes names to lowercase, and iOS 27's CFNetwork
+/// rejects that lowercase 101 outright ("bad response from the server").
+async fn negotiate(
+    ctx: &Arc<Ctx>,
+    stream: &mut TcpStream,
+) -> std::io::Result<Option<(String, Option<String>)>> {
+    let head = read_handshake_head(stream).await?;
+    let Some(req) = parse_request(&head) else {
+        write_simple_response(stream, 400, "Bad Request", &[]).await?;
+        return Ok(None);
+    };
+
+    // Constant-time token check, before the upgrade. The matching entry's identity (device name,
+    // `None` for the legacy shared token) and the token itself are captured for the session.
+    let Some(identity) = authorize(&req, ctx) else {
+        // 401 with Title-Case headers, then terminate the connection.
+        write_simple_response(stream, 401, "Unauthorized", &[]).await?;
+        return Ok(None);
+    };
+
+    // Validate the WebSocket upgrade and derive the accept key. A malformed upgrade never reaches
+    // this authenticated client's session.
+    let accept = match ws_upgrade(&req) {
+        WsUpgrade::Accept(accept) => accept,
+        // RFC 6455 §4.4: on an unsupported version, answer 426 and advertise the version we speak
+        // so a mismatched client can retry rather than guess.
+        WsUpgrade::BadVersion => {
+            write_simple_response(
+                stream,
+                426,
+                "Upgrade Required",
+                &[("Sec-WebSocket-Version", "13")],
+            )
+            .await?;
+            return Ok(None);
+        }
+        WsUpgrade::Malformed => {
+            write_simple_response(stream, 400, "Bad Request", &[]).await?;
+            return Ok(None);
+        }
+    };
+
+    // Emit the Title-Case 101. `permessage-deflate` is deliberately NOT negotiated: we omit
+    // `Sec-WebSocket-Extensions` entirely, so no compression is agreed (matching the reference
+    // server iOS 27 accepts).
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Accept: {accept}\r\n\
+         \r\n"
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.flush().await?;
+    Ok(Some(identity))
+}
+
 /// Read the HTTP request head (up to and including the terminating CRLFCRLF) from a freshly
 /// accepted socket, bounded by `MAX_HANDSHAKE_BYTES`. A WebSocket client sends nothing before the
 /// 101, so a well-behaved peer never writes bytes past the head; if it does, that's a protocol
@@ -399,10 +437,20 @@ fn parse_request(head: &[u8]) -> Option<http::Request<()>> {
     builder.body(()).ok()
 }
 
-/// Validate the WebSocket upgrade request (case-insensitively, per RFC 9110) and, if valid, return
-/// the `Sec-WebSocket-Accept` value for the client's key. Mirrors the checks tungstenite's server
-/// performs before it would have produced a 101.
-fn ws_accept_key(req: &http::Request<()>) -> Option<String> {
+/// The outcome of validating a WebSocket upgrade request.
+enum WsUpgrade {
+    /// A valid upgrade; carries the `Sec-WebSocket-Accept` value for the client's key.
+    Accept(String),
+    /// A websocket upgrade whose `Sec-WebSocket-Version` isn't the 13 we speak (→ 426).
+    BadVersion,
+    /// Not a well-formed websocket upgrade at all: missing Upgrade/Connection/Key (→ 400).
+    Malformed,
+}
+
+/// Validate the WebSocket upgrade request (case-insensitively, per RFC 9110). Mirrors the checks
+/// tungstenite's server performs before it would have produced a 101, but distinguishes a version
+/// mismatch (answerable with 426) from an otherwise malformed upgrade.
+fn ws_upgrade(req: &http::Request<()>) -> WsUpgrade {
     let headers = req.headers();
     let upgrade_ok = headers
         .get("Upgrade")
@@ -415,32 +463,39 @@ fn ws_accept_key(req: &http::Request<()>) -> Option<String> {
             v.split([' ', ','])
                 .any(|p| p.trim().eq_ignore_ascii_case("Upgrade"))
         });
-    let version_ok = headers
-        .get("Sec-WebSocket-Version")
-        .is_some_and(|v| v == "13");
-    if !(upgrade_ok && connection_ok && version_ok) {
-        return None;
+    if !(upgrade_ok && connection_ok) {
+        return WsUpgrade::Malformed;
     }
-    let key = headers.get("Sec-WebSocket-Key")?;
-    Some(derive_accept_key(key.as_bytes()))
+    if headers
+        .get("Sec-WebSocket-Version")
+        .is_none_or(|v| v != "13")
+    {
+        return WsUpgrade::BadVersion;
+    }
+    match headers.get("Sec-WebSocket-Key") {
+        Some(key) => WsUpgrade::Accept(derive_accept_key(key.as_bytes())),
+        None => WsUpgrade::Malformed,
+    }
 }
 
-/// Write a minimal Title-Case HTTP response (used for the 401 and 400 pre-upgrade refusals) and
-/// signal connection close. Best-effort: the caller drops the socket right after.
+/// Write a minimal Title-Case HTTP response (used for the 400/401/426 pre-upgrade refusals) with
+/// any extra headers, and signal connection close. Best-effort: the caller drops the socket right
+/// after.
 async fn write_simple_response(
     stream: &mut TcpStream,
     status: u16,
     reason: &str,
+    extra_headers: &[(&str, &str)],
 ) -> std::io::Result<()> {
     let body = reason;
-    let response = format!(
-        "HTTP/1.1 {status} {reason}\r\n\
-         Connection: close\r\n\
-         Content-Type: text/plain\r\n\
-         Content-Length: {len}\r\n\
-         \r\n{body}",
+    let mut response = format!("HTTP/1.1 {status} {reason}\r\nConnection: close\r\n");
+    for (name, value) in extra_headers {
+        response.push_str(&format!("{name}: {value}\r\n"));
+    }
+    response.push_str(&format!(
+        "Content-Type: text/plain\r\nContent-Length: {len}\r\n\r\n{body}",
         len = body.len(),
-    );
+    ));
     stream.write_all(response.as_bytes()).await?;
     stream.flush().await?;
     stream.shutdown().await
@@ -470,7 +525,9 @@ fn token_present(ctx: &Ctx, token: &str) -> bool {
 }
 
 /// The token a handshake request carries: `Authorization: Bearer <token>` or a `token=<token>`
-/// query parameter (for clients that can't set headers on a WS dial).
+/// query parameter (for clients that can't set headers on a WS dial). The query value is taken
+/// verbatim (no percent-decoding): minted tokens are URL-safe by construction, so a raw `%` never
+/// appears in a legitimate token and decoding would only widen the input we accept.
 fn presented_token(req: &http::Request<()>) -> Option<String> {
     req.headers()
         .get("authorization")

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -25,6 +25,17 @@ async fn serve(ctx: Arc<Ctx>) -> String {
     addr
 }
 
+/// As `serve`, but with an explicit (short) pre-upgrade handshake deadline so the deadline test is
+/// fast and deterministic instead of waiting the 10s production default.
+async fn serve_with_timeout(ctx: Arc<Ctx>, handshake_timeout: Duration) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        remote::serve_remote_on_with_timeout(ctx, listener, handshake_timeout).await
+    });
+    addr
+}
+
 async fn start_bridge(token: &str) -> (Arc<Ctx>, String) {
     let store = Store::open_in_memory().unwrap();
     let ctx = Ctx::new(store, Config::default(), None);
@@ -260,6 +271,77 @@ async fn handshake_bad_token_gets_401_and_closes() {
         .expect("the server closes the socket within 2s")
         .expect("read after 401");
     assert_eq!(n, 0, "the connection must be closed after a 401");
+}
+
+/// An authenticated client offering an unsupported `Sec-WebSocket-Version` gets a 426 that
+/// advertises the version the bridge speaks (RFC 6455 §4.4), not a bare 400.
+#[tokio::test]
+async fn handshake_bad_version_gets_426_with_supported_version() {
+    let (_ctx, addr) = start_bridge("sekrit-token").await;
+    let request = format!(
+        "GET /?token=sekrit-token HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Key: {SAMPLE_KEY}\r\n\
+         Sec-WebSocket-Version: 8\r\n\
+         \r\n"
+    );
+    let (_stream, resp) = raw_handshake(&addr, &request).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 426 "),
+        "an unsupported version must get 426 Upgrade Required: {resp:?}"
+    );
+    assert!(
+        resp.contains("\r\nSec-WebSocket-Version: 13\r\n"),
+        "the 426 must advertise the supported version: {resp:?}"
+    );
+}
+
+/// A peer that connects and then dribbles half a request line (never completing the head) must be
+/// dropped by the pre-upgrade handshake deadline rather than held open forever. The slot it briefly
+/// occupied must be freed, so a later legit handshake still succeeds. Uses a short injected deadline
+/// (200ms) so the test is fast and deterministic; production uses the 10s default.
+#[tokio::test]
+async fn handshake_deadline_drops_a_dribbling_client_and_frees_the_slot() {
+    let store = Store::open_in_memory().unwrap();
+    let ctx = Ctx::new(store, Config::default(), None);
+    ctx.remote_tokens
+        .write()
+        .unwrap()
+        .push(("tok".to_string(), None));
+    let addr = serve_with_timeout(ctx.clone(), Duration::from_millis(200)).await;
+
+    // Connect and send only a partial request head (no terminating CRLFCRLF), then go quiet.
+    let mut dribble = tokio::net::TcpStream::connect(&addr).await.unwrap();
+    dribble
+        .write_all(b"GET /?token=tok HTTP/1.1\r\nHost: 127.0.0.1\r\n")
+        .await
+        .unwrap();
+    dribble.flush().await.unwrap();
+
+    // The server closes it once the deadline elapses: the next read returns EOF (0 bytes), well
+    // within a generous ceiling that still catches a never-closing socket.
+    let mut buf = [0u8; 8];
+    let n = tokio::time::timeout(Duration::from_secs(5), dribble.read(&mut buf))
+        .await
+        .expect("the server drops a dribbling client within the deadline")
+        .expect("read after the server closes");
+    assert_eq!(
+        n, 0,
+        "a client that never completes the handshake is disconnected by the deadline"
+    );
+
+    // A subsequent legit handshake still succeeds — the dribbling client's slot was freed.
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/?token=tok"))
+        .await
+        .expect("a legit client connects after the dribbling one is reaped");
+    ws.send(Message::text(
+        json!({"jsonrpc":"2.0","id":1,"method":"ping"}).to_string(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(recv_json(&mut ws).await["result"], json!("pong"));
 }
 
 #[tokio::test]

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -10,33 +10,18 @@ use repomon_daemon::bytes_stream::WatchEntry;
 use repomon_daemon::conn::{ConnKind, ConnSession};
 use repomon_daemon::{Ctx, remote, rpc};
 use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_tungstenite::tungstenite::Message;
 
-/// A free localhost port (bind :0, read it back, release).
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
-/// Serve a prepared `ctx` on a fresh localhost port and wait for the listener. Tokens must already
-/// be seeded into `ctx.remote_tokens` (that is now the auth source, not a serve_remote argument).
+/// Serve a prepared `ctx` on an exclusive ephemeral localhost port. The listener is bound here
+/// (never released before `serve_remote_on` takes it), so there is no bind-then-rebind window for a
+/// concurrent test to steal the port — the socket accepts connections from the moment this returns.
+/// Tokens must already be seeded into `ctx.remote_tokens` (that is the auth source, not a
+/// serve_remote argument).
 async fn serve(ctx: Arc<Ctx>) -> String {
-    let addr = format!("127.0.0.1:{}", free_port());
-    {
-        let ctx = ctx.clone();
-        let addr = addr.clone();
-        tokio::spawn(async move { remote::serve_remote(ctx, &addr).await });
-    }
-    // Wait for the listener to come up (connect attempts, not sleeps).
-    for _ in 0..100 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move { remote::serve_remote_on(ctx, listener).await });
     addr
 }
 
@@ -148,6 +133,133 @@ async fn bridge_rejects_bad_or_missing_token_before_upgrade() {
         missing.is_err(),
         "missing token must not complete the upgrade"
     );
+}
+
+/// The RFC 6455 sample key and its companion `Sec-WebSocket-Accept` value (SHA1 of the key plus
+/// the WS GUID, base64). Fixed so the byte-level tests can assert the exact response bytes.
+const SAMPLE_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+const SAMPLE_ACCEPT: &str = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+/// Open a raw TCP connection, send `request` verbatim, and read the response head (up to and
+/// including the terminating CRLFCRLF, or EOF). Returns the still-open stream and the head as a
+/// string so tests can assert on the exact response bytes without a WS client that normalizes
+/// header casing.
+async fn raw_handshake(addr: &str, request: &str) -> (tokio::net::TcpStream, String) {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut chunk).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    (stream, String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Build a WS upgrade request for the bridge with the given token and any extra header lines.
+fn handshake_request(token: &str, extra_headers: &str) -> String {
+    format!(
+        "GET /?token={token} HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Key: {SAMPLE_KEY}\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         {extra_headers}\r\n"
+    )
+}
+
+/// CFNetwork (iOS 27) rejects a lowercase 101; the bridge must emit Title-Case response header
+/// names. Assert the raw response bytes carry `Connection:`, `Upgrade:`, and `Sec-WebSocket-Accept:`
+/// with exactly this casing and the correct accept value, and NOT their lowercase forms.
+#[tokio::test]
+async fn handshake_response_uses_title_case_header_names() {
+    let (_ctx, addr) = start_bridge("sekrit-token").await;
+    let (_stream, resp) = raw_handshake(&addr, &handshake_request("sekrit-token", "")).await;
+
+    assert!(
+        resp.starts_with("HTTP/1.1 101 "),
+        "expected a 101 status line, got: {resp:?}"
+    );
+    assert!(
+        resp.contains("\r\nConnection: Upgrade\r\n"),
+        "response must carry Title-Case `Connection: Upgrade`: {resp:?}"
+    );
+    assert!(
+        resp.contains("\r\nUpgrade: websocket\r\n"),
+        "response must carry Title-Case `Upgrade: websocket`: {resp:?}"
+    );
+    assert!(
+        resp.contains(&format!("\r\nSec-WebSocket-Accept: {SAMPLE_ACCEPT}\r\n")),
+        "response must carry Title-Case `Sec-WebSocket-Accept` with the correct value: {resp:?}"
+    );
+    // The lowercase serialization iOS 27 rejects must be gone.
+    assert!(
+        !resp.contains("\r\nconnection:") && !resp.contains("\r\nupgrade:"),
+        "no lowercase handshake header names may remain: {resp:?}"
+    );
+    assert!(
+        !resp.contains("\r\nsec-websocket-accept:"),
+        "no lowercase sec-websocket-accept may remain: {resp:?}"
+    );
+}
+
+/// A client offering `permessage-deflate` still gets a 101, and the bridge negotiates NO
+/// compression: it omits `Sec-WebSocket-Extensions` from the response entirely (matching the
+/// accepted reference server). We do NOT implement deflate.
+#[tokio::test]
+async fn handshake_does_not_negotiate_permessage_deflate() {
+    let (_ctx, addr) = start_bridge("sekrit-token").await;
+    let (_stream, resp) = raw_handshake(
+        &addr,
+        &handshake_request(
+            "sekrit-token",
+            "Sec-WebSocket-Extensions: permessage-deflate\r\n",
+        ),
+    )
+    .await;
+
+    assert!(
+        resp.starts_with("HTTP/1.1 101 "),
+        "a deflate-offering client still upgrades: {resp:?}"
+    );
+    assert!(
+        !resp
+            .to_ascii_lowercase()
+            .contains("sec-websocket-extensions"),
+        "the bridge must omit Sec-WebSocket-Extensions (no compression agreed): {resp:?}"
+    );
+}
+
+/// A bad token is refused with a 401 BEFORE the upgrade, and the connection is terminated (the
+/// server does not leave a half-open upgraded socket for an unauthorized client).
+#[tokio::test]
+async fn handshake_bad_token_gets_401_and_closes() {
+    let (_ctx, addr) = start_bridge("right-token").await;
+    let (mut stream, resp) = raw_handshake(&addr, &handshake_request("wrong-token", "")).await;
+
+    assert!(
+        resp.starts_with("HTTP/1.1 401 "),
+        "a bad token must be refused with 401 before the upgrade: {resp:?}"
+    );
+    assert!(
+        !resp.starts_with("HTTP/1.1 101"),
+        "an unauthorized client must never see a 101"
+    );
+    // The server terminates the connection after the 401: the next read is EOF.
+    let mut tail = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut tail))
+        .await
+        .expect("the server closes the socket within 2s")
+        .expect("read after 401");
+    assert_eq!(n, 0, "the connection must be closed after a 401");
 }
 
 #[tokio::test]


### PR DESCRIPTION
iOS 27's CFNetwork rejects the bridge's WebSocket handshake because tungstenite serializes response header names in lowercase (the http crate canonicalizes HeaderMap names, so no version bump can fix casing). Real devices on shipping iOS accept it today; the next iOS breaks every companion device. Diagnosed live on an iOS 27 simulator with differential testing against a reference server (identical semantics, Title-Case headers, accepted).

The 101 is now written by hand: bounded head read (16 KiB / 64 headers), the SAME constant-time pre-upgrade auth (401 before any upgrade byte, nothing leaked), RFC 6455 accept-key via tungstenite's derive_accept_key, Title-Case Connection/Upgrade/Sec-WebSocket-Accept, no extension negotiation, then from_raw_socket with the unchanged frame caps. Review confirmed the junk-after-request guard (no client bytes stranded pre-upgrade) and that everything downstream (revocation, filtering, sessions) is untouched.

Hardening from review: the whole pre-upgrade sequence now runs under a 10s deadline, so a silent or dribbling peer can no longer hold one of the 64 connection slots forever without authenticating (pre-existing gap, closed while in there); version mismatch answers 426 with Sec-WebSocket-Version: 13 per RFC. Also fixes the tests' free_port TOCTOU flake by handing the server a pre-bound listener.

18 bridge tests incl. byte-level Title-Case assertions (RED-first against the old serializer), deflate-request/no-extension-response, 401-before-upgrade, dribbling-client slot release, and 426; workspace tests, clippy, fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)