### PR TITLE
feat(host): repomon-agent-host crate — Windows per-agent host (Track C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -249,6 +255,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -397,7 +409,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -512,6 +524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +610,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
 dependencies = [
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -963,7 +992,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "gix-path",
  "libc",
@@ -1131,7 +1160,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1189,7 +1218,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "filetime",
  "fnv",
@@ -1240,7 +1269,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1338,7 +1367,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1432,7 +1461,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -1467,7 +1496,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -1567,7 +1596,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1933,7 +1962,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2060,7 +2089,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2201,6 +2230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,7 +2263,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2253,7 +2294,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2365,6 +2406,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,7 +2527,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -2486,7 +2548,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2573,6 +2635,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "repomon-host"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "clap",
+ "directories",
+ "getrandom 0.4.2",
+ "portable-pty",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "vt100",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "repomon-mcp"
 version = "0.5.0"
 dependencies = [
@@ -2645,7 +2725,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2660,7 +2740,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2673,7 +2753,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2809,6 +2889,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2927,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -3508,7 +3609,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3863,6 +3964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,7 +4036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/repomon-core",
     "crates/repomon-daemon",
+    "crates/repomon-host",
     "crates/repomon-mcp",
     "crates/repomon-tui",
 ]

--- a/crates/repomon-host/Cargo.toml
+++ b/crates/repomon-host/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "repomon-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Per-agent host process for repomon on Windows: owns a ConPTY + agent child + a server-side vt100 screen, serves a named-pipe control protocol, and survives daemon restarts (the tmux-server equivalent)."
+
+[[bin]]
+name = "repomon-agent-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+vt100 = { workspace = true }
+base64 = { workspace = true }
+clap = { workspace = true }
+directories = { workspace = true }
+# Declared here (not in workspace.dependencies) so Track C's only root-manifest
+# touch is the members list — parallel tracks may edit workspace.dependencies.
+getrandom = "0.4"
+
+[target.'cfg(windows)'.dependencies]
+tokio = { workspace = true }
+portable-pty = "0.9"
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/repomon-host/PROTOCOL.md
+++ b/crates/repomon-host/PROTOCOL.md
@@ -1,0 +1,309 @@
+# repomon-agent-host control protocol (v1) — FROZEN
+
+This document is the inter-track contract for repomon's native Windows session model.
+`repomon-agent-host.exe` (Track C) implements it; the daemon's `WindowsBackend` (Track I) and
+the attach client (Track F) build against **this document**, not against the host's code.
+
+**Freeze rule:** from the commit that introduces this file, the protocol is frozen for the
+implementation wave. Any change is a mini-RFC that the integrator must approve, and it must
+touch Tracks C, I, and F together. Extensions are additive only: new optional request fields,
+new response fields, and new ops. Unknown fields MUST be ignored by both sides. Unknown ops
+MUST produce an `err` response, never a disconnect.
+
+## 1. Roles and lifecycle
+
+One host process per agent window — the Windows equivalent of one tmux window on the tmux
+server. The host:
+
+1. Spawns the agent child on a ConPTY (via `portable-pty`), with a structured
+   `program + args + cwd + env` (never a shell string).
+2. Feeds every PTY output byte into a server-side `vt100` parser with 50 000 lines of
+   scrollback (parity with tmux `history-limit 50000`), and records `last_activity`
+   (Unix epoch seconds) on every output chunk.
+3. Serves the control protocol below on a named pipe.
+4. Writes a registry file on startup and removes it on exit.
+
+The host is spawned **detached** (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`) and keeps
+running when its parent (the daemon) dies. Durability parity: agents survive daemon restarts.
+
+**Exit semantics (tmux parity — the window disappears):** when the agent child exits, or when
+a `kill` request is served, the host removes its registry file and exits with status 0. There
+is no idle host without a child.
+
+### Host command line (spawn contract for Track I)
+
+```
+repomon-agent-host.exe
+    --session <session> --window <window> --cwd <dir>
+    [--owner <token>] [--cols <n>] [--rows <n>] [--env KEY=VALUE]...
+    -- <program> [args]...
+```
+
+- `--session` / `--window`: tmux-parity names (already validated `[A-Za-z0-9_-]+` upstream).
+- `--cols` / `--rows` default to **220 × 50** (parity with tmux `new-session -x 220 -y 50`).
+- `--env` adds/overrides variables on top of the host's inherited environment.
+- `--owner`: opaque owner token (see §6). If absent, the host generates a random one.
+- `<program>` is resolved like `CreateProcess` does; npm `.cmd` shims (e.g. `claude`) are
+  handled by `portable-pty`'s `CommandBuilder`.
+- Exit codes: `0` clean (child exited or `kill` served), `2` usage error, `1` runtime failure.
+
+## 2. Pipe naming
+
+Each host serves exactly one named pipe:
+
+```
+\\.\pipe\repomon-<session>-<window>
+```
+
+Example: session `repomon`, window `lane-3-1` → `\\.\pipe\repomon-repomon-lane-3-1`.
+
+Multiple simultaneous client connections are supported (the daemon's control connection, a
+byte subscriber, an attach client, …). The host keeps a spare pipe-server instance pending at
+all times.
+
+## 3. Security: per-user DACL (REQUIRED)
+
+The pipe MUST be created with an explicit security descriptor that grants access **only to
+the current user** (the SID of the host process's token), owner set to that SID, DACL
+protected (no inheritance): SDDL shape `O:<sid>G:<sid>D:P(A;;GA;;;<sid>)`. The first instance
+MUST be created with `FILE_FLAG_FIRST_PIPE_INSTANCE` so a squatter cannot pre-claim the name.
+The default (permissive) named-pipe DACL is not acceptable. The registry directory inherits
+the per-user protection of `<data_dir>` (under `%APPDATA%`); the owner token is a liveness /
+identity check, **not** the security boundary — the DACL is.
+
+## 4. Framing
+
+Length-prefixed JSON, both directions:
+
+```
+[u32 length, little-endian][length bytes of UTF-8 JSON]
+```
+
+- `length` is the byte length of the JSON payload only (prefix excluded).
+- Maximum frame size: **16 MiB** (`16 * 1024 * 1024` bytes). A peer receiving a larger
+  length MUST treat the connection as corrupt and disconnect.
+- One JSON document per frame. No trailing newline or padding.
+
+## 5. Conversation model
+
+A connection is in **request/response mode** until (if ever) a successful `subscribe_bytes`
+switches it to **stream mode**.
+
+- Request: `{"id": <u64>, "op": "<name>", ...op-specific fields}`
+- Success: `{"id": <same u64>, "ok": {...op-specific result}}`
+- Failure: `{"id": <same u64>, "err": "<human-readable message>"}`
+
+`id` is chosen by the client and echoed verbatim. Clients MAY pipeline requests; the host
+answers in order received. In stream mode the host pushes unsolicited frames (see
+`subscribe_bytes`) and ignores any further client frames on that connection; disconnecting
+is the only unsubscribe.
+
+## 6. Owner-token handshake
+
+Parity with the tmux `@repomon-owner` server option. The token is an opaque string fixed at
+spawn (`--owner`, or host-generated). It appears in the registry file and in every `hello`
+response. Adoption rule (Track I): after connecting and reading `hello`, a daemon compares
+`owner` with its own identity — on mismatch the daemon MUST back off (not adopt, not reap,
+not kill). There is no way to change a host's owner after spawn.
+
+## 7. Requests
+
+All examples show the full frame payload. Optional fields may be omitted entirely.
+
+### 7.1 `hello`
+
+Request: `{"id": 1, "op": "hello"}`
+
+Response:
+
+```json
+{"id": 1, "ok": {
+  "proto": 1,
+  "session": "repomon",
+  "window": "lane-3-1",
+  "cwd": "C:\\Users\\me\\code\\proj",
+  "program": "claude",
+  "args": ["--permission-mode", "plan"],
+  "agent_pid": 5678,
+  "host_pid": 4321,
+  "started_at": 1789000000,
+  "last_activity": 1789000123,
+  "owner": "daemon-DESKTOP-ME-1a2b3c"
+}}
+```
+
+- `proto`: protocol version, always `1` for this document.
+- `agent_pid`: the ConPTY child's process id.
+- `started_at` / `last_activity`: Unix epoch seconds. `last_activity` is the time of the
+  last PTY output chunk (parity with tmux `#{window_activity}`); equals `started_at` until
+  the child first writes.
+
+### 7.2 `capture`
+
+Request: `{"id": 2, "op": "capture", "lines": 500}` (`lines` optional)
+
+Response: `{"id": 2, "ok": {"text": "…"}}`
+
+Parity with `tmux capture-pane -e -p [-S -<lines>]`: the visible screen's rows, preceded by
+up to `lines` rows of scrollback when `lines` is present, joined with `\n`, each row carrying
+inline SGR escape sequences. Rendered from the host's vt100 screen (the source of truth —
+ConPTY-synthesized quirks do not leak into capture).
+
+### 7.3 `cursor`
+
+Request: `{"id": 3, "op": "cursor"}`
+
+Response: `{"id": 3, "ok": {"col": 12, "row": 4, "visible": true}}`
+
+0-based visible-pane coordinates. `visible` mirrors tmux `#{cursor_flag}`; clients treat
+`visible: false` as "no cursor" (tmux `cursor_named` → `None`).
+
+### 7.4 `size`
+
+Request: `{"id": 4, "op": "size"}`
+
+Response: `{"id": 4, "ok": {"cols": 220, "rows": 50}}`
+
+### 7.5 `alternate_on`
+
+Request: `{"id": 5, "op": "alternate_on"}`
+
+Response: `{"id": 5, "ok": {"on": true}}`
+
+Whether the child is on the alternate screen (full-screen TUI), parity with
+`#{alternate_on}`.
+
+### 7.6 `resize`
+
+Request: `{"id": 6, "op": "resize", "cols": 190, "rows": 45}`
+
+Response: `{"id": 6, "ok": {}}`
+
+Resizes the ConPTY and the vt100 screen. **Last client wins** — no arbitration; the most
+recent `resize` from any connection is in effect.
+
+### 7.7 `send_literal`
+
+Request: `{"id": 7, "op": "send_literal", "text": "y"}`
+
+Response: `{"id": 7, "ok": {}}`
+
+Writes the UTF-8 bytes of `text` to the child's input. No translation, no trailing newline
+(parity with `send-keys -l`).
+
+### 7.8 `send_text`
+
+Request: `{"id": 8, "op": "send_text", "text": "continue"}`
+
+Response: `{"id": 8, "ok": {}}`
+
+Writes the UTF-8 bytes of `text`, then a carriage return (`\r`) — parity with
+`send-keys -l <text>` + `send-keys Enter`.
+
+### 7.9 `send_key`
+
+Request: `{"id": 9, "op": "send_key", "key": "C-c"}`
+
+Response: `{"id": 9, "ok": {}}`
+
+`key` uses the tmux key vocabulary already emitted by the daemon and TUI:
+
+- Named: `Enter`, `Escape`, `Tab`, `BTab`, `BSpace`, `DC`, `Home`, `End`, `PageUp`,
+  `PageDown`, `Up`, `Down`, `Left`, `Right`, `F1`…`F12`, `Space`.
+- Modified: `C-<key>` (Ctrl), `M-<key>` (Meta/Alt), for both single characters (`C-c`,
+  `M-f`) and named keys (`C-Up`, `M-BSpace`).
+- A single printable character stands for itself.
+
+The host translates to conventional VT input sequences (e.g. `C-c` → `0x03`, `Up` →
+`ESC [ A`, `BTab` → `ESC [ Z`, `C-Up` → `ESC [ 1 ; 5 A`, `M-x` → `ESC x`). Unknown names →
+`err`.
+
+### 7.10 `scroll_wheel`
+
+Request: `{"id": 10, "op": "scroll_wheel", "up": true, "ticks": 3}`
+
+Response: `{"id": 10, "ok": {}}`
+
+Writes SGR mouse-wheel sequences to the child's input at the pane's top-left, `ticks` times:
+button 64 (up) / 65 (down), i.e. `ESC [ < 64 ; 1 ; 1 M` per tick (exact tmux
+`scroll_wheel_named` parity). `ticks: 0` is a no-op success.
+
+### 7.11 `subscribe_bytes`
+
+Request: `{"id": 11, "op": "subscribe_bytes"}`
+
+Response: `{"id": 11, "ok": {}}`
+
+After the `ok`, the connection is in stream mode. The host pushes frames of the shape:
+
+```json
+{"stream": "bytes", "data": "<base64>"}
+```
+
+- `data` is standard base64 (RFC 4648, with padding) of raw bytes.
+- **The FIRST stream frame is a full current-screen replay**: a byte sequence that redraws
+  the host's vt100 screen from scratch on an empty terminal of the current size (clear,
+  contents with attributes, cursor position and visibility). A client that starts a fresh
+  emulator, applies frame 1, then applies subsequent frames verbatim converges exactly.
+- Every subsequent frame is a raw PTY output chunk, in order, as produced by the child.
+- The subscription ends when the client disconnects, or when the host exits (pipe EOF).
+  There is no unsubscribe request.
+
+### 7.12 `kill`
+
+Request: `{"id": 12, "op": "kill"}`
+
+Response: `{"id": 12, "ok": {}}`
+
+Parity with `kill-window`: the host terminates the agent child, removes its registry file,
+and exits. The `ok` is sent before exit; clients must tolerate pipe EOF immediately after.
+
+## 8. Registry files
+
+Directory: `<data_dir>\hosts\<session>\`, one file per live window: `<window>.json`.
+`<data_dir>` is repomon's data dir exactly as `repomon_core::config::data_dir()` computes it
+(`REPOMON_DATA_DIR` env override honored; the host honors the same override).
+
+Schema (v1):
+
+```json
+{
+  "v": 1,
+  "session": "repomon",
+  "window": "lane-3-1",
+  "pipe": "\\\\.\\pipe\\repomon-repomon-lane-3-1",
+  "host_pid": 4321,
+  "agent_pid": 5678,
+  "program": "claude",
+  "args": ["--permission-mode", "plan"],
+  "cwd": "C:\\Users\\me\\code\\proj",
+  "owner": "daemon-DESKTOP-ME-1a2b3c",
+  "started_at": 1789000000
+}
+```
+
+- Written **atomically** (temp file + rename) after the pipe server is listening, so a
+  registry entry implies a connectable pipe (modulo crashes).
+- Removed by the host on clean exit (child exit or `kill`).
+- **Stale-entry GC (Track I):** a scanner that fails to connect to `pipe` (file gone /
+  refused) may treat the entry as stale and delete the JSON file. `last_activity` is NOT in
+  the registry — it changes constantly; read it via `hello`.
+- Unknown JSON fields MUST be ignored; additions bump nothing (additive-only, `v` stays 1).
+
+## 9. Mapping to `SessionBackend` (informative)
+
+| Backend call | Host op |
+|---|---|
+| `capture_named` | `capture` |
+| `cursor_named` | `cursor` |
+| `size_named` | `size` |
+| `alternate_on_named` | `alternate_on` |
+| `resize_named` | `resize` |
+| `send_literal_named` | `send_literal` |
+| `send_text_named` | `send_text` |
+| `send_key_named` | `send_key` |
+| `scroll_wheel_named` | `scroll_wheel` |
+| `open_byte_stream` | `subscribe_bytes` |
+| `kill_named` | `kill` |
+| `list_windows_with_activity` | registry scan + `hello` per host |
+| `claim_or_verify_owner` | registry/`hello` `owner` comparison |

--- a/crates/repomon-host/src/cli.rs
+++ b/crates/repomon-host/src/cli.rs
@@ -1,0 +1,98 @@
+//! The host's command line — the spawn contract in PROTOCOL.md §1. Parsed with clap on
+//! every OS so the contract is tested everywhere, even though only Windows runs it.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// `repomon-agent-host --session S --window W --cwd DIR [--owner TOK] [--cols N] [--rows N]
+/// [--env K=V]... -- PROGRAM [ARGS]...`
+#[derive(Debug, Parser)]
+#[command(name = "repomon-agent-host", disable_help_flag = false)]
+pub struct HostArgs {
+    /// Session name (tmux-parity, `[A-Za-z0-9_-]+`).
+    #[arg(long)]
+    pub session: String,
+    /// Window name within the session.
+    #[arg(long)]
+    pub window: String,
+    /// Working directory for the agent child.
+    #[arg(long)]
+    pub cwd: PathBuf,
+    /// Opaque owner token (PROTOCOL.md §6); generated randomly when absent.
+    #[arg(long)]
+    pub owner: Option<String>,
+    /// Initial columns (tmux `new-session -x 220` parity).
+    #[arg(long, default_value_t = 220)]
+    pub cols: u16,
+    /// Initial rows (tmux `new-session -y 50` parity).
+    #[arg(long, default_value_t = 50)]
+    pub rows: u16,
+    /// Extra environment for the child, on top of the host's inherited environment.
+    #[arg(long = "env", value_parser = parse_env_pair)]
+    pub env: Vec<(String, String)>,
+    /// The agent program and its arguments (structured — never a shell string).
+    #[arg(last = true, required = true, num_args = 1..)]
+    pub command: Vec<String>,
+}
+
+fn parse_env_pair(s: &str) -> Result<(String, String), String> {
+    s.split_once('=')
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .ok_or_else(|| format!("expected KEY=VALUE, got {s:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<HostArgs, clap::Error> {
+        HostArgs::try_parse_from(
+            std::iter::once("repomon-agent-host").chain(args.iter().copied()),
+        )
+    }
+
+    #[test]
+    fn full_spawn_line_parses() {
+        let a = parse(&[
+            "--session", "repomon", "--window", "lane-3-1", "--cwd", "C:\\work",
+            "--owner", "tok", "--cols", "190", "--rows", "45",
+            "--env", "FOO=bar", "--env", "BAZ=qux=quux",
+            "--", "claude", "--permission-mode", "plan",
+        ])
+        .unwrap();
+        assert_eq!(a.session, "repomon");
+        assert_eq!(a.window, "lane-3-1");
+        assert_eq!(a.cwd, std::path::PathBuf::from("C:\\work"));
+        assert_eq!(a.owner.as_deref(), Some("tok"));
+        assert_eq!((a.cols, a.rows), (190, 45));
+        assert_eq!(
+            a.env,
+            vec![("FOO".to_string(), "bar".to_string()), ("BAZ".to_string(), "qux=quux".to_string())],
+            "value may contain '='"
+        );
+        assert_eq!(a.command, vec!["claude", "--permission-mode", "plan"]);
+    }
+
+    #[test]
+    fn size_defaults_to_tmux_parity_220_by_50() {
+        let a = parse(&["--session", "s", "--window", "w", "--cwd", "/x", "--", "cmd.exe"]).unwrap();
+        assert_eq!((a.cols, a.rows), (220, 50));
+        assert_eq!(a.owner, None);
+        assert!(a.env.is_empty());
+    }
+
+    #[test]
+    fn command_is_required() {
+        assert!(parse(&["--session", "s", "--window", "w", "--cwd", "/x"]).is_err());
+        assert!(parse(&["--session", "s", "--window", "w", "--cwd", "/x", "--"]).is_err());
+    }
+
+    #[test]
+    fn env_without_equals_is_rejected() {
+        let r = parse(&[
+            "--session", "s", "--window", "w", "--cwd", "/x", "--env", "NOEQUALS", "--", "cmd",
+        ]);
+        assert!(r.is_err());
+    }
+}

--- a/crates/repomon-host/src/cli.rs
+++ b/crates/repomon-host/src/cli.rs
@@ -47,18 +47,32 @@ mod tests {
     use super::*;
 
     fn parse(args: &[&str]) -> Result<HostArgs, clap::Error> {
-        HostArgs::try_parse_from(
-            std::iter::once("repomon-agent-host").chain(args.iter().copied()),
-        )
+        HostArgs::try_parse_from(std::iter::once("repomon-agent-host").chain(args.iter().copied()))
     }
 
     #[test]
     fn full_spawn_line_parses() {
         let a = parse(&[
-            "--session", "repomon", "--window", "lane-3-1", "--cwd", "C:\\work",
-            "--owner", "tok", "--cols", "190", "--rows", "45",
-            "--env", "FOO=bar", "--env", "BAZ=qux=quux",
-            "--", "claude", "--permission-mode", "plan",
+            "--session",
+            "repomon",
+            "--window",
+            "lane-3-1",
+            "--cwd",
+            "C:\\work",
+            "--owner",
+            "tok",
+            "--cols",
+            "190",
+            "--rows",
+            "45",
+            "--env",
+            "FOO=bar",
+            "--env",
+            "BAZ=qux=quux",
+            "--",
+            "claude",
+            "--permission-mode",
+            "plan",
         ])
         .unwrap();
         assert_eq!(a.session, "repomon");
@@ -68,7 +82,10 @@ mod tests {
         assert_eq!((a.cols, a.rows), (190, 45));
         assert_eq!(
             a.env,
-            vec![("FOO".to_string(), "bar".to_string()), ("BAZ".to_string(), "qux=quux".to_string())],
+            vec![
+                ("FOO".to_string(), "bar".to_string()),
+                ("BAZ".to_string(), "qux=quux".to_string())
+            ],
             "value may contain '='"
         );
         assert_eq!(a.command, vec!["claude", "--permission-mode", "plan"]);
@@ -76,7 +93,17 @@ mod tests {
 
     #[test]
     fn size_defaults_to_tmux_parity_220_by_50() {
-        let a = parse(&["--session", "s", "--window", "w", "--cwd", "/x", "--", "cmd.exe"]).unwrap();
+        let a = parse(&[
+            "--session",
+            "s",
+            "--window",
+            "w",
+            "--cwd",
+            "/x",
+            "--",
+            "cmd.exe",
+        ])
+        .unwrap();
         assert_eq!((a.cols, a.rows), (220, 50));
         assert_eq!(a.owner, None);
         assert!(a.env.is_empty());
@@ -91,7 +118,16 @@ mod tests {
     #[test]
     fn env_without_equals_is_rejected() {
         let r = parse(&[
-            "--session", "s", "--window", "w", "--cwd", "/x", "--env", "NOEQUALS", "--", "cmd",
+            "--session",
+            "s",
+            "--window",
+            "w",
+            "--cwd",
+            "/x",
+            "--env",
+            "NOEQUALS",
+            "--",
+            "cmd",
         ]);
         assert!(r.is_err());
     }

--- a/crates/repomon-host/src/codec.rs
+++ b/crates/repomon-host/src/codec.rs
@@ -10,7 +10,11 @@ pub const MAX_FRAME: usize = 16 * 1024 * 1024;
 /// Wrap a JSON payload in the wire framing: 4-byte little-endian length + payload.
 pub fn encode_frame(json: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(4 + json.len());
-    out.extend_from_slice(&u32::try_from(json.len()).expect("frame length fits u32").to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(json.len())
+            .expect("frame length fits u32")
+            .to_le_bytes(),
+    );
     out.extend_from_slice(json);
     out
 }
@@ -55,7 +59,11 @@ pub struct FrameTooLarge(pub usize);
 
 impl std::fmt::Display for FrameTooLarge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "frame of {} bytes exceeds the {MAX_FRAME}-byte limit", self.0)
+        write!(
+            f,
+            "frame of {} bytes exceeds the {MAX_FRAME}-byte limit",
+            self.0
+        )
     }
 }
 
@@ -91,10 +99,17 @@ mod tests {
         for (i, b) in frame.iter().enumerate() {
             dec.extend(&[*b]);
             if i < frame.len() - 1 {
-                assert_eq!(dec.next_frame().unwrap(), None, "premature frame at byte {i}");
+                assert_eq!(
+                    dec.next_frame().unwrap(),
+                    None,
+                    "premature frame at byte {i}"
+                );
             }
         }
-        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":2}".as_slice()));
+        assert_eq!(
+            dec.next_frame().unwrap().as_deref(),
+            Some(b"{\"id\":2}".as_slice())
+        );
     }
 
     #[test]
@@ -103,8 +118,14 @@ mod tests {
         bytes.extend_from_slice(&encode_frame(b"{\"id\":2}"));
         let mut dec = FrameDecoder::new();
         dec.extend(&bytes);
-        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":1}".as_slice()));
-        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":2}".as_slice()));
+        assert_eq!(
+            dec.next_frame().unwrap().as_deref(),
+            Some(b"{\"id\":1}".as_slice())
+        );
+        assert_eq!(
+            dec.next_frame().unwrap().as_deref(),
+            Some(b"{\"id\":2}".as_slice())
+        );
         assert_eq!(dec.next_frame().unwrap(), None);
     }
 

