### PR TITLE
feat(dist): install.ps1 + windows release job (Track E)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: release
 on:
   push:
     tags: ["v*"]
+  # Manual dispatch on a branch ref runs only build-windows (the other jobs are
+  # tag-gated) so the Windows packaging can be validated before a real release.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,6 +14,7 @@ jobs:
   build:
     # Both macOS arches build on the arm64 runner via cross-compilation (macOS clang is a
     # universal toolchain). Avoids depending on the scarce/slow macos-13 Intel runners.
+    if: github.ref_type == 'tag'
     strategy:
       matrix:
         target: [aarch64-apple-darwin, x86_64-apple-darwin]
@@ -38,6 +42,7 @@ jobs:
 
   build-linux:
     # Each Linux arch builds natively on its own runner (no cross C toolchain needed).
+    if: github.ref_type == 'tag'
     strategy:
       matrix:
         include:
@@ -67,9 +72,59 @@ jobs:
             repomon-*.tar.gz
             repomon-*.tar.gz.sha256
 
+  build-windows:
+    # Runs on tag pushes AND on workflow_dispatch from any branch, so the Windows
+    # packaging can be exercised before the release flow is finalized.
+    #
+    # Draft status: both matrix legs are continue-on-error until the native Windows
+    # port (Tracks A/B/C) has merged and the workspace actually builds on
+    # x86_64-pc-windows-msvc. Wave 3 (Track G) flips the x86_64 leg to required.
+    # aarch64-pc-windows-msvc stays best-effort (stretch target).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+            experimental: true # TODO(Track G): flip to false once the Windows port lands
+          - target: aarch64-pc-windows-msvc
+            experimental: true # stretch target, allowed to fail
+    continue-on-error: ${{ matrix.experimental }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup show
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Package
+        shell: pwsh
+        run: |
+          $version = if ($env:GITHUB_REF -like 'refs/tags/*') {
+            $env:GITHUB_REF_NAME -replace '^v', ''
+          } else {
+            "0.0.0-$($env:GITHUB_SHA.Substring(0, 7))" # branch dispatch: dev version
+          }
+          $dist = "repomon-$version-${{ matrix.target }}"
+          New-Item -ItemType Directory -Path $dist | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/repomon.exe", `
+            "target/${{ matrix.target }}/release/repomond.exe" -Destination $dist
+          # repomon-agent-host (crates/repomon-host, Track C) may not have landed
+          # yet; include it in the zip whenever the workspace produced it.
+          $agentHost = "target/${{ matrix.target }}/release/repomon-agent-host.exe"
+          if (Test-Path $agentHost) { Copy-Item $agentHost -Destination $dist }
+          Compress-Archive -Path "$dist/*" -DestinationPath "$dist.zip"
+          (Get-FileHash "$dist.zip" -Algorithm SHA256).Hash.ToLower() |
+            Set-Content "$dist.zip.sha256"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            repomon-*.zip
+            repomon-*.zip.sha256
+
   universal:
     # Merge the two thin binaries into one fat (arm64+x86_64) archive for a
     # one-download-fits-all manual install. lipo is macOS-only, so this runs on macOS.
+    if: github.ref_type == 'tag'
     needs: build
     runs-on: macos-14
     steps:
@@ -96,12 +151,13 @@ jobs:
             repomon-*-universal-apple-darwin.tar.gz.sha256
 
   release:
-    needs: [build, universal, build-linux]
+    if: github.ref_type == 'tag'
+    needs: [build, universal, build-linux, build-windows]
     runs-on: ubuntu-latest
     env:
       HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v4        # for install.sh
+      - uses: actions/checkout@v4        # for install.sh / install.ps1
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -110,7 +166,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" dist/*.tar.gz install.sh \
+          # nullglob: the Windows zips are best-effort while build-windows is
+          # continue-on-error; a release without them must still succeed.
+          shopt -s nullglob
+          gh release create "$GITHUB_REF_NAME" dist/*.tar.gz dist/*.zip dist/*.zip.sha256 \
+            install.sh install.ps1 \
             --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes
       - name: Bump tap formula
         if: env.HAS_TAP_TOKEN == 'true'

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,109 @@
+# repomon installer for Windows. Downloads prebuilt binaries from GitHub Releases.
+# No Rust toolchain required. Works on Windows PowerShell 5.1 and PowerShell 7+.
+#
+#   irm https://github.com/AliHamzaAzam/repomon/releases/latest/download/install.ps1 | iex
+#
+# Env overrides:
+#   REPOMON_INSTALL_DIR   install location (default: %LOCALAPPDATA%\Programs\repomon)
+#   REPOMON_VERSION       version tag to install (default: latest), e.g. v0.5.0
+#
+# No param() block and no exit calls: this script must be safe to pipe into
+# Invoke-Expression from an interactive shell. Errors throw instead.
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue' # Invoke-WebRequest is much faster without the progress bar
+
+$repo = 'AliHamzaAzam/repomon'
+$headers = @{ 'User-Agent' = 'repomon-install' }
+
+# Windows PowerShell 5.1 may default to TLS 1.0; GitHub requires TLS 1.2+.
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    [Net.ServicePointManager]::SecurityProtocol = `
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
+
+$dest = if ($env:REPOMON_INSTALL_DIR) {
+    $env:REPOMON_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA 'Programs\repomon'
+}
+
+$target = switch ($env:PROCESSOR_ARCHITECTURE) {
+    'AMD64' { 'x86_64-pc-windows-msvc' }
+    'ARM64' { 'aarch64-pc-windows-msvc' }
+    default { throw "unsupported Windows architecture: $env:PROCESSOR_ARCHITECTURE" }
+}
+
+# Resolve the release tag (latest unless REPOMON_VERSION pins one).
+if (-not $env:REPOMON_VERSION -or $env:REPOMON_VERSION -eq 'latest') {
+    $tag = (Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest" -Headers $headers).tag_name
+} else {
+    $tag = $env:REPOMON_VERSION
+}
+if (-not $tag) { throw 'could not determine release tag' }
+$ver = $tag -replace '^v', ''
+
+$tmp = Join-Path ([IO.Path]::GetTempPath()) "repomon-install-$([IO.Path]::GetRandomFileName())"
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $zip = Join-Path $tmp 'repomon.zip'
+    $url = "https://github.com/$repo/releases/download/$tag/repomon-$ver-$target.zip"
+    Write-Host "Downloading repomon $ver ($target)..."
+    try {
+        # -UseBasicParsing: required on Windows PowerShell 5.1 when the IE engine
+        # is unavailable; accepted (and ignored) by PowerShell 7+.
+        Invoke-WebRequest -Uri $url -OutFile $zip -Headers $headers -UseBasicParsing
+    } catch {
+        if ($target -eq 'aarch64-pc-windows-msvc') {
+            # ARM64 builds are best-effort; fall back to x86_64 under emulation.
+            $target = 'x86_64-pc-windows-msvc'
+            $url = "https://github.com/$repo/releases/download/$tag/repomon-$ver-$target.zip"
+            Write-Host "No ARM64 build for $tag; falling back to x86_64 (runs under emulation)..."
+            Invoke-WebRequest -Uri $url -OutFile $zip -Headers $headers -UseBasicParsing
+        } else {
+            throw
+        }
+    }
+    Expand-Archive -Path $zip -DestinationPath $tmp -Force
+
+    New-Item -ItemType Directory -Path $dest -Force | Out-Null
+    $installed = @()
+    foreach ($exe in 'repomon.exe', 'repomond.exe', 'repomon-agent-host.exe') {
+        $src = Join-Path $tmp $exe
+        if (Test-Path $src) {
+            try {
+                Copy-Item -Path $src -Destination $dest -Force
+            } catch {
+                throw ("could not replace $exe in ${dest}: $($_.Exception.Message)`n" +
+                    "If repomon is running, stop it first (close the TUI and run 'repomond' shutdown or end the process), then re-run the installer.")
+            }
+            $installed += $exe
+        }
+    }
+    if ($installed.Count -eq 0) { throw "release archive contained no repomon binaries" }
+    Write-Host "Installed $($installed -join ', ') to $dest"
+} finally {
+    Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Add the install dir to the user PATH if it isn't there yet.
+$destNorm = $dest.TrimEnd('\')
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$onPath = @($userPath -split ';' | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\') }) -contains $destNorm
+if (-not $onPath) {
+    $newPath = if ($userPath) { "$userPath;$dest" } else { $dest }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    $env:Path = "$env:Path;$dest"
+    Write-Host "Added $dest to your user PATH (already active in this session; new terminals pick it up automatically)."
+}
+
+# Runtime dependency check. repomon needs git; no tmux on Windows (native agent hosts).
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Host "Warning: 'git' is not installed. repomon needs it. Install Git for Windows:"
+    Write-Host '    winget install --id Git.Git'
+}
+
+Write-Host ''
+Write-Host 'Enable cd-on-exit by adding to your PowerShell profile ($PROFILE):'
+Write-Host '    repomon shell-init powershell | Out-String | Invoke-Expression'
+Write-Host "Run 'repomon' to get started."


### PR DESCRIPTION
Track E of the native Windows plan (Wave 1): distribution draft. Zip + install.ps1 per the locked decisions; scoop/winget deferred.

## install.ps1 (new, repo root)

Windows counterpart of `install.sh`, same structure and env overrides:

- `REPOMON_INSTALL_DIR` (default `%LOCALAPPDATA%\Programs\repomon`) and `REPOMON_VERSION` (default `latest`, e.g. `v0.5.0`).
- Resolves the latest tag via the GitHub releases API, downloads `repomon-<ver>-<target>.zip`, extracts in a temp dir, copies `repomon.exe` / `repomond.exe` / `repomon-agent-host.exe` (each copy guarded by `Test-Path`, so archives without the host binary install fine).
- Adds the install dir to the **user** PATH if missing (and to the current session).
- Arch detection via `PROCESSOR_ARCHITECTURE`: AMD64 -> `x86_64-pc-windows-msvc`, ARM64 -> `aarch64-pc-windows-msvc` with automatic fallback to the x86_64 zip (emulation) when no native ARM64 asset exists, since that leg is best-effort.
- Safe for `irm https://.../install.ps1 | iex`: no `param()` block, no `exit` (errors `throw`), works on Windows PowerShell 5.1 (TLS 1.2 bump, `-UseBasicParsing`) and PowerShell 7+.
- Dependency hint for git (winget); no tmux check, the Windows backend does not use it. Epilogue points at `repomon shell-init powershell` (lands with Track D4, same wave).

## .github/workflows/release.yml

- New `build-windows` job on `windows-latest`: matrix over `x86_64-pc-windows-msvc` plus a stretch `aarch64-pc-windows-msvc` leg. Mirrors the existing jobs (rustup show / target add / `cargo build --release --locked --target ...`), builds the whole workspace so `repomon-agent-host.exe` is picked up automatically once `crates/repomon-host` (Track C) lands; its copy into the zip is guarded by an existence check so the job works before and after.
- Packages `repomon-<ver>-<target>.zip` (`Compress-Archive`) with a `.zip.sha256` sidecar (`Get-FileHash`), uploaded per target like the tar.gz jobs.
- **Both Windows legs are `continue-on-error` for now**: the workspace does not compile for the MSVC target until Tracks A/B/C merge, and a broken draft job must not block macOS/Linux tag releases. `TODO(Track G)` marks the Wave-3 flip of x86_64 to required.
- New `workflow_dispatch` trigger: the pre-existing jobs (`build`, `build-linux`, `universal`, `release`) are gated `if: github.ref_type == 'tag'`, so a manual dispatch on a branch runs **only** `build-windows` (with a `0.0.0-<sha7>` dev version) to validate packaging before Wave 3. Tag-push behavior for the existing jobs is unchanged.
- `release` job now needs `build-windows` and attaches `dist/*.zip`, `dist/*.zip.sha256`, and `install.ps1` alongside the tarballs and `install.sh`; `shopt -s nullglob` keeps the release green if the best-effort Windows zips are absent.

## Validation

- `install.ps1`: PowerShell is not installed on this machine (`pwsh` absent, no brew cask), so validation was by careful line-by-line review against PS 5.1/7 semantics (documented gotchas addressed: `-UseBasicParsing`, TLS 1.2 on 5.1, no `param()`/`exit` under `iex`, case-insensitive PATH comparison) plus a matching review of the embedded pwsh Package step extracted to a standalone file. A real end-to-end run needs the first release with Windows zips (Wave 3 / Track G checklist item 1 covers that on a clean VM); until then the workflow_dispatch path exercises the packaging half.
- `release.yml`: YAML parse validated; job structure mirrors the existing target jobs verbatim (artifact naming, upload paths, version derivation).
- Gate (no Rust touched, run to prove a clean tree): `cargo fmt --check && cargo clippy --workspace --all-targets --locked -D warnings && cargo test --workspace --locked` — all green.

## Merge notes

- File-disjoint from Tracks A-D (only `install.ps1` + `release.yml`); ci.yml untouched (Track A owns it). Can land in any order within Wave 1.
- Track G (Wave 3) flips the x86_64 windows leg to required, finalizes the release flow end-to-end, and tests the installer one-liner on a clean VM.
- No tags pushed; validate via Actions -> release -> Run workflow on this branch after merge (or on the branch itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