--- a/crates/repomon-host/src/codec.rs
+++ b/crates/repomon-host/src/codec.rs
@@ -1,0 +1,122 @@
+//! Length-prefixed JSON framing (PROTOCOL.md §4): `[u32 LE length][length bytes of JSON]`.
+//!
+//! Pure logic, tested on every OS. The decoder is incremental: feed it arbitrary byte
+//! chunks (pipe reads split frames wherever they like) and pull complete frames out.
+
+/// Maximum JSON payload size (PROTOCOL.md §4): a peer seeing a larger length treats the
+/// connection as corrupt.
+pub const MAX_FRAME: usize = 16 * 1024 * 1024;
+
+/// Wrap a JSON payload in the wire framing: 4-byte little-endian length + payload.
+pub fn encode_frame(json: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + json.len());
+    out.extend_from_slice(&u32::try_from(json.len()).expect("frame length fits u32").to_le_bytes());
+    out.extend_from_slice(json);
+    out
+}
+
+/// Incremental frame decoder: `extend` with whatever the pipe read returned, then drain
+/// complete frames with `next_frame` (`Ok(None)` = need more bytes).
+#[derive(Default)]
+pub struct FrameDecoder {
+    buf: Vec<u8>,
+}
+
+impl FrameDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn extend(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Pop the next complete frame's payload, if the buffer holds one.
+    pub fn next_frame(&mut self) -> Result<Option<Vec<u8>>, FrameTooLarge> {
+        if self.buf.len() < 4 {
+            return Ok(None);
+        }
+        let len = u32::from_le_bytes(self.buf[..4].try_into().expect("4 bytes")) as usize;
+        if len > MAX_FRAME {
+            return Err(FrameTooLarge(len));
+        }
+        if self.buf.len() < 4 + len {
+            return Ok(None);
+        }
+        let payload = self.buf[4..4 + len].to_vec();
+        self.buf.drain(..4 + len);
+        Ok(Some(payload))
+    }
+}
+
+/// A peer announced a frame larger than [`MAX_FRAME`] — the connection is corrupt.
+#[derive(Debug, PartialEq, Eq)]
+pub struct FrameTooLarge(pub usize);
+
+impl std::fmt::Display for FrameTooLarge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "frame of {} bytes exceeds the {MAX_FRAME}-byte limit", self.0)
+    }
+}
+
+impl std::error::Error for FrameTooLarge {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_prefixes_little_endian_length() {
+        let frame = encode_frame(br#"{"id":1}"#);
+        assert_eq!(&frame[..4], &8u32.to_le_bytes());
+        assert_eq!(&frame[4..], br#"{"id":1}"#);
+    }
+
+    #[test]
+    fn decoder_round_trips_a_frame() {
+        let mut dec = FrameDecoder::new();
+        dec.extend(&encode_frame(br#"{"id":7,"op":"hello"}"#));
+        assert_eq!(
+            dec.next_frame().unwrap().as_deref(),
+            Some(br#"{"id":7,"op":"hello"}"#.as_slice())
+        );
+        assert_eq!(dec.next_frame().unwrap(), None);
+    }
+
+    #[test]
+    fn decoder_handles_split_reads() {
+        let frame = encode_frame(b"{\"id\":2}");
+        let mut dec = FrameDecoder::new();
+        // One byte at a time: no frame until the last byte arrives.
+        for (i, b) in frame.iter().enumerate() {
+            dec.extend(&[*b]);
+            if i < frame.len() - 1 {
+                assert_eq!(dec.next_frame().unwrap(), None, "premature frame at byte {i}");
+            }
+        }
+        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":2}".as_slice()));
+    }
+
+    #[test]
+    fn decoder_yields_back_to_back_frames() {
+        let mut bytes = encode_frame(b"{\"id\":1}");
+        bytes.extend_from_slice(&encode_frame(b"{\"id\":2}"));
+        let mut dec = FrameDecoder::new();
+        dec.extend(&bytes);
+        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":1}".as_slice()));
+        assert_eq!(dec.next_frame().unwrap().as_deref(), Some(b"{\"id\":2}".as_slice()));
+        assert_eq!(dec.next_frame().unwrap(), None);
+    }
+
+    #[test]
+    fn decoder_rejects_oversized_frames() {
+        let mut dec = FrameDecoder::new();
+        dec.extend(&((MAX_FRAME as u32) + 1).to_le_bytes());
+        assert!(dec.next_frame().is_err());
+    }
+
+    #[test]
+    fn max_frame_is_16_mib() {
+        assert_eq!(MAX_FRAME, 16 * 1024 * 1024);
+    }
+}

--- a/crates/repomon-host/src/dacl.rs
+++ b/crates/repomon-host/src/dacl.rs
@@ -1,0 +1,127 @@
+//! Per-user pipe security (PROTOCOL.md §3): an explicit DACL granting access only to the
+//! current user, built from SDDL `O:<sid>G:<sid>D:P(A;;GA;;;<sid>)`. The default named-pipe
+//! DACL is not acceptable.
+
+use std::ffi::c_void;
+use std::ptr::null_mut;
+
+use anyhow::{Context as _, bail};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, LocalFree};
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+use windows_sys::Win32::Security::{
+    GetTokenInformation, SECURITY_ATTRIBUTES, TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+/// An owned self-relative security descriptor restricting access to the current user.
+pub struct PipeSecurity {
+    descriptor: *mut c_void,
+}
+
+// The descriptor is an immutable LocalAlloc'd blob; moving it across threads is fine.
+unsafe impl Send for PipeSecurity {}
+unsafe impl Sync for PipeSecurity {}
+
+impl PipeSecurity {
+    /// Build the descriptor for the process's own user.
+    pub fn current_user_only() -> anyhow::Result<Self> {
+        let sid = current_user_sid_string()?;
+        let sddl = format!("O:{sid}G:{sid}D:P(A;;GA;;;{sid})");
+        let wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut descriptor: *mut c_void = null_mut();
+        let ok = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut descriptor as *mut *mut c_void as *mut _,
+                null_mut(),
+            )
+        };
+        if ok == 0 {
+            bail!(
+                "ConvertStringSecurityDescriptorToSecurityDescriptorW({sddl}) failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        Ok(Self { descriptor })
+    }
+
+    /// `SECURITY_ATTRIBUTES` pointing at the descriptor, for
+    /// `ServerOptions::create_with_security_attributes_raw`. The returned value borrows
+    /// `self`; keep `self` alive for the call.
+    pub fn attributes(&self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: self.descriptor,
+            bInheritHandle: 0,
+        }
+    }
+}
+
+impl Drop for PipeSecurity {
+    fn drop(&mut self) {
+        unsafe {
+            LocalFree(self.descriptor);
+        }
+    }
+}
+
+/// The current process token's user SID, as a string (`S-1-5-21-…`).
+fn current_user_sid_string() -> anyhow::Result<String> {
+    unsafe {
+        let mut token: HANDLE = null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            bail!(
+                "OpenProcessToken failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        let result = (|| {
+            let mut len = 0u32;
+            // First call sizes the buffer; it "fails" with ERROR_INSUFFICIENT_BUFFER.
+            GetTokenInformation(token, TokenUser, null_mut(), 0, &mut len);
+            if len == 0 {
+                bail!(
+                    "GetTokenInformation sizing failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            let mut buf = vec![0u8; len as usize];
+            if GetTokenInformation(
+                token,
+                TokenUser,
+                buf.as_mut_ptr() as *mut c_void,
+                len,
+                &mut len,
+            ) == 0
+            {
+                bail!(
+                    "GetTokenInformation failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+            let mut sid_w: *mut u16 = null_mut();
+            if ConvertSidToStringSidW(token_user.User.Sid, &mut sid_w) == 0 {
+                bail!(
+                    "ConvertSidToStringSidW failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            let mut end = sid_w;
+            while *end != 0 {
+                end = end.add(1);
+            }
+            let sid = String::from_utf16_lossy(std::slice::from_raw_parts(
+                sid_w,
+                end.offset_from(sid_w) as usize,
+            ));
+            LocalFree(sid_w as *mut c_void);
+            Ok(sid)
+        })();
+        CloseHandle(token);
+        result.context("resolve current user SID")
+    }
+}

--- a/crates/repomon-host/src/dispatch.rs
+++ b/crates/repomon-host/src/dispatch.rs
@@ -5,9 +5,7 @@
 
 use serde::Serialize;
 
-use crate::protocol::{
-    self, AlternateOk, CaptureOk, CursorOk, HelloInfo, Op, Response, SizeOk,
-};
+use crate::protocol::{self, AlternateOk, CaptureOk, CursorOk, HelloInfo, Op, Response, SizeOk};
 use crate::screen::Screen;
 
 /// The PTY side of an op, as the dispatcher sees it. The Windows server implements this
@@ -54,7 +52,12 @@ pub struct Dispatcher {
 impl Dispatcher {
     pub fn new(meta: HostMeta, screen: Screen, pty: Box<dyn PtyIo>) -> Self {
         let last_activity = meta.started_at;
-        Self { meta, screen, pty, last_activity }
+        Self {
+            meta,
+            screen,
+            pty,
+            last_activity,
+        }
     }
 
     /// Feed a chunk of PTY output (`now` = epoch seconds), tmux `#{window_activity}` parity.
@@ -74,7 +77,10 @@ impl Dispatcher {
         let req = match protocol::parse_request(payload) {
             Ok(req) => req,
             Err(e) => {
-                return (to_vec(&Response::err(e.id.unwrap_or(0), e.message)), Effect::None);
+                return (
+                    to_vec(&Response::err(e.id.unwrap_or(0), e.message)),
+                    Effect::None,
+                );
             }
         };
         let id = req.id;
@@ -99,19 +105,35 @@ impl Dispatcher {
                 Effect::None,
             ),
             Op::Capture { lines } => (
-                to_vec(&Response::ok(id, &CaptureOk { text: self.screen.capture(lines) })),
+                to_vec(&Response::ok(
+                    id,
+                    &CaptureOk {
+                        text: self.screen.capture(lines),
+                    },
+                )),
                 Effect::None,
             ),
             Op::Cursor => {
                 let (col, row, visible) = self.screen.cursor();
-                (to_vec(&Response::ok(id, &CursorOk { col, row, visible })), Effect::None)
+                (
+                    to_vec(&Response::ok(id, &CursorOk { col, row, visible })),
+                    Effect::None,
+                )
             }
             Op::Size => {
                 let (cols, rows) = self.screen.size();
-                (to_vec(&Response::ok(id, &SizeOk { cols, rows })), Effect::None)
+                (
+                    to_vec(&Response::ok(id, &SizeOk { cols, rows })),
+                    Effect::None,
+                )
             }
             Op::AlternateOn => (
-                to_vec(&Response::ok(id, &AlternateOk { on: self.screen.alternate_on() })),
+                to_vec(&Response::ok(
+                    id,
+                    &AlternateOk {
+                        on: self.screen.alternate_on(),
+                    },
+                )),
                 Effect::None,
             ),
             Op::Resize { cols, rows } => match self.pty.resize(cols, rows) {
@@ -120,7 +142,10 @@ impl Dispatcher {
                     self.screen.resize(cols, rows);
                     (to_vec(&Response::empty_ok(id)), Effect::None)
                 }
-                Err(e) => (to_vec(&Response::err(id, format!("resize: {e:#}"))), Effect::None),
+                Err(e) => (
+                    to_vec(&Response::err(id, format!("resize: {e:#}"))),
+                    Effect::None,
+                ),
             },
             Op::SendLiteral { text } => (self.write_ok(id, text.as_bytes()), Effect::None),
             Op::SendText { text } => {
@@ -130,7 +155,10 @@ impl Dispatcher {
             }
             Op::SendKey { key } => match crate::keys::key_to_bytes(&key) {
                 Some(bytes) => (self.write_ok(id, &bytes), Effect::None),
-                None => (to_vec(&Response::err(id, format!("unknown key {key:?}"))), Effect::None),
+                None => (
+                    to_vec(&Response::err(id, format!("unknown key {key:?}"))),
+                    Effect::None,
+                ),
             },
             Op::ScrollWheel { up, ticks } => {
                 if ticks == 0 {
@@ -144,7 +172,10 @@ impl Dispatcher {
             Op::SubscribeBytes => (to_vec(&Response::empty_ok(id)), Effect::StartStream),
             Op::Kill => match self.pty.kill() {
                 Ok(()) => (to_vec(&Response::empty_ok(id)), Effect::Shutdown),
-                Err(e) => (to_vec(&Response::err(id, format!("kill: {e:#}"))), Effect::Shutdown),
+                Err(e) => (
+                    to_vec(&Response::err(id, format!("kill: {e:#}"))),
+                    Effect::Shutdown,
+                ),
             },
         };
         (payload, effect)
@@ -182,7 +213,10 @@ mod tests {
 
     impl PtyIo for FakePty {
         fn write(&mut self, bytes: &[u8]) -> anyhow::Result<()> {
-            self.calls.lock().unwrap().push(PtyCall::Write(bytes.to_vec()));
+            self.calls
+                .lock()
+                .unwrap()
+                .push(PtyCall::Write(bytes.to_vec()));
             Ok(())
         }
         fn resize(&mut self, cols: u16, rows: u16) -> anyhow::Result<()> {
@@ -208,7 +242,10 @@ mod tests {
             owner: "tok123".into(),
             started_at: 40,
         };
-        (Dispatcher::new(meta, crate::screen::Screen::new(80, 24), Box::new(pty)), calls)
+        (
+            Dispatcher::new(meta, crate::screen::Screen::new(80, 24), Box::new(pty)),
+            calls,
+        )
     }
 
     fn handle(d: &mut Dispatcher, req: &str) -> (serde_json::Value, Effect) {
@@ -251,10 +288,16 @@ mod tests {
         let (v, _) = handle(&mut d, r#"{"id":2,"op":"capture"}"#);
         assert!(v["ok"]["text"].as_str().unwrap().starts_with("hi there"));
         let (v, _) = handle(&mut d, r#"{"id":3,"op":"cursor"}"#);
-        assert_eq!((v["ok"]["col"].as_u64(), v["ok"]["row"].as_u64()), (Some(8), Some(0)));
+        assert_eq!(
+            (v["ok"]["col"].as_u64(), v["ok"]["row"].as_u64()),
+            (Some(8), Some(0))
+        );
         assert_eq!(v["ok"]["visible"], true);
         let (v, _) = handle(&mut d, r#"{"id":4,"op":"size"}"#);
-        assert_eq!((v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()), (Some(80), Some(24)));
+        assert_eq!(
+            (v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()),
+            (Some(80), Some(24))
+        );
         let (v, _) = handle(&mut d, r#"{"id":5,"op":"alternate_on"}"#);
         assert_eq!(v["ok"]["on"], false);
     }
@@ -264,23 +307,35 @@ mod tests {
         let (mut d, calls) = dispatcher();
         let (v, _) = handle(&mut d, r#"{"id":6,"op":"resize","cols":100,"rows":30}"#);
         assert_eq!(v["ok"], serde_json::json!({}));
-        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Resize(100, 30)]);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Resize(100, 30)]
+        );
         let (v, _) = handle(&mut d, r#"{"id":7,"op":"size"}"#);
-        assert_eq!((v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()), (Some(100), Some(30)));
+        assert_eq!(
+            (v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()),
+            (Some(100), Some(30))
+        );
     }
 
     #[test]
     fn send_literal_writes_exact_bytes() {
         let (mut d, calls) = dispatcher();
         handle(&mut d, r#"{"id":7,"op":"send_literal","text":"y"}"#);
-        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(b"y".to_vec())]);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(b"y".to_vec())]
+        );
     }
 
     #[test]
     fn send_text_appends_carriage_return() {
         let (mut d, calls) = dispatcher();
         handle(&mut d, r#"{"id":8,"op":"send_text","text":"continue"}"#);
-        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(b"continue\r".to_vec())]);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(b"continue\r".to_vec())]
+        );
     }
 
     #[test]
@@ -288,19 +343,35 @@ mod tests {
         let (mut d, calls) = dispatcher();
         let (v, _) = handle(&mut d, r#"{"id":9,"op":"send_key","key":"C-c"}"#);
         assert_eq!(v["ok"], serde_json::json!({}));
-        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(vec![0x03])]);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(vec![0x03])]
+        );
 
         let (v, _) = handle(&mut d, r#"{"id":10,"op":"send_key","key":"Fnord"}"#);
         assert!(v["err"].as_str().unwrap().contains("Fnord"));
-        assert_eq!(calls.lock().unwrap().len(), 1, "no write for an unknown key");
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "no write for an unknown key"
+        );
     }
 
     #[test]
     fn scroll_wheel_writes_sgr_sequences() {
         let (mut d, calls) = dispatcher();
-        handle(&mut d, r#"{"id":11,"op":"scroll_wheel","up":true,"ticks":2}"#);
-        handle(&mut d, r#"{"id":12,"op":"scroll_wheel","up":false,"ticks":1}"#);
-        handle(&mut d, r#"{"id":13,"op":"scroll_wheel","up":true,"ticks":0}"#);
+        handle(
+            &mut d,
+            r#"{"id":11,"op":"scroll_wheel","up":true,"ticks":2}"#,
+        );
+        handle(
+            &mut d,
+            r#"{"id":12,"op":"scroll_wheel","up":false,"ticks":1}"#,
+        );
+        handle(
+            &mut d,
+            r#"{"id":13,"op":"scroll_wheel","up":true,"ticks":0}"#,
+        );
         assert_eq!(
             calls.lock().unwrap().as_slice(),
             &[

--- a/crates/repomon-host/src/dispatch.rs
+++ b/crates/repomon-host/src/dispatch.rs
@@ -1,0 +1,358 @@
+//! Request dispatch: protocol op → screen/PTY action → response payload.
+//!
+//! OS-neutral on purpose: the PTY side is behind [`PtyIo`], so every op's semantics are
+//! tested on all OSes with a fake; the Windows server plugs in the real ConPTY.
+
+use serde::Serialize;
+
+use crate::protocol::{
+    self, AlternateOk, CaptureOk, CursorOk, HelloInfo, Op, Response, SizeOk,
+};
+use crate::screen::Screen;
+
+/// The PTY side of an op, as the dispatcher sees it. The Windows server implements this
+/// over the real ConPTY; tests use a recording fake.
+pub trait PtyIo: Send {
+    fn write(&mut self, bytes: &[u8]) -> anyhow::Result<()>;
+    fn resize(&mut self, cols: u16, rows: u16) -> anyhow::Result<()>;
+    fn kill(&mut self) -> anyhow::Result<()>;
+}
+
+/// Immutable facts about this host, reported by `hello` and mirrored in the registry file.
+pub struct HostMeta {
+    pub session: String,
+    pub window: String,
+    pub cwd: String,
+    pub program: String,
+    pub args: Vec<String>,
+    pub agent_pid: u32,
+    pub owner: String,
+    /// Unix epoch seconds.
+    pub started_at: i64,
+}
+
+/// What the connection loop must do after sending the response frame.
+#[derive(Debug, Clone, Copy)]
+pub enum Effect {
+    None,
+    /// `subscribe_bytes` succeeded: switch this connection to stream mode. The first pushed
+    /// frame must wrap [`Dispatcher::replay`].
+    StartStream,
+    /// `kill` was served: remove the registry entry and exit the host.
+    Shutdown,
+}
+
+/// One host's shared brain: the vt100 screen, the PTY handle, and activity bookkeeping.
+/// The server wraps it in a mutex; every op is a short synchronous critical section.
+pub struct Dispatcher {
+    meta: HostMeta,
+    screen: Screen,
+    pty: Box<dyn PtyIo>,
+    last_activity: i64,
+}
+
+impl Dispatcher {
+    pub fn new(meta: HostMeta, screen: Screen, pty: Box<dyn PtyIo>) -> Self {
+        let last_activity = meta.started_at;
+        Self { meta, screen, pty, last_activity }
+    }
+
+    /// Feed a chunk of PTY output (`now` = epoch seconds), tmux `#{window_activity}` parity.
+    pub fn process_output(&mut self, bytes: &[u8], now: i64) {
+        self.screen.process(bytes);
+        self.last_activity = now;
+    }
+
+    /// The full current-screen replay for a new byte subscriber's first frame.
+    pub fn replay(&self) -> Vec<u8> {
+        self.screen.replay()
+    }
+
+    /// Handle one request frame; returns the response payload (JSON, unframed) and the
+    /// connection effect. Never panics on bad input — errors become `err` responses.
+    pub fn handle(&mut self, payload: &[u8], _now: i64) -> (Vec<u8>, Effect) {
+        let req = match protocol::parse_request(payload) {
+            Ok(req) => req,
+            Err(e) => {
+                return (to_vec(&Response::err(e.id.unwrap_or(0), e.message)), Effect::None);
+            }
+        };
+        let id = req.id;
+        let (payload, effect) = match req.op {
+            Op::Hello => (
+                to_vec(&Response::ok(
+                    id,
+                    &HelloInfo {
+                        proto: protocol::PROTO_VERSION,
+                        session: self.meta.session.clone(),
+                        window: self.meta.window.clone(),
+                        cwd: self.meta.cwd.clone(),
+                        program: self.meta.program.clone(),
+                        args: self.meta.args.clone(),
+                        agent_pid: self.meta.agent_pid,
+                        host_pid: std::process::id(),
+                        started_at: self.meta.started_at,
+                        last_activity: self.last_activity,
+                        owner: self.meta.owner.clone(),
+                    },
+                )),
+                Effect::None,
+            ),
+            Op::Capture { lines } => (
+                to_vec(&Response::ok(id, &CaptureOk { text: self.screen.capture(lines) })),
+                Effect::None,
+            ),
+            Op::Cursor => {
+                let (col, row, visible) = self.screen.cursor();
+                (to_vec(&Response::ok(id, &CursorOk { col, row, visible })), Effect::None)
+            }
+            Op::Size => {
+                let (cols, rows) = self.screen.size();
+                (to_vec(&Response::ok(id, &SizeOk { cols, rows })), Effect::None)
+            }
+            Op::AlternateOn => (
+                to_vec(&Response::ok(id, &AlternateOk { on: self.screen.alternate_on() })),
+                Effect::None,
+            ),
+            Op::Resize { cols, rows } => match self.pty.resize(cols, rows) {
+                Ok(()) => {
+                    // Last client wins: whatever arrived most recently is the size.
+                    self.screen.resize(cols, rows);
+                    (to_vec(&Response::empty_ok(id)), Effect::None)
+                }
+                Err(e) => (to_vec(&Response::err(id, format!("resize: {e:#}"))), Effect::None),
+            },
+            Op::SendLiteral { text } => (self.write_ok(id, text.as_bytes()), Effect::None),
+            Op::SendText { text } => {
+                let mut bytes = text.into_bytes();
+                bytes.push(b'\r');
+                (self.write_ok(id, &bytes), Effect::None)
+            }
+            Op::SendKey { key } => match crate::keys::key_to_bytes(&key) {
+                Some(bytes) => (self.write_ok(id, &bytes), Effect::None),
+                None => (to_vec(&Response::err(id, format!("unknown key {key:?}"))), Effect::None),
+            },
+            Op::ScrollWheel { up, ticks } => {
+                if ticks == 0 {
+                    (to_vec(&Response::empty_ok(id)), Effect::None)
+                } else {
+                    let button = if up { 64 } else { 65 };
+                    let seq = format!("\x1b[<{button};1;1M").repeat(ticks as usize);
+                    (self.write_ok(id, seq.as_bytes()), Effect::None)
+                }
+            }
+            Op::SubscribeBytes => (to_vec(&Response::empty_ok(id)), Effect::StartStream),
+            Op::Kill => match self.pty.kill() {
+                Ok(()) => (to_vec(&Response::empty_ok(id)), Effect::Shutdown),
+                Err(e) => (to_vec(&Response::err(id, format!("kill: {e:#}"))), Effect::Shutdown),
+            },
+        };
+        (payload, effect)
+    }
+
+    fn write_ok(&mut self, id: u64, bytes: &[u8]) -> Vec<u8> {
+        match self.pty.write(bytes) {
+            Ok(()) => to_vec(&Response::empty_ok(id)),
+            Err(e) => to_vec(&Response::err(id, format!("write: {e:#}"))),
+        }
+    }
+}
+
+fn to_vec<T: Serialize>(v: &T) -> Vec<u8> {
+    serde_json::to_vec(v).expect("response serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum PtyCall {
+        Write(Vec<u8>),
+        Resize(u16, u16),
+        Kill,
+    }
+
+    #[derive(Clone, Default)]
+    struct FakePty {
+        calls: Arc<Mutex<Vec<PtyCall>>>,
+    }
+
+    impl PtyIo for FakePty {
+        fn write(&mut self, bytes: &[u8]) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push(PtyCall::Write(bytes.to_vec()));
+            Ok(())
+        }
+        fn resize(&mut self, cols: u16, rows: u16) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push(PtyCall::Resize(cols, rows));
+            Ok(())
+        }
+        fn kill(&mut self) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push(PtyCall::Kill);
+            Ok(())
+        }
+    }
+
+    fn dispatcher() -> (Dispatcher, Arc<Mutex<Vec<PtyCall>>>) {
+        let pty = FakePty::default();
+        let calls = pty.calls.clone();
+        let meta = HostMeta {
+            session: "repomon".into(),
+            window: "lane-3-1".into(),
+            cwd: "C:\\work".into(),
+            program: "claude".into(),
+            args: vec!["--plan".into()],
+            agent_pid: 5678,
+            owner: "tok123".into(),
+            started_at: 40,
+        };
+        (Dispatcher::new(meta, crate::screen::Screen::new(80, 24), Box::new(pty)), calls)
+    }
+
+    fn handle(d: &mut Dispatcher, req: &str) -> (serde_json::Value, Effect) {
+        let (payload, effect) = d.handle(req.as_bytes(), 99);
+        (serde_json::from_slice(&payload).unwrap(), effect)
+    }
+
+    #[test]
+    fn hello_reports_meta_and_activity() {
+        let (mut d, _) = dispatcher();
+        d.process_output(b"boot noise", 42);
+        let (v, effect) = handle(&mut d, r#"{"id":1,"op":"hello"}"#);
+        assert!(matches!(effect, Effect::None));
+        assert_eq!(v["id"], 1);
+        let ok = &v["ok"];
+        assert_eq!(ok["proto"], 1);
+        assert_eq!(ok["session"], "repomon");
+        assert_eq!(ok["window"], "lane-3-1");
+        assert_eq!(ok["cwd"], "C:\\work");
+        assert_eq!(ok["program"], "claude");
+        assert_eq!(ok["args"][0], "--plan");
+        assert_eq!(ok["agent_pid"], 5678);
+        assert_eq!(ok["host_pid"], std::process::id());
+        assert_eq!(ok["started_at"], 40);
+        assert_eq!(ok["last_activity"], 42, "bumped by PTY output");
+        assert_eq!(ok["owner"], "tok123");
+    }
+
+    #[test]
+    fn last_activity_starts_at_started_at() {
+        let (mut d, _) = dispatcher();
+        let (v, _) = handle(&mut d, r#"{"id":1,"op":"hello"}"#);
+        assert_eq!(v["ok"]["last_activity"], 40);
+    }
+
+    #[test]
+    fn screen_queries_answer_from_the_vt100_state() {
+        let (mut d, _) = dispatcher();
+        d.process_output(b"hi there", 41);
+        let (v, _) = handle(&mut d, r#"{"id":2,"op":"capture"}"#);
+        assert!(v["ok"]["text"].as_str().unwrap().starts_with("hi there"));
+        let (v, _) = handle(&mut d, r#"{"id":3,"op":"cursor"}"#);
+        assert_eq!((v["ok"]["col"].as_u64(), v["ok"]["row"].as_u64()), (Some(8), Some(0)));
+        assert_eq!(v["ok"]["visible"], true);
+        let (v, _) = handle(&mut d, r#"{"id":4,"op":"size"}"#);
+        assert_eq!((v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()), (Some(80), Some(24)));
+        let (v, _) = handle(&mut d, r#"{"id":5,"op":"alternate_on"}"#);
+        assert_eq!(v["ok"]["on"], false);
+    }
+
+    #[test]
+    fn resize_hits_pty_and_screen() {
+        let (mut d, calls) = dispatcher();
+        let (v, _) = handle(&mut d, r#"{"id":6,"op":"resize","cols":100,"rows":30}"#);
+        assert_eq!(v["ok"], serde_json::json!({}));
+        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Resize(100, 30)]);
+        let (v, _) = handle(&mut d, r#"{"id":7,"op":"size"}"#);
+        assert_eq!((v["ok"]["cols"].as_u64(), v["ok"]["rows"].as_u64()), (Some(100), Some(30)));
+    }
+
+    #[test]
+    fn send_literal_writes_exact_bytes() {
+        let (mut d, calls) = dispatcher();
+        handle(&mut d, r#"{"id":7,"op":"send_literal","text":"y"}"#);
+        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(b"y".to_vec())]);
+    }
+
+    #[test]
+    fn send_text_appends_carriage_return() {
+        let (mut d, calls) = dispatcher();
+        handle(&mut d, r#"{"id":8,"op":"send_text","text":"continue"}"#);
+        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(b"continue\r".to_vec())]);
+    }
+
+    #[test]
+    fn send_key_translates_and_rejects_unknown() {
+        let (mut d, calls) = dispatcher();
+        let (v, _) = handle(&mut d, r#"{"id":9,"op":"send_key","key":"C-c"}"#);
+        assert_eq!(v["ok"], serde_json::json!({}));
+        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Write(vec![0x03])]);
+
+        let (v, _) = handle(&mut d, r#"{"id":10,"op":"send_key","key":"Fnord"}"#);
+        assert!(v["err"].as_str().unwrap().contains("Fnord"));
+        assert_eq!(calls.lock().unwrap().len(), 1, "no write for an unknown key");
+    }
+
+    #[test]
+    fn scroll_wheel_writes_sgr_sequences() {
+        let (mut d, calls) = dispatcher();
+        handle(&mut d, r#"{"id":11,"op":"scroll_wheel","up":true,"ticks":2}"#);
+        handle(&mut d, r#"{"id":12,"op":"scroll_wheel","up":false,"ticks":1}"#);
+        handle(&mut d, r#"{"id":13,"op":"scroll_wheel","up":true,"ticks":0}"#);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[
+                PtyCall::Write(b"\x1b[<64;1;1M\x1b[<64;1;1M".to_vec()),
+                PtyCall::Write(b"\x1b[<65;1;1M".to_vec()),
+            ],
+            "64=up, 65=down, ticks=0 writes nothing"
+        );
+    }
+
+    #[test]
+    fn subscribe_bytes_starts_streaming() {
+        let (mut d, _) = dispatcher();
+        let (v, effect) = handle(&mut d, r#"{"id":11,"op":"subscribe_bytes"}"#);
+        assert_eq!(v["ok"], serde_json::json!({}));
+        assert!(matches!(effect, Effect::StartStream));
+    }
+
+    #[test]
+    fn kill_terminates_child_and_shuts_down() {
+        let (mut d, calls) = dispatcher();
+        let (v, effect) = handle(&mut d, r#"{"id":12,"op":"kill"}"#);
+        assert_eq!(v["ok"], serde_json::json!({}));
+        assert!(matches!(effect, Effect::Shutdown));
+        assert_eq!(calls.lock().unwrap().as_slice(), &[PtyCall::Kill]);
+    }
+
+    #[test]
+    fn unknown_op_answers_err_and_keeps_the_connection() {
+        let (mut d, _) = dispatcher();
+        let (v, effect) = handle(&mut d, r#"{"id":33,"op":"warp_core"}"#);
+        assert_eq!(v["id"], 33);
+        assert!(v["err"].is_string());
+        assert!(matches!(effect, Effect::None));
+    }
+
+    #[test]
+    fn garbage_answers_err_with_id_zero() {
+        let (mut d, _) = dispatcher();
+        let (v, effect) = handle(&mut d, "not json");
+        assert_eq!(v["id"], 0);
+        assert!(v["err"].is_string());
+        assert!(matches!(effect, Effect::None));
+    }
+
+    #[test]
+    fn replay_snapshot_matches_screen() {
+        let (mut d, _) = dispatcher();
+        d.process_output(b"snapshot me", 41);
+        let replay = d.replay();
+        let mut fresh = vt100::Parser::new(24, 80, 0);
+        fresh.process(&replay);
+        assert!(fresh.screen().contents().starts_with("snapshot me"));
+    }
+}

--- a/crates/repomon-host/src/dispatch.rs
+++ b/crates/repomon-host/src/dispatch.rs
@@ -178,7 +178,7 @@ impl Dispatcher {
                 ),
             },
         };
-        (payload, effect)
+        (cap_frame(id, payload), effect)
     }
 
     fn write_ok(&mut self, id: u64, bytes: &[u8]) -> Vec<u8> {
@@ -186,6 +186,20 @@ impl Dispatcher {
             Ok(()) => to_vec(&Response::empty_ok(id)),
             Err(e) => to_vec(&Response::err(id, format!("write: {e:#}"))),
         }
+    }
+}
+
+/// PROTOCOL.md §4 binds both directions to [`crate::codec::MAX_FRAME`]: a response that
+/// would overflow it (a pathological deep-history capture) becomes an `err` instead of a
+/// frame the client must treat as corrupt.
+fn cap_frame(id: u64, payload: Vec<u8>) -> Vec<u8> {
+    if payload.len() > crate::codec::MAX_FRAME {
+        to_vec(&Response::err(
+            id,
+            "response exceeds the 16 MiB frame limit",
+        ))
+    } else {
+        payload
     }
 }
 
@@ -415,6 +429,24 @@ mod tests {
         assert_eq!(v["id"], 0);
         assert!(v["err"].is_string());
         assert!(matches!(effect, Effect::None));
+    }
+
+    #[test]
+    fn oversized_response_payloads_become_errors() {
+        // PROTOCOL.md §4 binds BOTH directions to the 16 MiB frame limit; a pathological
+        // capture (50k history lines of escapes) must not make the host emit a frame the
+        // client is required to treat as corrupt.
+        let small = cap_frame(7, br#"{"id":7,"ok":{}}"#.to_vec());
+        assert_eq!(
+            small,
+            br#"{"id":7,"ok":{}}"#.to_vec(),
+            "small payloads pass through"
+        );
+
+        let huge = cap_frame(7, vec![b'x'; crate::codec::MAX_FRAME + 1]);
+        let v: serde_json::Value = serde_json::from_slice(&huge).unwrap();
+        assert_eq!(v["id"], 7);
+        assert!(v["err"].as_str().unwrap().contains("frame limit"));
     }
 
     #[test]

--- a/crates/repomon-host/src/keys.rs
+++ b/crates/repomon-host/src/keys.rs
@@ -1,0 +1,220 @@
+//! tmux key-name → VT input-byte translation (PROTOCOL.md §7.9).
+//!
+//! The daemon and TUI already speak tmux's key vocabulary (`Enter`, `Escape`, `C-c`,
+//! `M-BSpace`, `C-Up`, …); on Unix tmux turns those names into terminal input sequences.
+//! This module is that key table for the Windows host: conventional VT/xterm sequences,
+//! matching what tmux itself writes to a pane.
+
+/// Translate a tmux key name into the bytes to write to the child's input. `None` for
+/// names outside the vocabulary (the caller answers `err`).
+pub fn key_to_bytes(key: &str) -> Option<Vec<u8>> {
+    let (mut ctrl, mut alt) = (false, false);
+    let mut rest = key;
+    loop {
+        if let Some(r) = rest.strip_prefix("C-") {
+            if r.is_empty() {
+                return None;
+            }
+            ctrl = true;
+            rest = r;
+        } else if let Some(r) = rest.strip_prefix("M-") {
+            if r.is_empty() {
+                return None;
+            }
+            alt = true;
+            rest = r;
+        } else {
+            break;
+        }
+    }
+    if rest.is_empty() {
+        return None;
+    }
+
+    // A single character stands for itself (Ctrl folds it to a control byte).
+    let mut chars = rest.chars();
+    let c = chars.next().expect("non-empty");
+    if chars.next().is_none() {
+        let mut out = Vec::new();
+        if alt {
+            out.push(0x1b);
+        }
+        if ctrl {
+            out.push(ctrl_byte(c)?);
+        } else {
+            let mut buf = [0u8; 4];
+            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        }
+        return Some(out);
+    }
+
+    named_key(rest, ctrl, alt)
+}
+
+/// The control byte for `Ctrl+<c>` (`C-a` → 0x01, `C-Space`/`C-@` → 0x00, `C-[` → ESC …).
+fn ctrl_byte(c: char) -> Option<u8> {
+    match c.to_ascii_uppercase() {
+        c @ 'A'..='Z' => Some(c as u8 - b'A' + 1),
+        '@' => Some(0x00),
+        '[' => Some(0x1b),
+        '\\' => Some(0x1c),
+        ']' => Some(0x1d),
+        '^' => Some(0x1e),
+        '_' => Some(0x1f),
+        '?' => Some(0x7f),
+        _ => None,
+    }
+}
+
+/// How a named key is encoded, both plain and with xterm CSI modifiers.
+enum Named {
+    /// Plain bytes; Alt prefixes ESC, Ctrl has no distinct encoding (base is sent).
+    Plain(&'static [u8]),
+    /// `ESC [ <final>` plain, `ESC [ 1 ; <mod> <final>` modified (arrows).
+    CsiLetter(u8),
+    /// `ESC [ <num> ~` plain, `ESC [ <num> ; <mod> ~` modified (DC/IC/Page*/F5+).
+    Tilde(u8),
+    /// tmux-default `ESC [ <num> ~` plain, xterm `ESC [ 1 ; <mod> <final>` modified.
+    HomeEnd(u8, u8),
+    /// `ESC O <final>` plain, `ESC [ 1 ; <mod> <final>` modified (F1–F4).
+    Ss3(u8),
+}
+
+fn named_key(name: &str, ctrl: bool, alt: bool) -> Option<Vec<u8>> {
+    use Named::*;
+    if name == "Space" {
+        let byte = if ctrl { 0x00 } else { b' ' };
+        return Some(if alt { vec![0x1b, byte] } else { vec![byte] });
+    }
+    let kind = match name {
+        "Enter" => Plain(b"\r"),
+        "Escape" => Plain(b"\x1b"),
+        "Tab" => Plain(b"\t"),
+        "BTab" => Plain(b"\x1b[Z"),
+        "BSpace" => Plain(b"\x7f"),
+        "Up" => CsiLetter(b'A'),
+        "Down" => CsiLetter(b'B'),
+        "Right" => CsiLetter(b'C'),
+        "Left" => CsiLetter(b'D'),
+        "Home" => HomeEnd(1, b'H'),
+        "End" => HomeEnd(4, b'F'),
+        "IC" => Tilde(2),
+        "DC" => Tilde(3),
+        "PageUp" | "PgUp" => Tilde(5),
+        "PageDown" | "PgDn" => Tilde(6),
+        "F1" => Ss3(b'P'),
+        "F2" => Ss3(b'Q'),
+        "F3" => Ss3(b'R'),
+        "F4" => Ss3(b'S'),
+        "F5" => Tilde(15),
+        "F6" => Tilde(17),
+        "F7" => Tilde(18),
+        "F8" => Tilde(19),
+        "F9" => Tilde(20),
+        "F10" => Tilde(21),
+        "F11" => Tilde(23),
+        "F12" => Tilde(24),
+        _ => return None,
+    };
+    // xterm modifier parameter: 1 + 2·Alt + 4·Ctrl.
+    let modifier = 1 + if alt { 2 } else { 0 } + if ctrl { 4 } else { 0 };
+    let modified = ctrl || alt;
+    Some(match kind {
+        Plain(bytes) => {
+            let mut out = Vec::new();
+            if alt {
+                out.push(0x1b);
+            }
+            out.extend_from_slice(bytes);
+            out
+        }
+        CsiLetter(l) if !modified => vec![0x1b, b'[', l],
+        CsiLetter(l) => format!("\x1b[1;{modifier}{}", l as char).into_bytes(),
+        Tilde(n) if !modified => format!("\x1b[{n}~").into_bytes(),
+        Tilde(n) => format!("\x1b[{n};{modifier}~").into_bytes(),
+        HomeEnd(n, _) if !modified => format!("\x1b[{n}~").into_bytes(),
+        HomeEnd(_, l) => format!("\x1b[1;{modifier}{}", l as char).into_bytes(),
+        Ss3(l) if !modified => vec![0x1b, b'O', l],
+        Ss3(l) => format!("\x1b[1;{modifier}{}", l as char).into_bytes(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[track_caller]
+    fn bytes(name: &str) -> Vec<u8> {
+        key_to_bytes(name).unwrap_or_else(|| panic!("key {name:?} should translate"))
+    }
+
+    #[test]
+    fn named_keys_translate() {
+        assert_eq!(bytes("Enter"), b"\r");
+        assert_eq!(bytes("Escape"), b"\x1b");
+        assert_eq!(bytes("Tab"), b"\t");
+        assert_eq!(bytes("BTab"), b"\x1b[Z");
+        assert_eq!(bytes("BSpace"), b"\x7f");
+        assert_eq!(bytes("Space"), b" ");
+        assert_eq!(bytes("DC"), b"\x1b[3~");
+        assert_eq!(bytes("Home"), b"\x1b[1~");
+        assert_eq!(bytes("End"), b"\x1b[4~");
+        assert_eq!(bytes("PageUp"), b"\x1b[5~");
+        assert_eq!(bytes("PageDown"), b"\x1b[6~");
+        assert_eq!(bytes("Up"), b"\x1b[A");
+        assert_eq!(bytes("Down"), b"\x1b[B");
+        assert_eq!(bytes("Right"), b"\x1b[C");
+        assert_eq!(bytes("Left"), b"\x1b[D");
+        assert_eq!(bytes("F1"), b"\x1bOP");
+        assert_eq!(bytes("F5"), b"\x1b[15~");
+        assert_eq!(bytes("F12"), b"\x1b[24~");
+    }
+
+    #[test]
+    fn single_characters_stand_for_themselves() {
+        assert_eq!(bytes("a"), b"a");
+        assert_eq!(bytes("Z"), b"Z");
+        assert_eq!(bytes("/"), b"/");
+        // Multi-byte UTF-8 chars pass through too.
+        assert_eq!(bytes("é"), "é".as_bytes());
+    }
+
+    #[test]
+    fn ctrl_characters_become_control_bytes() {
+        assert_eq!(bytes("C-c"), vec![0x03]);
+        assert_eq!(bytes("C-a"), vec![0x01]);
+        assert_eq!(bytes("C-z"), vec![0x1a]);
+        // tmux accepts either case for the letter.
+        assert_eq!(bytes("C-C"), vec![0x03]);
+        assert_eq!(bytes("C-Space"), vec![0x00]);
+        assert_eq!(bytes("C-["), vec![0x1b]);
+        assert_eq!(bytes("C-_"), vec![0x1f]);
+    }
+
+    #[test]
+    fn meta_prefixes_escape() {
+        assert_eq!(bytes("M-f"), b"\x1bf");
+        assert_eq!(bytes("M-b"), b"\x1bb");
+        assert_eq!(bytes("M-BSpace"), b"\x1b\x7f");
+        assert_eq!(bytes("M-Enter"), b"\x1b\r");
+    }
+
+    #[test]
+    fn modified_named_keys_use_csi_modifiers() {
+        // xterm modifier encoding: 5 = Ctrl, 3 = Alt.
+        assert_eq!(bytes("C-Up"), b"\x1b[1;5A");
+        assert_eq!(bytes("C-Right"), b"\x1b[1;5C");
+        assert_eq!(bytes("M-Up"), b"\x1b[1;3A");
+        assert_eq!(bytes("M-Left"), b"\x1b[1;3D");
+        assert_eq!(bytes("C-Home"), b"\x1b[1;5H");
+        assert_eq!(bytes("C-PageUp"), b"\x1b[5;5~");
+        assert_eq!(bytes("C-DC"), b"\x1b[3;5~");
+    }
+
+    #[test]
+    fn unknown_keys_are_none() {
+        assert_eq!(key_to_bytes("Fnord"), None);
+        assert_eq!(key_to_bytes("C-Fnord"), None);
+        assert_eq!(key_to_bytes(""), None);
+    }
+}

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod codec;
 pub mod keys;
 pub mod protocol;
+pub mod screen;
 
 /// Real entry point on Windows (the non-Windows binary is a hard stub).
 #[cfg(windows)]

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -9,6 +9,7 @@
 //! Everything protocol- and screen-shaped is cross-platform and tested on every OS; only the
 //! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
 
+pub mod cli;
 pub mod codec;
 pub mod dispatch;
 pub mod keys;

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -10,6 +10,7 @@
 //! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
 
 pub mod codec;
+pub mod keys;
 pub mod protocol;
 
 /// Real entry point on Windows (the non-Windows binary is a hard stub).

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -10,6 +10,7 @@
 //! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
 
 pub mod codec;
+pub mod protocol;
 
 /// Real entry point on Windows (the non-Windows binary is a hard stub).
 #[cfg(windows)]

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod codec;
 pub mod keys;
 pub mod protocol;
+pub mod registry;
 pub mod screen;
 
 /// Real entry point on Windows (the non-Windows binary is a hard stub).

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -17,9 +17,14 @@ pub mod protocol;
 pub mod registry;
 pub mod screen;
 
-/// Real entry point on Windows (the non-Windows binary is a hard stub).
 #[cfg(windows)]
-pub fn windows_main() -> std::process::ExitCode {
-    eprintln!("repomon-agent-host: not yet implemented");
-    std::process::ExitCode::FAILURE
-}
+pub mod dacl;
+#[cfg(windows)]
+pub mod pty;
+#[cfg(windows)]
+mod run;
+#[cfg(windows)]
+pub mod server;
+
+#[cfg(windows)]
+pub use run::windows_main;

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -10,6 +10,7 @@
 //! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
 
 pub mod codec;
+pub mod dispatch;
 pub mod keys;
 pub mod protocol;
 pub mod registry;

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -9,6 +9,8 @@
 //! Everything protocol- and screen-shaped is cross-platform and tested on every OS; only the
 //! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
 
+pub mod codec;
+
 /// Real entry point on Windows (the non-Windows binary is a hard stub).
 #[cfg(windows)]
 pub fn windows_main() -> std::process::ExitCode {

--- a/crates/repomon-host/src/lib.rs
+++ b/crates/repomon-host/src/lib.rs
@@ -1,0 +1,17 @@
+//! repomon-agent-host: the per-agent host process for repomon's native Windows backend.
+//!
+//! One host per agent window — the Windows equivalent of a tmux window on the out-of-process
+//! tmux server. The host owns a ConPTY + the agent child + a server-side vt100 screen with
+//! scrollback, serves the length-prefixed JSON control protocol documented in `PROTOCOL.md`
+//! on `\\.\pipe\repomon-<session>-<window>`, registers itself under
+//! `<data_dir>\hosts\<session>\<window>.json`, and survives daemon restarts.
+//!
+//! Everything protocol- and screen-shaped is cross-platform and tested on every OS; only the
+//! ConPTY spawn, the named-pipe server, and the pipe DACL are `cfg(windows)`.
+
+/// Real entry point on Windows (the non-Windows binary is a hard stub).
+#[cfg(windows)]
+pub fn windows_main() -> std::process::ExitCode {
+    eprintln!("repomon-agent-host: not yet implemented");
+    std::process::ExitCode::FAILURE
+}

--- a/crates/repomon-host/src/main.rs
+++ b/crates/repomon-host/src/main.rs
@@ -1,0 +1,14 @@
+//! `repomon-agent-host` binary entry point. See `PROTOCOL.md` for the contract this
+//! process implements. The binary compiles everywhere so the workspace builds on all
+//! OSes, but the runtime is Windows-only (Unix uses tmux).
+
+#[cfg(windows)]
+fn main() -> std::process::ExitCode {
+    repomon_host::windows_main()
+}
+
+#[cfg(not(windows))]
+fn main() -> std::process::ExitCode {
+    eprintln!("repomon-agent-host runs only on Windows; on macOS/Linux repomon uses tmux.");
+    std::process::ExitCode::from(2)
+}

--- a/crates/repomon-host/src/protocol.rs
+++ b/crates/repomon-host/src/protocol.rs
@@ -1,0 +1,275 @@
+//! Serde types for the control protocol (PROTOCOL.md §5–§7). The golden-JSON tests below
+//! protect the FROZEN wire shapes: if one of these breaks, the contract broke.
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+
+/// Protocol version answered in `hello`.
+pub const PROTO_VERSION: u32 = 1;
+
+/// A client request: `{"id": N, "op": "<name>", ...params}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Request {
+    pub id: u64,
+    #[serde(flatten)]
+    pub op: Op,
+}
+
+/// The op name plus its parameters (PROTOCOL.md §7), tagged by `"op"`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Op {
+    Hello,
+    Capture {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lines: Option<u32>,
+    },
+    Cursor,
+    Size,
+    AlternateOn,
+    Resize { cols: u16, rows: u16 },
+    SendLiteral { text: String },
+    SendText { text: String },
+    SendKey { key: String },
+    ScrollWheel { up: bool, ticks: u32 },
+    SubscribeBytes,
+    Kill,
+}
+
+/// `hello`'s ok body — field order is part of nothing (JSON), but kept matching PROTOCOL.md
+/// §7.1 for readable goldens.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelloInfo {
+    pub proto: u32,
+    pub session: String,
+    pub window: String,
+    pub cwd: String,
+    pub program: String,
+    pub args: Vec<String>,
+    pub agent_pid: u32,
+    pub host_pid: u32,
+    pub started_at: i64,
+    pub last_activity: i64,
+    pub owner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaptureOk {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorOk {
+    pub col: u16,
+    pub row: u16,
+    pub visible: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SizeOk {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AlternateOk {
+    pub on: bool,
+}
+
+/// The `{}` ok body of side-effect ops (resize, send_*, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmptyOk {}
+
+/// `{"id": N, "ok": {...}}` — generic so typed bodies serialize with their declared field
+/// order (a `serde_json::Value` would re-sort keys alphabetically).
+#[derive(Debug, Clone, Serialize)]
+pub struct OkResponse<T> {
+    pub id: u64,
+    pub ok: T,
+}
+
+/// `{"id": N, "err": "message"}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrResponse {
+    pub id: u64,
+    pub err: String,
+}
+
+/// Constructors for the two response shapes.
+pub struct Response;
+
+impl Response {
+    pub fn ok<T: Serialize>(id: u64, body: &T) -> OkResponse<&T> {
+        OkResponse { id, ok: body }
+    }
+
+    pub fn empty_ok(id: u64) -> OkResponse<EmptyOk> {
+        OkResponse { id, ok: EmptyOk {} }
+    }
+
+    pub fn err(id: u64, message: impl Into<String>) -> ErrResponse {
+        ErrResponse { id, err: message.into() }
+    }
+}
+
+/// A pushed frame on a `subscribe_bytes` connection: `{"stream":"bytes","data":"<base64>"}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamFrame {
+    pub stream: String,
+    pub data: String,
+}
+
+impl StreamFrame {
+    /// Wrap raw PTY bytes as a stream frame (standard base64, with padding).
+    pub fn bytes(data: &[u8]) -> Self {
+        Self {
+            stream: "bytes".to_string(),
+            data: base64::engine::general_purpose::STANDARD.encode(data),
+        }
+    }
+}
+
+/// A request that didn't parse. `id` is recovered when the payload was at least JSON with a
+/// numeric `id`, so the host can answer `err` instead of disconnecting (PROTOCOL.md freeze
+/// rule: unknown ops get an error response, never a hangup).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub id: Option<u64>,
+    pub message: String,
+}
+
+/// Parse one frame payload into a [`Request`].
+pub fn parse_request(payload: &[u8]) -> Result<Request, ParseError> {
+    match serde_json::from_slice::<Request>(payload) {
+        Ok(req) => Ok(req),
+        Err(e) => {
+            let id = serde_json::from_slice::<serde_json::Value>(payload)
+                .ok()
+                .and_then(|v| v.get("id").and_then(serde_json::Value::as_u64));
+            Err(ParseError { id, message: e.to_string() })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_json<T: serde::Serialize>(v: &T) -> String {
+        serde_json::to_string(v).unwrap()
+    }
+
+    #[test]
+    fn request_wire_shapes_are_frozen() {
+        let cases: Vec<(Request, &str)> = vec![
+            (Request { id: 1, op: Op::Hello }, r#"{"id":1,"op":"hello"}"#),
+            (
+                Request { id: 2, op: Op::Capture { lines: Some(500) } },
+                r#"{"id":2,"op":"capture","lines":500}"#,
+            ),
+            (Request { id: 2, op: Op::Capture { lines: None } }, r#"{"id":2,"op":"capture"}"#),
+            (Request { id: 3, op: Op::Cursor }, r#"{"id":3,"op":"cursor"}"#),
+            (Request { id: 4, op: Op::Size }, r#"{"id":4,"op":"size"}"#),
+            (Request { id: 5, op: Op::AlternateOn }, r#"{"id":5,"op":"alternate_on"}"#),
+            (
+                Request { id: 6, op: Op::Resize { cols: 190, rows: 45 } },
+                r#"{"id":6,"op":"resize","cols":190,"rows":45}"#,
+            ),
+            (
+                Request { id: 7, op: Op::SendLiteral { text: "y".into() } },
+                r#"{"id":7,"op":"send_literal","text":"y"}"#,
+            ),
+            (
+                Request { id: 8, op: Op::SendText { text: "continue".into() } },
+                r#"{"id":8,"op":"send_text","text":"continue"}"#,
+            ),
+            (
+                Request { id: 9, op: Op::SendKey { key: "C-c".into() } },
+                r#"{"id":9,"op":"send_key","key":"C-c"}"#,
+            ),
+            (
+                Request { id: 10, op: Op::ScrollWheel { up: true, ticks: 3 } },
+                r#"{"id":10,"op":"scroll_wheel","up":true,"ticks":3}"#,
+            ),
+            (Request { id: 11, op: Op::SubscribeBytes }, r#"{"id":11,"op":"subscribe_bytes"}"#),
+            (Request { id: 12, op: Op::Kill }, r#"{"id":12,"op":"kill"}"#),
+        ];
+        for (req, golden) in cases {
+            assert_eq!(to_json(&req), golden);
+            assert_eq!(parse_request(golden.as_bytes()).unwrap(), req);
+        }
+    }
+
+    #[test]
+    fn hello_response_wire_shape_is_frozen() {
+        let hello = HelloInfo {
+            proto: 1,
+            session: "repomon".into(),
+            window: "lane-3-1".into(),
+            cwd: "C:\\Users\\me\\code\\proj".into(),
+            program: "claude".into(),
+            args: vec!["--permission-mode".into(), "plan".into()],
+            agent_pid: 5678,
+            host_pid: 4321,
+            started_at: 1789000000,
+            last_activity: 1789000123,
+            owner: "daemon-DESKTOP-ME-1a2b3c".into(),
+        };
+        assert_eq!(
+            to_json(&Response::ok(1, &hello)),
+            r#"{"id":1,"ok":{"proto":1,"session":"repomon","window":"lane-3-1","cwd":"C:\\Users\\me\\code\\proj","program":"claude","args":["--permission-mode","plan"],"agent_pid":5678,"host_pid":4321,"started_at":1789000000,"last_activity":1789000123,"owner":"daemon-DESKTOP-ME-1a2b3c"}}"#
+        );
+    }
+
+    #[test]
+    fn simple_ok_and_err_shapes_are_frozen() {
+        assert_eq!(
+            to_json(&Response::ok(2, &CaptureOk { text: "hi".into() })),
+            r#"{"id":2,"ok":{"text":"hi"}}"#
+        );
+        assert_eq!(
+            to_json(&Response::ok(3, &CursorOk { col: 12, row: 4, visible: true })),
+            r#"{"id":3,"ok":{"col":12,"row":4,"visible":true}}"#
+        );
+        assert_eq!(
+            to_json(&Response::ok(4, &SizeOk { cols: 220, rows: 50 })),
+            r#"{"id":4,"ok":{"cols":220,"rows":50}}"#
+        );
+        assert_eq!(
+            to_json(&Response::ok(5, &AlternateOk { on: true })),
+            r#"{"id":5,"ok":{"on":true}}"#
+        );
+        assert_eq!(to_json(&Response::empty_ok(6)), r#"{"id":6,"ok":{}}"#);
+        assert_eq!(
+            to_json(&Response::err(9, "unknown key \"C-Fnord\"")),
+            r#"{"id":9,"err":"unknown key \"C-Fnord\""}"#
+        );
+    }
+
+    #[test]
+    fn stream_frame_shape_is_frozen() {
+        assert_eq!(
+            to_json(&StreamFrame::bytes(b"\x1b[2J")),
+            r#"{"stream":"bytes","data":"G1sySg=="}"#
+        );
+    }
+
+    #[test]
+    fn unknown_op_yields_error_with_id() {
+        let err = parse_request(br#"{"id":33,"op":"warp_core"}"#).unwrap_err();
+        assert_eq!(err.id, Some(33));
+        assert!(err.message.contains("warp_core") || err.message.contains("unknown"));
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        // Additive-extension rule: peers must ignore fields they don't know.
+        let req = parse_request(br#"{"id":4,"op":"size","future_hint":true}"#).unwrap();
+        assert_eq!(req, Request { id: 4, op: Op::Size });
+    }
+
+    #[test]
+    fn garbage_yields_error_without_id() {
+        assert_eq!(parse_request(b"not json").unwrap_err().id, None);
+    }
+}

--- a/crates/repomon-host/src/protocol.rs
+++ b/crates/repomon-host/src/protocol.rs
@@ -27,11 +27,23 @@ pub enum Op {
     Cursor,
     Size,
     AlternateOn,
-    Resize { cols: u16, rows: u16 },
-    SendLiteral { text: String },
-    SendText { text: String },
-    SendKey { key: String },
-    ScrollWheel { up: bool, ticks: u32 },
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    SendLiteral {
+        text: String,
+    },
+    SendText {
+        text: String,
+    },
+    SendKey {
+        key: String,
+    },
+    ScrollWheel {
+        up: bool,
+        ticks: u32,
+    },
     SubscribeBytes,
     Kill,
 }
@@ -108,7 +120,10 @@ impl Response {
     }
 
     pub fn err(id: u64, message: impl Into<String>) -> ErrResponse {
-        ErrResponse { id, err: message.into() }
+        ErrResponse {
+            id,
+            err: message.into(),
+        }
     }
 }
 
@@ -146,7 +161,10 @@ pub fn parse_request(payload: &[u8]) -> Result<Request, ParseError> {
             let id = serde_json::from_slice::<serde_json::Value>(payload)
                 .ok()
                 .and_then(|v| v.get("id").and_then(serde_json::Value::as_u64));
-            Err(ParseError { id, message: e.to_string() })
+            Err(ParseError {
+                id,
+                message: e.to_string(),
+            })
         }
     }
 }
@@ -162,37 +180,102 @@ mod tests {
     #[test]
     fn request_wire_shapes_are_frozen() {
         let cases: Vec<(Request, &str)> = vec![
-            (Request { id: 1, op: Op::Hello }, r#"{"id":1,"op":"hello"}"#),
             (
-                Request { id: 2, op: Op::Capture { lines: Some(500) } },
+                Request {
+                    id: 1,
+                    op: Op::Hello,
+                },
+                r#"{"id":1,"op":"hello"}"#,
+            ),
+            (
+                Request {
+                    id: 2,
+                    op: Op::Capture { lines: Some(500) },
+                },
                 r#"{"id":2,"op":"capture","lines":500}"#,
             ),
-            (Request { id: 2, op: Op::Capture { lines: None } }, r#"{"id":2,"op":"capture"}"#),
-            (Request { id: 3, op: Op::Cursor }, r#"{"id":3,"op":"cursor"}"#),
-            (Request { id: 4, op: Op::Size }, r#"{"id":4,"op":"size"}"#),
-            (Request { id: 5, op: Op::AlternateOn }, r#"{"id":5,"op":"alternate_on"}"#),
             (
-                Request { id: 6, op: Op::Resize { cols: 190, rows: 45 } },
+                Request {
+                    id: 2,
+                    op: Op::Capture { lines: None },
+                },
+                r#"{"id":2,"op":"capture"}"#,
+            ),
+            (
+                Request {
+                    id: 3,
+                    op: Op::Cursor,
+                },
+                r#"{"id":3,"op":"cursor"}"#,
+            ),
+            (
+                Request {
+                    id: 4,
+                    op: Op::Size,
+                },
+                r#"{"id":4,"op":"size"}"#,
+            ),
+            (
+                Request {
+                    id: 5,
+                    op: Op::AlternateOn,
+                },
+                r#"{"id":5,"op":"alternate_on"}"#,
+            ),
+            (
+                Request {
+                    id: 6,
+                    op: Op::Resize {
+                        cols: 190,
+                        rows: 45,
+                    },
+                },
                 r#"{"id":6,"op":"resize","cols":190,"rows":45}"#,
             ),
             (
-                Request { id: 7, op: Op::SendLiteral { text: "y".into() } },
+                Request {
+                    id: 7,
+                    op: Op::SendLiteral { text: "y".into() },
+                },
                 r#"{"id":7,"op":"send_literal","text":"y"}"#,
             ),
             (
-                Request { id: 8, op: Op::SendText { text: "continue".into() } },
+                Request {
+                    id: 8,
+                    op: Op::SendText {
+                        text: "continue".into(),
+                    },
+                },
                 r#"{"id":8,"op":"send_text","text":"continue"}"#,
             ),
             (
-                Request { id: 9, op: Op::SendKey { key: "C-c".into() } },
+                Request {
+                    id: 9,
+                    op: Op::SendKey { key: "C-c".into() },
+                },
                 r#"{"id":9,"op":"send_key","key":"C-c"}"#,
             ),
             (
-                Request { id: 10, op: Op::ScrollWheel { up: true, ticks: 3 } },
+                Request {
+                    id: 10,
+                    op: Op::ScrollWheel { up: true, ticks: 3 },
+                },
                 r#"{"id":10,"op":"scroll_wheel","up":true,"ticks":3}"#,
             ),
-            (Request { id: 11, op: Op::SubscribeBytes }, r#"{"id":11,"op":"subscribe_bytes"}"#),
-            (Request { id: 12, op: Op::Kill }, r#"{"id":12,"op":"kill"}"#),
+            (
+                Request {
+                    id: 11,
+                    op: Op::SubscribeBytes,
+                },
+                r#"{"id":11,"op":"subscribe_bytes"}"#,
+            ),
+            (
+                Request {
+                    id: 12,
+                    op: Op::Kill,
+                },
+                r#"{"id":12,"op":"kill"}"#,
+            ),
         ];
         for (req, golden) in cases {
             assert_eq!(to_json(&req), golden);
@@ -228,11 +311,24 @@ mod tests {
             r#"{"id":2,"ok":{"text":"hi"}}"#
         );
         assert_eq!(
-            to_json(&Response::ok(3, &CursorOk { col: 12, row: 4, visible: true })),
+            to_json(&Response::ok(
+                3,
+                &CursorOk {
+                    col: 12,
+                    row: 4,
+                    visible: true
+                }
+            )),
             r#"{"id":3,"ok":{"col":12,"row":4,"visible":true}}"#
         );
         assert_eq!(
-            to_json(&Response::ok(4, &SizeOk { cols: 220, rows: 50 })),
+            to_json(&Response::ok(
+                4,
+                &SizeOk {
+                    cols: 220,
+                    rows: 50
+                }
+            )),
             r#"{"id":4,"ok":{"cols":220,"rows":50}}"#
         );
         assert_eq!(
@@ -265,7 +361,13 @@ mod tests {
     fn unknown_fields_are_ignored() {
         // Additive-extension rule: peers must ignore fields they don't know.
         let req = parse_request(br#"{"id":4,"op":"size","future_hint":true}"#).unwrap();
-        assert_eq!(req, Request { id: 4, op: Op::Size });
+        assert_eq!(
+            req,
+            Request {
+                id: 4,
+                op: Op::Size
+            }
+        );
     }
 
     #[test]

--- a/crates/repomon-host/src/pty.rs
+++ b/crates/repomon-host/src/pty.rs
@@ -1,0 +1,106 @@
+//! ConPTY child management via `portable-pty` (Windows only).
+//!
+//! `CommandBuilder` gets the structured `program + args + cwd + env` straight from the CLI —
+//! no shell strings, no `cmd /c` quoting — and it resolves npm `.cmd` shims (`claude`) the
+//! way `CreateProcess` alone would not.
+
+use std::path::Path;
+
+use anyhow::Context as _;
+use portable_pty::{Child, ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+use crate::dispatch::PtyIo;
+
+/// Everything `spawn_child` hands back: the dispatcher-side controller, the raw output
+/// reader (drained by a dedicated thread), and the child (waited by another thread).
+pub struct SpawnedChild {
+    pub controller: PtyController,
+    pub reader: Box<dyn std::io::Read + Send>,
+    pub child: Box<dyn Child + Send + Sync>,
+    pub child_pid: u32,
+}
+
+/// The dispatcher's handle on the ConPTY: input writes, resizes, kills.
+pub struct PtyController {
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn std::io::Write + Send>,
+    killer: Box<dyn ChildKiller + Send + Sync>,
+}
+
+impl PtyIo for PtyController {
+    fn write(&mut self, bytes: &[u8]) -> anyhow::Result<()> {
+        self.writer
+            .write_all(bytes)
+            .context("write to ConPTY input")?;
+        self.writer.flush().context("flush ConPTY input")?;
+        Ok(())
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) -> anyhow::Result<()> {
+        self.master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("resize ConPTY")
+    }
+
+    fn kill(&mut self) -> anyhow::Result<()> {
+        self.killer.kill().context("kill agent child")
+    }
+}
+
+/// Open a `cols × rows` ConPTY and spawn the agent child on it.
+pub fn spawn_child(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &[(String, String)],
+    cols: u16,
+    rows: u16,
+) -> anyhow::Result<SpawnedChild> {
+    let pty = native_pty_system();
+    let pair = pty
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .context("open ConPTY")?;
+
+    let mut cmd = CommandBuilder::new(program);
+    cmd.args(args);
+    cmd.cwd(cwd);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .with_context(|| format!("spawn {program:?}"))?;
+    // The slave side belongs to the child now; dropping our handle lets child-exit surface
+    // as EOF on the reader.
+    drop(pair.slave);
+
+    let child_pid = child.process_id().unwrap_or(0);
+    let killer = child.clone_killer();
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .context("clone ConPTY reader")?;
+    let writer = pair.master.take_writer().context("take ConPTY writer")?;
+
+    Ok(SpawnedChild {
+        controller: PtyController {
+            master: pair.master,
+            writer,
+            killer,
+        },
+        reader,
+        child,
+        child_pid,
+    })
+}

--- a/crates/repomon-host/src/registry.rs
+++ b/crates/repomon-host/src/registry.rs
@@ -32,7 +32,10 @@ pub fn pipe_name(session: &str, window: &str) -> String {
 
 /// `<data_dir>\hosts\<session>\<window>.json` (PROTOCOL.md §8).
 pub fn registry_path(data_dir: &Path, session: &str, window: &str) -> PathBuf {
-    data_dir.join("hosts").join(session).join(format!("{window}.json"))
+    data_dir
+        .join("hosts")
+        .join(session)
+        .join(format!("{window}.json"))
 }
 
 /// repomon's data dir, mirroring `repomon_core::config::data_dir()` exactly (the host must
@@ -57,7 +60,10 @@ fn data_dir_from(override_var: Option<String>) -> PathBuf {
 /// directories. A crash can leave a `.tmp` file but never a torn JSON.
 pub fn write_atomic(path: &Path, entry: &RegistryEntry) -> std::io::Result<()> {
     let parent = path.parent().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::InvalidInput, "registry path has no parent")
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "registry path has no parent",
+        )
     })?;
     std::fs::create_dir_all(parent)?;
     let json = serde_json::to_vec(entry).expect("registry entry serializes");
@@ -110,7 +116,10 @@ mod tests {
 
     #[test]
     fn pipe_name_matches_protocol() {
-        assert_eq!(pipe_name("repomon", "lane-3-1"), r"\\.\pipe\repomon-repomon-lane-3-1");
+        assert_eq!(
+            pipe_name("repomon", "lane-3-1"),
+            r"\\.\pipe\repomon-repomon-lane-3-1"
+        );
     }
 
     #[test]
@@ -118,7 +127,10 @@ mod tests {
         let p = registry_path(std::path::Path::new("/data"), "repomon", "lane-3-1");
         assert_eq!(
             p,
-            std::path::Path::new("/data").join("hosts").join("repomon").join("lane-3-1.json")
+            std::path::Path::new("/data")
+                .join("hosts")
+                .join("repomon")
+                .join("lane-3-1.json")
         );
     }
 
@@ -137,8 +149,7 @@ mod tests {
         let path = registry_path(dir.path(), &e.session, &e.window);
         write_atomic(&path, &e).unwrap();
 
-        let back: RegistryEntry =
-            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let back: RegistryEntry = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(back, e);
 
         // No temp litter next to the file.
@@ -158,7 +169,11 @@ mod tests {
         let with = data_dir_from(Some("C:\\override".into()));
         assert_eq!(with, std::path::PathBuf::from("C:\\override"));
         let empty = data_dir_from(Some(String::new()));
-        assert_ne!(empty, std::path::PathBuf::from(""), "empty override is ignored");
+        assert_ne!(
+            empty,
+            std::path::PathBuf::from(""),
+            "empty override is ignored"
+        );
     }
 
     #[test]

--- a/crates/repomon-host/src/registry.rs
+++ b/crates/repomon-host/src/registry.rs
@@ -1,0 +1,171 @@
+//! Host registry files and pipe naming (PROTOCOL.md §2, §8).
+//!
+//! The registry directory is the Windows equivalent of tmux's window list: one JSON file per
+//! live window under `<data_dir>\hosts\<session>\`, written atomically on startup and removed
+//! on exit. The daemon's re-adoption scan (Track I) walks it.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// One live window's registry file (PROTOCOL.md §8, schema v1). Field order matches the
+/// documented example; unknown fields are ignored on read (additive-only evolution).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    pub v: u32,
+    pub session: String,
+    pub window: String,
+    pub pipe: String,
+    pub host_pid: u32,
+    pub agent_pid: u32,
+    pub program: String,
+    pub args: Vec<String>,
+    pub cwd: String,
+    pub owner: String,
+    pub started_at: i64,
+}
+
+/// `\\.\pipe\repomon-<session>-<window>` (PROTOCOL.md §2).
+pub fn pipe_name(session: &str, window: &str) -> String {
+    format!(r"\\.\pipe\repomon-{session}-{window}")
+}
+
+/// `<data_dir>\hosts\<session>\<window>.json` (PROTOCOL.md §8).
+pub fn registry_path(data_dir: &Path, session: &str, window: &str) -> PathBuf {
+    data_dir.join("hosts").join(session).join(format!("{window}.json"))
+}
+
+/// repomon's data dir, mirroring `repomon_core::config::data_dir()` exactly (the host must
+/// not depend on the heavy core crate): `REPOMON_DATA_DIR` override, else the platform
+/// project data dir.
+pub fn data_dir() -> PathBuf {
+    data_dir_from(std::env::var("REPOMON_DATA_DIR").ok())
+}
+
+fn data_dir_from(override_var: Option<String>) -> PathBuf {
+    if let Some(x) = override_var
+        && !x.is_empty()
+    {
+        return PathBuf::from(x);
+    }
+    directories::ProjectDirs::from("", "", "repomon")
+        .map(|d| d.data_dir().to_path_buf())
+        .unwrap_or_else(|| PathBuf::from(".").join("repomon-data"))
+}
+
+/// Write the entry atomically: temp file in the same directory, then rename. Creates parent
+/// directories. A crash can leave a `.tmp` file but never a torn JSON.
+pub fn write_atomic(path: &Path, entry: &RegistryEntry) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "registry path has no parent")
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let json = serde_json::to_vec(entry).expect("registry entry serializes");
+    let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
+    std::fs::write(&tmp, json)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Remove the entry; already-gone is success (host exit races the daemon's stale GC).
+pub fn remove(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// A random 128-bit hex owner token, for hosts spawned without `--owner`.
+pub fn generate_owner_token() -> String {
+    let mut buf = [0u8; 16];
+    getrandom::fill(&mut buf).expect("os entropy");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry() -> RegistryEntry {
+        RegistryEntry {
+            v: 1,
+            session: "repomon".into(),
+            window: "lane-3-1".into(),
+            pipe: pipe_name("repomon", "lane-3-1"),
+            host_pid: 4321,
+            agent_pid: 5678,
+            program: "claude".into(),
+            args: vec!["--permission-mode".into(), "plan".into()],
+            cwd: "C:\\Users\\me\\code\\proj".into(),
+            owner: "daemon-DESKTOP-ME-1a2b3c".into(),
+            started_at: 1789000000,
+        }
+    }
+
+    #[test]
+    fn pipe_name_matches_protocol() {
+        assert_eq!(pipe_name("repomon", "lane-3-1"), r"\\.\pipe\repomon-repomon-lane-3-1");
+    }
+
+    #[test]
+    fn registry_path_matches_protocol() {
+        let p = registry_path(std::path::Path::new("/data"), "repomon", "lane-3-1");
+        assert_eq!(
+            p,
+            std::path::Path::new("/data").join("hosts").join("repomon").join("lane-3-1.json")
+        );
+    }
+
+    #[test]
+    fn registry_entry_wire_shape_is_frozen() {
+        assert_eq!(
+            serde_json::to_string(&entry()).unwrap(),
+            r#"{"v":1,"session":"repomon","window":"lane-3-1","pipe":"\\\\.\\pipe\\repomon-repomon-lane-3-1","host_pid":4321,"agent_pid":5678,"program":"claude","args":["--permission-mode","plan"],"cwd":"C:\\Users\\me\\code\\proj","owner":"daemon-DESKTOP-ME-1a2b3c","started_at":1789000000}"#
+        );
+    }
+
+    #[test]
+    fn write_read_remove_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let e = entry();
+        let path = registry_path(dir.path(), &e.session, &e.window);
+        write_atomic(&path, &e).unwrap();
+
+        let back: RegistryEntry =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(back, e);
+
+        // No temp litter next to the file.
+        let siblings: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .map(|d| d.unwrap().file_name())
+            .collect();
+        assert_eq!(siblings, vec![std::ffi::OsString::from("lane-3-1.json")]);
+
+        remove(&path).unwrap();
+        assert!(!path.exists());
+        remove(&path).unwrap(); // idempotent — a second remove is not an error
+    }
+
+    #[test]
+    fn data_dir_override_wins() {
+        let with = data_dir_from(Some("C:\\override".into()));
+        assert_eq!(with, std::path::PathBuf::from("C:\\override"));
+        let empty = data_dir_from(Some(String::new()));
+        assert_ne!(empty, std::path::PathBuf::from(""), "empty override is ignored");
+    }
+
+    #[test]
+    fn owner_tokens_are_random_hex() {
+        let (a, b) = (generate_owner_token(), generate_owner_token());
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 32);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/repomon-host/src/run.rs
+++ b/crates/repomon-host/src/run.rs
@@ -1,0 +1,141 @@
+//! Host process assembly (Windows only): parse the spawn contract, start the ConPTY child,
+//! register, and serve until the child dies or a `kill` arrives.
+
+use std::process::ExitCode;
+use std::sync::{Arc, Mutex};
+
+use clap::Parser as _;
+use tokio::sync::broadcast;
+
+use crate::cli::HostArgs;
+use crate::dacl::PipeSecurity;
+use crate::dispatch::{Dispatcher, HostMeta};
+use crate::screen::Screen;
+use crate::server::{self, ServerCtx, epoch_now};
+use crate::{pty, registry};
+
+pub fn windows_main() -> ExitCode {
+    let args = HostArgs::parse();
+    match run(args) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("repomon-agent-host: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
+    let owner = args
+        .owner
+        .clone()
+        .unwrap_or_else(registry::generate_owner_token);
+    let (program, program_args) = args
+        .command
+        .split_first()
+        .expect("clap enforces a non-empty command");
+
+    let spawned = pty::spawn_child(
+        program,
+        program_args,
+        &args.cwd,
+        &args.env,
+        args.cols,
+        args.rows,
+    )?;
+    let started_at = epoch_now();
+
+    let meta = HostMeta {
+        session: args.session.clone(),
+        window: args.window.clone(),
+        cwd: args.cwd.display().to_string(),
+        program: program.clone(),
+        args: program_args.to_vec(),
+        agent_pid: spawned.child_pid,
+        owner: owner.clone(),
+        started_at,
+    };
+
+    let data_dir = registry::data_dir();
+    let registry_path = registry::registry_path(&data_dir, &args.session, &args.window);
+    let pipe = registry::pipe_name(&args.session, &args.window);
+
+    let entry = registry::RegistryEntry {
+        v: 1,
+        session: args.session.clone(),
+        window: args.window.clone(),
+        pipe: pipe.clone(),
+        host_pid: std::process::id(),
+        agent_pid: spawned.child_pid,
+        program: program.clone(),
+        args: program_args.to_vec(),
+        cwd: args.cwd.display().to_string(),
+        owner,
+        started_at,
+    };
+
+    let (bytes_tx, _) = broadcast::channel::<Vec<u8>>(1024);
+    let ctx = Arc::new(ServerCtx {
+        dispatcher: Mutex::new(Dispatcher::new(
+            meta,
+            Screen::new(args.cols, args.rows),
+            Box::new(spawned.controller),
+        )),
+        bytes_tx: bytes_tx.clone(),
+        registry_path: registry_path.clone(),
+    });
+
+    spawn_reader_thread(spawned.reader, ctx.clone());
+    spawn_waiter_thread(spawned.child, registry_path.clone());
+
+    let security = PipeSecurity::current_user_only()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(async move {
+        // Listen first, then register: a registry entry implies a connectable pipe
+        // (PROTOCOL.md §8).
+        let first_instance = server::create_instance(&pipe, &security, true)?;
+        registry::write_atomic(&registry_path, &entry)?;
+        server::serve(pipe, security, first_instance, ctx).await
+    })?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Drain ConPTY output: feed the vt100 screen (bumping `last_activity`) and fan the raw
+/// chunk out to byte subscribers. EOF means the child is gone — the waiter thread owns the
+/// shutdown.
+fn spawn_reader_thread(mut reader: Box<dyn std::io::Read + Send>, ctx: Arc<ServerCtx>) {
+    std::thread::spawn(move || {
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(n) => {
+                    let chunk = &buf[..n];
+                    {
+                        let mut dispatcher = ctx.dispatcher.lock().expect("dispatcher lock");
+                        dispatcher.process_output(chunk, epoch_now());
+                        // Send while holding the lock: subscribers snapshot-then-subscribe
+                        // under the same lock, so replay/live can never gap or overlap.
+                        let _ = ctx.bytes_tx.send(chunk.to_vec());
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Wait for the agent child; on exit, linger briefly (lets an in-flight `kill` response
+/// flush), remove the registry entry, and exit — the window disappears, tmux-style.
+fn spawn_waiter_thread(
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    registry_path: std::path::PathBuf,
+) {
+    std::thread::spawn(move || {
+        let _ = child.wait();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let _ = registry::remove(&registry_path);
+        std::process::exit(0);
+    });
+}

--- a/crates/repomon-host/src/screen.rs
+++ b/crates/repomon-host/src/screen.rs
@@ -1,0 +1,195 @@
+//! The server-side terminal screen: a vt100 emulator with tmux-parity scrollback.
+//!
+//! This is the source of truth for `capture`/`cursor`/`size`/`alternate_on` and for the
+//! `subscribe_bytes` first-frame replay — ConPTY rendering quirks never leak past it.
+//! Pure logic, tested on every OS with canned byte streams.
+
+/// Scrollback depth, parity with tmux `configure()`'s `history-limit 50000`.
+pub const HISTORY_LIMIT: usize = 50_000;
+
+/// A vt100 screen sized `cols × rows` with [`HISTORY_LIMIT`] lines of scrollback.
+///
+/// All geometry at this boundary is `(cols, rows)` / `(col, row)` — protocol order — even
+/// though vt100 itself speaks `(rows, cols)`.
+pub struct Screen {
+    parser: vt100::Parser,
+}
+
+impl Screen {
+    pub fn new(cols: u16, rows: u16) -> Self {
+        Self { parser: vt100::Parser::new(rows, cols, HISTORY_LIMIT) }
+    }
+
+    /// Feed raw PTY output bytes.
+    pub fn process(&mut self, bytes: &[u8]) {
+        self.parser.process(bytes);
+    }
+
+    /// Parity with `tmux capture-pane -e -p [-S -lines]`: up to `lines` rows of scrollback,
+    /// then every visible row, joined with `\n`, each row carrying its inline SGR escapes.
+    pub fn capture(&mut self, lines: Option<u32>) -> String {
+        let (_, cols) = self.parser.screen().size();
+        let mut out: Vec<String> = Vec::new();
+        if let Some(want) = lines {
+            // Clamp to the scrollback actually available (set_scrollback clamps for us).
+            self.parser.set_scrollback(usize::MAX);
+            let avail = self.parser.screen().scrollback();
+            let take = (want as usize).min(avail);
+            // At offset k the top visible row is the row k above the live top: walking k from
+            // `take` down to 1 yields the history rows oldest-first, ending flush against the
+            // live screen.
+            for k in (1..=take).rev() {
+                self.parser.set_scrollback(k);
+                let row = self.parser.screen().rows_formatted(0, cols).next().unwrap_or_default();
+                out.push(String::from_utf8_lossy(&row).into_owned());
+            }
+        }
+        self.parser.set_scrollback(0);
+        for row in self.parser.screen().rows_formatted(0, cols) {
+            out.push(String::from_utf8_lossy(&row).into_owned());
+        }
+        out.join("\n")
+    }
+
+    /// `(col, row, visible)`, 0-based — parity with `#{cursor_x}/#{cursor_y}/#{cursor_flag}`.
+    pub fn cursor(&self) -> (u16, u16, bool) {
+        let screen = self.parser.screen();
+        let (row, col) = screen.cursor_position();
+        (col, row, !screen.hide_cursor())
+    }
+
+    /// `(cols, rows)` — parity with `#{pane_width}/#{pane_height}`.
+    pub fn size(&self) -> (u16, u16) {
+        let (rows, cols) = self.parser.screen().size();
+        (cols, rows)
+    }
+
+    /// Whether the child is on the alternate screen — parity with `#{alternate_on}`.
+    pub fn alternate_on(&self) -> bool {
+        self.parser.screen().alternate_screen()
+    }
+
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        self.parser.set_size(rows, cols);
+    }
+
+    /// The `subscribe_bytes` first frame: bytes that recreate the current terminal state
+    /// (contents, attributes, cursor, input modes) from scratch on an empty emulator.
+    pub fn replay(&self) -> Vec<u8> {
+        self.parser.screen().state_formatted()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_limit_matches_tmux_configure() {
+        assert_eq!(HISTORY_LIMIT, 50_000);
+    }
+
+    #[test]
+    fn capture_renders_visible_rows() {
+        let mut s = Screen::new(80, 24);
+        s.process(b"hello\r\nworld");
+        let text = s.capture(None);
+        let lines: Vec<&str> = text.split('\n').collect();
+        assert_eq!(lines.len(), 24, "one line per visible row");
+        assert_eq!(lines[0], "hello");
+        assert_eq!(lines[1], "world");
+    }
+
+    #[test]
+    fn capture_preserves_sgr_escapes() {
+        let mut s = Screen::new(80, 24);
+        s.process(b"\x1b[31mred\x1b[0m plain");
+        let text = s.capture(None);
+        assert!(text.contains("red"), "text survives: {text:?}");
+        assert!(text.contains('\x1b'), "escapes included: {text:?}");
+    }
+
+    #[test]
+    fn capture_with_lines_prepends_scrollback() {
+        let mut s = Screen::new(80, 24);
+        for i in 0..30 {
+            s.process(format!("line-{i}\r\n").as_bytes());
+        }
+        // 31 rows used (trailing prompt row) on a 24-row screen → 7 rows of scrollback.
+        let visible = s.capture(None);
+        assert!(!visible.contains("line-0"), "line-0 scrolled out: {visible:?}");
+
+        let with_history = s.capture(Some(10));
+        let lines: Vec<&str> = with_history.split('\n').collect();
+        assert_eq!(lines.len(), 24 + 7, "clamped to available scrollback");
+        assert_eq!(lines[0], "line-0");
+        assert_eq!(lines[6], "line-6");
+        assert_eq!(lines[7], "line-7", "visible screen follows history seamlessly");
+
+        // Asking for less history than available takes the newest rows.
+        let two = s.capture(Some(2));
+        let lines: Vec<&str> = two.split('\n').collect();
+        assert_eq!(lines.len(), 26);
+        assert_eq!(lines[0], "line-5");
+    }
+
+    #[test]
+    fn capture_after_scrollback_read_leaves_view_at_bottom() {
+        let mut s = Screen::new(80, 24);
+        for i in 0..30 {
+            s.process(format!("line-{i}\r\n").as_bytes());
+        }
+        let _ = s.capture(Some(5));
+        // A later plain capture must see the live (bottom) view, not a scrolled one.
+        let visible = s.capture(None);
+        assert!(visible.contains("line-29"), "back at the live view: {visible:?}");
+    }
+
+    #[test]
+    fn cursor_tracks_position_and_visibility() {
+        let mut s = Screen::new(80, 24);
+        s.process(b"abc");
+        assert_eq!(s.cursor(), (3, 0, true), "(col, row, visible)");
+        s.process(b"\x1b[?25l");
+        assert_eq!(s.cursor().2, false, "hidden cursor reports visible=false");
+        s.process(b"\x1b[?25h\x1b[5;11H");
+        assert_eq!(s.cursor(), (10, 4, true), "0-based col/row");
+    }
+
+    #[test]
+    fn size_and_resize() {
+        let mut s = Screen::new(220, 50);
+        assert_eq!(s.size(), (220, 50), "(cols, rows)");
+        s.resize(100, 30);
+        assert_eq!(s.size(), (100, 30));
+        assert_eq!(s.capture(None).split('\n').count(), 30);
+    }
+
+    #[test]
+    fn alternate_screen_tracking() {
+        let mut s = Screen::new(80, 24);
+        assert!(!s.alternate_on());
+        s.process(b"\x1b[?1049h");
+        assert!(s.alternate_on(), "smcup enters the alternate screen");
+        s.process(b"\x1b[?1049l");
+        assert!(!s.alternate_on(), "rmcup leaves it");
+    }
+
+    #[test]
+    fn replay_reproduces_screen_on_a_fresh_emulator() {
+        let mut s = Screen::new(80, 24);
+        s.process(b"\x1b[2;3H\x1b[1;32mgreen bold\x1b[0m\r\ntail");
+        let replay = s.replay();
+
+        let mut fresh = vt100::Parser::new(24, 80, 0);
+        fresh.process(&replay);
+        let (orig, copy) = (s.parser.screen(), fresh.screen());
+        assert_eq!(copy.contents(), orig.contents(), "text converges");
+        assert_eq!(copy.cursor_position(), orig.cursor_position(), "cursor converges");
+        assert_eq!(
+            copy.cell(1, 2).unwrap().fgcolor(),
+            orig.cell(1, 2).unwrap().fgcolor(),
+            "attributes converge"
+        );
+    }
+}

--- a/crates/repomon-host/src/screen.rs
+++ b/crates/repomon-host/src/screen.rs
@@ -17,7 +17,9 @@ pub struct Screen {
 
 impl Screen {
     pub fn new(cols: u16, rows: u16) -> Self {
-        Self { parser: vt100::Parser::new(rows, cols, HISTORY_LIMIT) }
+        Self {
+            parser: vt100::Parser::new(rows, cols, HISTORY_LIMIT),
+        }
     }
 
     /// Feed raw PTY output bytes.
@@ -40,7 +42,12 @@ impl Screen {
             // live screen.
             for k in (1..=take).rev() {
                 self.parser.set_scrollback(k);
-                let row = self.parser.screen().rows_formatted(0, cols).next().unwrap_or_default();
+                let row = self
+                    .parser
+                    .screen()
+                    .rows_formatted(0, cols)
+                    .next()
+                    .unwrap_or_default();
                 out.push(String::from_utf8_lossy(&row).into_owned());
             }
         }
@@ -117,14 +124,20 @@ mod tests {
         }
         // 31 rows used (trailing prompt row) on a 24-row screen → 7 rows of scrollback.
         let visible = s.capture(None);
-        assert!(!visible.contains("line-0"), "line-0 scrolled out: {visible:?}");
+        assert!(
+            !visible.contains("line-0"),
+            "line-0 scrolled out: {visible:?}"
+        );
 
         let with_history = s.capture(Some(10));
         let lines: Vec<&str> = with_history.split('\n').collect();
         assert_eq!(lines.len(), 24 + 7, "clamped to available scrollback");
         assert_eq!(lines[0], "line-0");
         assert_eq!(lines[6], "line-6");
-        assert_eq!(lines[7], "line-7", "visible screen follows history seamlessly");
+        assert_eq!(
+            lines[7], "line-7",
+            "visible screen follows history seamlessly"
+        );
 
         // Asking for less history than available takes the newest rows.
         let two = s.capture(Some(2));
@@ -142,7 +155,10 @@ mod tests {
         let _ = s.capture(Some(5));
         // A later plain capture must see the live (bottom) view, not a scrolled one.
         let visible = s.capture(None);
-        assert!(visible.contains("line-29"), "back at the live view: {visible:?}");
+        assert!(
+            visible.contains("line-29"),
+            "back at the live view: {visible:?}"
+        );
     }
 
     #[test]
@@ -151,7 +167,7 @@ mod tests {
         s.process(b"abc");
         assert_eq!(s.cursor(), (3, 0, true), "(col, row, visible)");
         s.process(b"\x1b[?25l");
-        assert_eq!(s.cursor().2, false, "hidden cursor reports visible=false");
+        assert!(!s.cursor().2, "hidden cursor reports visible=false");
         s.process(b"\x1b[?25h\x1b[5;11H");
         assert_eq!(s.cursor(), (10, 4, true), "0-based col/row");
     }
@@ -185,7 +201,11 @@ mod tests {
         fresh.process(&replay);
         let (orig, copy) = (s.parser.screen(), fresh.screen());
         assert_eq!(copy.contents(), orig.contents(), "text converges");
-        assert_eq!(copy.cursor_position(), orig.cursor_position(), "cursor converges");
+        assert_eq!(
+            copy.cursor_position(),
+            orig.cursor_position(),
+            "cursor converges"
+        );
         assert_eq!(
             copy.cell(1, 2).unwrap().fgcolor(),
             orig.cell(1, 2).unwrap().fgcolor(),

--- a/crates/repomon-host/src/server.rs
+++ b/crates/repomon-host/src/server.rs
@@ -1,0 +1,140 @@
+//! The named-pipe control server (Windows only): accept loop, per-connection
+//! request/response handling, and `subscribe_bytes` streaming (PROTOCOL.md §5).
+
+use std::ffi::c_void;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use tokio::sync::broadcast;
+
+use crate::codec::{FrameDecoder, encode_frame};
+use crate::dacl::PipeSecurity;
+use crate::dispatch::{Dispatcher, Effect};
+use crate::protocol::StreamFrame;
+
+/// Shared server context: the dispatcher, the PTY byte fan-out, and what to clean up on
+/// `kill`.
+pub struct ServerCtx {
+    pub dispatcher: Mutex<Dispatcher>,
+    pub bytes_tx: broadcast::Sender<Vec<u8>>,
+    pub registry_path: std::path::PathBuf,
+}
+
+/// Create one pipe-server instance. The first instance claims the name exclusively
+/// (`FILE_FLAG_FIRST_PIPE_INSTANCE`) so a squatter can't pre-bind it; every instance
+/// carries the per-user DACL.
+pub fn create_instance(
+    pipe: &str,
+    security: &PipeSecurity,
+    first: bool,
+) -> std::io::Result<NamedPipeServer> {
+    let mut attrs = security.attributes();
+    unsafe {
+        ServerOptions::new()
+            .first_pipe_instance(first)
+            .create_with_security_attributes_raw(pipe, &mut attrs as *mut _ as *mut c_void)
+    }
+}
+
+/// Accept loop: hand each connected client to its own task, keeping a spare instance
+/// pending at all times. `first_instance` is the pre-created instance whose existence let
+/// the caller write the registry entry only once the pipe was connectable.
+pub async fn serve(
+    pipe: String,
+    security: PipeSecurity,
+    first_instance: NamedPipeServer,
+    ctx: Arc<ServerCtx>,
+) -> anyhow::Result<()> {
+    let mut instance = first_instance;
+    loop {
+        instance.connect().await?;
+        let next = create_instance(&pipe, &security, false)?;
+        let conn = std::mem::replace(&mut instance, next);
+        let ctx = ctx.clone();
+        tokio::spawn(async move {
+            handle_conn(conn, ctx).await;
+        });
+    }
+}
+
+/// One client connection: request/response until disconnect, a corrupt frame, `kill`, or
+/// an upgrade to stream mode.
+async fn handle_conn(mut conn: NamedPipeServer, ctx: Arc<ServerCtx>) {
+    let mut decoder = FrameDecoder::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = match conn.read(&mut buf).await {
+            Ok(0) | Err(_) => return,
+            Ok(n) => n,
+        };
+        decoder.extend(&buf[..n]);
+        loop {
+            let payload = match decoder.next_frame() {
+                Ok(Some(p)) => p,
+                Ok(None) => break,
+                Err(_) => return, // corrupt peer: disconnect (PROTOCOL.md §4)
+            };
+            let (response, effect) = ctx
+                .dispatcher
+                .lock()
+                .expect("dispatcher lock")
+                .handle(&payload, epoch_now());
+            if conn.write_all(&encode_frame(&response)).await.is_err() {
+                return;
+            }
+            match effect {
+                Effect::None => {}
+                Effect::Shutdown => {
+                    // kill: ok is on the wire; tear the window down like tmux kill-window.
+                    let _ = conn.flush().await;
+                    let _ = crate::registry::remove(&ctx.registry_path);
+                    std::process::exit(0);
+                }
+                Effect::StartStream => {
+                    stream_bytes(conn, ctx).await;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Stream mode: full-replay first frame, then live PTY chunks until disconnect. The
+/// receiver is subscribed under the dispatcher lock, so no byte can fall between the
+/// replay snapshot and the live tail (the PTY reader holds the same lock to feed bytes).
+async fn stream_bytes(mut conn: NamedPipeServer, ctx: Arc<ServerCtx>) {
+    let (replay, mut rx) = {
+        let dispatcher = ctx.dispatcher.lock().expect("dispatcher lock");
+        (dispatcher.replay(), ctx.bytes_tx.subscribe())
+    };
+    if send_stream_frame(&mut conn, &replay).await.is_err() {
+        return;
+    }
+    loop {
+        match rx.recv().await {
+            Ok(chunk) => {
+                if send_stream_frame(&mut conn, &chunk).await.is_err() {
+                    return;
+                }
+            }
+            // Lagged = we dropped chunks and the client's emulator would corrupt.
+            // Disconnect; the client reconnects and gets a fresh replay.
+            Err(broadcast::error::RecvError::Lagged(_))
+            | Err(broadcast::error::RecvError::Closed) => return,
+        }
+    }
+}
+
+async fn send_stream_frame(conn: &mut NamedPipeServer, data: &[u8]) -> std::io::Result<()> {
+    let frame = serde_json::to_vec(&StreamFrame::bytes(data)).expect("stream frame serializes");
+    conn.write_all(&encode_frame(&frame)).await
+}
+
+/// Unix epoch seconds (`#{window_activity}` parity).
+pub fn epoch_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/crates/repomon-host/tests/windows_integration.rs
+++ b/crates/repomon-host/tests/windows_integration.rs
@@ -1,0 +1,317 @@
+//! Windows-only end-to-end tests: spawn the real `repomon-agent-host` binary with a real
+//! ConPTY child, drive the named-pipe protocol exactly as PROTOCOL.md specifies, and check
+//! tmux-parity lifecycle semantics (registry appears/disappears, host dies with its child).
+//!
+//! These compile on every OS (the whole file is cfg(windows)-gated) but only execute on the
+//! Windows CI leg (landing with Track A). Written before the runtime existed — they are the
+//! RED half of TDD for the cfg(windows) modules.
+
+#![cfg(windows)]
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use repomon_host::codec::{FrameDecoder, encode_frame};
+use repomon_host::registry;
+
+const HOST_BIN: &str = env!("CARGO_BIN_EXE_repomon-agent-host");
+
+struct HostUnderTest {
+    child: Child,
+    data_dir: tempfile::TempDir,
+    session: String,
+    window: String,
+}
+
+impl HostUnderTest {
+    fn spawn(window: &str, command: &[&str]) -> Self {
+        let data_dir = tempfile::tempdir().unwrap();
+        let session = format!("itest{}", std::process::id());
+        let mut args = vec![
+            "--session".to_string(),
+            session.clone(),
+            "--window".to_string(),
+            window.to_string(),
+            "--cwd".to_string(),
+            data_dir.path().display().to_string(),
+            "--owner".to_string(),
+            "itest-owner-token".to_string(),
+            "--".to_string(),
+        ];
+        args.extend(command.iter().map(|s| s.to_string()));
+        let child = Command::new(HOST_BIN)
+            .args(&args)
+            .env("REPOMON_DATA_DIR", data_dir.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn host binary");
+        Self {
+            child,
+            data_dir,
+            session,
+            window: window.to_string(),
+        }
+    }
+
+    fn registry_path(&self) -> PathBuf {
+        registry::registry_path(self.data_dir.path(), &self.session, &self.window)
+    }
+
+    fn pipe_name(&self) -> String {
+        registry::pipe_name(&self.session, &self.window)
+    }
+
+    fn wait_for(&self, what: &str, timeout: Duration, mut cond: impl FnMut() -> bool) {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if cond() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        panic!("timed out waiting for {what}");
+    }
+
+    fn connect(&self) -> PipeClient {
+        let mut last_err = None;
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(10) {
+            match std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(self.pipe_name())
+            {
+                Ok(f) => {
+                    return PipeClient {
+                        file: f,
+                        decoder: FrameDecoder::new(),
+                        next_id: 1,
+                    };
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+        panic!("could not connect to {}: {last_err:?}", self.pipe_name());
+    }
+}
+
+impl Drop for HostUnderTest {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct PipeClient {
+    file: std::fs::File,
+    decoder: FrameDecoder,
+    next_id: u64,
+}
+
+impl PipeClient {
+    fn read_frame(&mut self) -> serde_json::Value {
+        let mut buf = [0u8; 65536];
+        loop {
+            if let Some(payload) = self.decoder.next_frame().expect("well-formed frame") {
+                return serde_json::from_slice(&payload).expect("frame is JSON");
+            }
+            let n = self.file.read(&mut buf).expect("pipe read");
+            assert!(n > 0, "pipe EOF while waiting for a frame");
+            self.decoder.extend(&buf[..n]);
+        }
+    }
+
+    fn request(&mut self, op_and_params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let mut req = op_and_params;
+        req["id"] = id.into();
+        self.file
+            .write_all(&encode_frame(req.to_string().as_bytes()))
+            .unwrap();
+        self.file.flush().unwrap();
+        let resp = self.read_frame();
+        assert_eq!(resp["id"], id, "response id echoes request id");
+        resp
+    }
+
+    fn ok(&mut self, op_and_params: serde_json::Value) -> serde_json::Value {
+        let resp = self.request(op_and_params);
+        assert!(resp.get("ok").is_some(), "expected ok, got {resp}");
+        resp["ok"].clone()
+    }
+}
+
+fn capture_text(client: &mut PipeClient) -> String {
+    client.ok(serde_json::json!({"op": "capture"}))["text"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn host_serves_the_full_protocol_end_to_end() {
+    let host = HostUnderTest::spawn("w1", &["cmd.exe"]);
+    host.wait_for("registry file", Duration::from_secs(10), || {
+        host.registry_path().exists()
+    });
+
+    // Registry entry matches PROTOCOL.md §8.
+    let entry: registry::RegistryEntry =
+        serde_json::from_slice(&std::fs::read(host.registry_path()).unwrap()).unwrap();
+    assert_eq!(entry.v, 1);
+    assert_eq!(entry.window, "w1");
+    assert_eq!(entry.pipe, host.pipe_name());
+    assert_eq!(entry.owner, "itest-owner-token");
+    assert!(entry.agent_pid > 0);
+
+    let mut c = host.connect();
+
+    // hello: owner-token handshake + meta.
+    let hello = c.ok(serde_json::json!({"op": "hello"}));
+    assert_eq!(hello["proto"], 1);
+    assert_eq!(hello["window"], "w1");
+    assert_eq!(hello["owner"], "itest-owner-token");
+    assert_eq!(hello["program"], "cmd.exe");
+    assert_eq!(hello["agent_pid"], entry.agent_pid);
+    assert!(hello["last_activity"].as_i64().unwrap() >= hello["started_at"].as_i64().unwrap());
+
+    // Default size is tmux parity 220×50.
+    let size = c.ok(serde_json::json!({"op": "size"}));
+    assert_eq!(
+        (size["cols"].as_u64(), size["rows"].as_u64()),
+        (Some(220), Some(50))
+    );
+
+    // send_text + capture: type a command into cmd.exe and see its output.
+    c.ok(serde_json::json!({"op": "send_text", "text": "echo host-e2e-done"}));
+    let host_ref = &host;
+    let mut probe = host.connect();
+    host_ref.wait_for("echo output in capture", Duration::from_secs(15), || {
+        capture_text(&mut probe).contains("host-e2e-done")
+    });
+
+    // cursor is somewhere on screen and visible for a shell prompt.
+    let cursor = c.ok(serde_json::json!({"op": "cursor"}));
+    assert_eq!(cursor["visible"], true);
+
+    // alternate_on is false for a plain shell.
+    assert_eq!(c.ok(serde_json::json!({"op": "alternate_on"}))["on"], false);
+
+    // resize: last client wins.
+    c.ok(serde_json::json!({"op": "resize", "cols": 100, "rows": 30}));
+    let size = c.ok(serde_json::json!({"op": "size"}));
+    assert_eq!(
+        (size["cols"].as_u64(), size["rows"].as_u64()),
+        (Some(100), Some(30))
+    );
+
+    // send_key round-trip (unknown key errors, connection stays usable).
+    let resp = c.request(serde_json::json!({"op": "send_key", "key": "NoSuchKey"}));
+    assert!(resp["err"].as_str().unwrap().contains("NoSuchKey"));
+    c.ok(serde_json::json!({"op": "send_key", "key": "Escape"}));
+
+    // subscribe_bytes on a separate connection: first frame is a full replay.
+    let mut sub = host.connect();
+    sub.ok(serde_json::json!({"op": "subscribe_bytes"}));
+    let first = sub.read_frame();
+    assert_eq!(first["stream"], "bytes");
+    let replay = base64::engine::general_purpose::STANDARD
+        .decode(first["data"].as_str().unwrap())
+        .unwrap();
+    let mut emu = vt100::Parser::new(30, 100, 0);
+    emu.process(&replay);
+    assert!(
+        emu.screen().contents().contains("host-e2e-done"),
+        "replay reproduces the screen: {:?}",
+        emu.screen().contents()
+    );
+
+    // Live bytes follow the replay.
+    c.ok(serde_json::json!({"op": "send_text", "text": "echo stream-follows"}));
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut streamed = Vec::new();
+    while Instant::now() < deadline {
+        let frame = sub.read_frame();
+        streamed.extend(
+            base64::engine::general_purpose::STANDARD
+                .decode(frame["data"].as_str().unwrap())
+                .unwrap(),
+        );
+        if String::from_utf8_lossy(&streamed).contains("stream-follows") {
+            break;
+        }
+    }
+    assert!(
+        String::from_utf8_lossy(&streamed).contains("stream-follows"),
+        "live PTY bytes arrive on the subscription"
+    );
+
+    // kill: window disappears like tmux kill-window.
+    c.ok(serde_json::json!({"op": "kill"}));
+    host.wait_for("registry entry removed", Duration::from_secs(10), || {
+        !host.registry_path().exists()
+    });
+}
+
+#[test]
+fn child_exit_removes_registry_and_host_exits() {
+    let mut host = HostUnderTest::spawn("w2", &["cmd.exe", "/c", "ping -n 2 127.0.0.1 >NUL"]);
+    host.wait_for("registry file", Duration::from_secs(10), || {
+        host.registry_path().exists()
+    });
+    host.wait_for(
+        "registry cleanup after child exit",
+        Duration::from_secs(20),
+        || !host.registry_path().exists(),
+    );
+    // The host process itself exits cleanly (status 0), like a tmux window closing.
+    let start = Instant::now();
+    let status = loop {
+        if let Some(s) = host.child.try_wait().unwrap() {
+            break s;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "host process exits"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(status.success(), "clean exit, got {status:?}");
+}
+
+#[test]
+fn npm_cmd_shim_note_is_covered_by_commandbuilder() {
+    // Risk item from the master plan: `.cmd` shims (the `claude` npm shim) must spawn.
+    // CommandBuilder resolves them; prove it with a throwaway .cmd script.
+    let dir = tempfile::tempdir().unwrap();
+    let shim = dir.path().join("fakeclaude.cmd");
+    std::fs::write(
+        &shim,
+        "@echo off\r\necho shim-ran\r\nping -n 30 127.0.0.1 >NUL\r\n",
+    )
+    .unwrap();
+
+    let host = HostUnderTest::spawn("w3", &[shim.to_str().unwrap()]);
+    host.wait_for("registry file", Duration::from_secs(10), || {
+        host.registry_path().exists()
+    });
+    let mut c = host.connect();
+    let host_ref = &host;
+    let mut probe = host.connect();
+    host_ref.wait_for("shim output", Duration::from_secs(15), || {
+        capture_text(&mut probe).contains("shim-ran")
+    });
+    c.ok(serde_json::json!({"op": "kill"}));
+    host.wait_for("registry entry removed", Duration::from_secs(10), || {
+        !host.registry_path().exists()
+    });
+}


### PR DESCRIPTION
## Track C — `crates/repomon-host` (Wave 1)

Standalone per-agent host binary (`repomon-agent-host.exe`): owns a ConPTY + agent child + server-side vt100 screen with scrollback, serves a length-prefixed JSON control protocol on a per-user-DACL named pipe, registers under `<data_dir>\hosts\<session>\<window>.json`, and survives daemon restarts — the Windows equivalent of the tmux server. No daemon integration here (Track I, Wave 2).

### PROTOCOL.md is FROZEN as of the first commit on this branch
`crates/repomon-host/PROTOCOL.md` is the inter-track contract Tracks I (WindowsBackend) and F (attach client) build against. Any change after that commit is a mini-RFC requiring integrator approval.

### Scope / merge notes
- Files: `crates/repomon-host/**` + root `Cargo.toml` **members list only** (deps declared crate-locally to avoid `workspace.dependencies` conflicts with parallel tracks).
- `Cargo.lock` conflicts with other Wave-1 PRs are expected; integrator resolves.
- Pure-logic tests (codec, protocol golden JSON, key translation, vt100 capture, registry) run on all OSes; `#[cfg(windows)]` integration tests run once Track A's `windows-latest` CI leg lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)