### PR TITLE
feat(tui): PowerShell shell-init + REPOMON_CD_FILE cd-on-exit + tailscale Windows fallback (Track D4)

### DIFF
--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -514,12 +514,20 @@ fn generate_token() -> String {
     buf.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// The machine's Tailscale IPv4, via the `tailscale` CLI (PATH, then the Mac app bundle).
+/// Candidate `tailscale` binaries: PATH first, then the platform's default install
+/// location (the Mac app bundle, or the Windows Program Files directory).
+fn tailscale_candidates() -> [&'static str; 2] {
+    let fallback = if cfg!(windows) {
+        r"C:\Program Files\Tailscale\tailscale.exe"
+    } else {
+        "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+    };
+    ["tailscale", fallback]
+}
+
+/// The machine's Tailscale IPv4, via the `tailscale` CLI.
 fn tailscale_ip() -> Option<String> {
-    for bin in [
-        "tailscale",
-        "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
-    ] {
+    for bin in tailscale_candidates() {
         if let Ok(out) = std::process::Command::new(bin).args(["ip", "-4"]).output() {
             if out.status.success() {
                 let ip = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -792,6 +800,20 @@ mod tests {
     #[test]
     fn shell_init_rejects_unsupported_shell() {
         assert!(super::shell_init(clap_complete::Shell::Elvish).is_err());
+    }
+
+    #[test]
+    fn tailscale_candidates_path_then_platform_fallback() {
+        let [first, fallback] = super::tailscale_candidates();
+        assert_eq!(first, "tailscale");
+        if cfg!(windows) {
+            assert_eq!(fallback, r"C:\Program Files\Tailscale\tailscale.exe");
+        } else {
+            assert_eq!(
+                fallback,
+                "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+            );
+        }
     }
 
     #[test]

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -70,7 +70,7 @@ pub enum Command {
     },
     /// Print shell integration (cd-on-exit) for `eval "$(repomon shell-init zsh)"`.
     ShellInit {
-        /// Shell: zsh, bash, or fish.
+        /// Shell: zsh, bash, fish, or powershell.
         shell: clap_complete::Shell,
     },
     /// Write a roff man page to stdout (used by the Homebrew formula).
@@ -708,6 +708,24 @@ repomon() {
 }
 "#;
 
+const POWERSHELL_CD_WRAPPER: &str = r#"# repomon shell integration: cd into a lane's worktree on exit.
+# Add to $PROFILE: repomon shell-init powershell | Out-String | Invoke-Expression
+function repomon {
+    $bin = (Get-Command -Name repomon -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1).Source
+    if (-not $bin) { Write-Error 'repomon: binary not found on PATH'; return }
+    $tmp = [System.IO.Path]::GetTempFileName()
+    $env:REPOMON_CD_FILE = $tmp
+    try { & $bin @args }
+    finally { Remove-Item Env:\REPOMON_CD_FILE -ErrorAction SilentlyContinue }
+    $dir = Get-Content -LiteralPath $tmp -TotalCount 1 -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+    if ($dir -and (Test-Path -LiteralPath $dir -PathType Container)) {
+        Set-Location -LiteralPath $dir
+    }
+}
+"#;
+
 const FISH_CD_WRAPPER: &str = r#"# repomon shell integration: cd into a lane's worktree on exit.
 function repomon
     set -l tmp (mktemp)
@@ -722,9 +740,10 @@ pub fn shell_init(shell: clap_complete::Shell) -> Result<String> {
     let snippet = match shell {
         clap_complete::Shell::Zsh | clap_complete::Shell::Bash => POSIX_CD_WRAPPER,
         clap_complete::Shell::Fish => FISH_CD_WRAPPER,
+        clap_complete::Shell::PowerShell => POWERSHELL_CD_WRAPPER,
         other => {
             return Err(anyhow!(
-                "shell-init: unsupported shell '{other}'; use zsh, bash, or fish"
+                "shell-init: unsupported shell '{other}'; use zsh, bash, fish, or powershell"
             ));
         }
     };
@@ -761,8 +780,18 @@ mod tests {
     }
 
     #[test]
+    fn shell_init_powershell_defines_wrapper() {
+        let out = super::shell_init(clap_complete::Shell::PowerShell).unwrap();
+        assert!(out.contains("function repomon"));
+        assert!(out.contains("$env:REPOMON_CD_FILE"));
+        assert!(out.contains("Set-Location"));
+        // The wrapper must invoke the real binary, not recurse into the function.
+        assert!(out.contains("-CommandType Application"));
+    }
+
+    #[test]
     fn shell_init_rejects_unsupported_shell() {
-        assert!(super::shell_init(clap_complete::Shell::PowerShell).is_err());
+        assert!(super::shell_init(clap_complete::Shell::Elvish).is_err());
     }
 
     #[test]

--- a/crates/repomon-tui/src/lib.rs
+++ b/crates/repomon-tui/src/lib.rs
@@ -236,8 +236,17 @@ async fn start_embedded(config: &Config) -> Result<(PathBuf, EmbeddedGuard)> {
     ))
 }
 
-/// Write the chosen path to `$REPOMON_CD_FD` (or stdout) for the shell wrapper to cd into.
+/// Write the chosen path for the shell wrapper to cd into: `$REPOMON_CD_FILE` (a temp
+/// file, used by the PowerShell wrapper), else `$REPOMON_CD_FD` (an inherited fd, used
+/// by the POSIX/fish wrappers), else stdout.
 fn emit_cd(path: &Path) {
+    if let Ok(file_path) = std::env::var("REPOMON_CD_FILE")
+        && !file_path.is_empty()
+        && std::fs::write(&file_path, format!("{}\n", path.display())).is_ok()
+    {
+        return;
+    }
+    #[cfg(unix)]
     if let Ok(fd_str) = std::env::var("REPOMON_CD_FD") {
         if let Ok(fd) = fd_str.parse::<i32>() {
             use std::io::Write;
@@ -250,4 +259,23 @@ fn emit_cd(path: &Path) {
         }
     }
     println!("{}", path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn emit_cd_writes_repomon_cd_file() {
+        let dir = std::env::temp_dir().join(format!("repomon-emit-cd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cd_file = dir.join("cd-target");
+        // Safety: tests in this module are the only readers/writers of this var.
+        unsafe { std::env::set_var("REPOMON_CD_FILE", &cd_file) };
+        super::emit_cd(Path::new("/some/lane/worktree"));
+        unsafe { std::env::remove_var("REPOMON_CD_FILE") };
+        let written = std::fs::read_to_string(&cd_file).unwrap();
+        assert_eq!(written.trim_end(), "/some/lane/worktree");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
Wave 1, Track D4 of the native Windows plan (docs/superpowers/plans/2026-07-19-repomon-native-windows.md).

## What

- **PowerShell `shell-init`**: `repomon shell-init powershell` now emits a `repomon` function that points `$env:REPOMON_CD_FILE` at a temp file, invokes the real binary (`Get-Command -CommandType Application`, so the function never recurses), and `Set-Location`s into the file's first line on exit. Load via `repomon shell-init powershell | Out-String | Invoke-Expression` in `$PROFILE`.
- **`emit_cd` (lib.rs)**: honors `REPOMON_CD_FILE` first (portable temp-file mechanism), then the existing inherited-fd path (now `#[cfg(unix)]`, byte-for-byte unchanged for bash/zsh/fish), then stdout. Zero behavior change for existing shells; the zsh/bash/fish wrappers are untouched.
- **Tailscale detection**: new `tailscale_candidates()` — PATH first, then the platform fallback (`C:\Program Files\Tailscale\tailscale.exe` on Windows, the Mac app bundle elsewhere).
- Tests: inverted the old `shell_init_rejects_unsupported_shell` (powershell was the rejected case; Elvish keeps the rejection arm covered), plus new unit tests for the emitted PowerShell script, `emit_cd` file mode, and the tailscale candidate list. All run on every OS.

## Gate (run in the worktree)

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- `cargo test --workspace --locked`: 18 suites, 362 passed / 0 failed / 2 ignored
- `cargo check --target x86_64-pc-windows-msvc`: **blocked on this macOS host by pre-existing C-sys build scripts** (`ring`'s `cc` build and `libsqlite3-sys` need a Windows C toolchain). Verified pre-existing: `cargo check --target x86_64-pc-windows-msvc -p repomon-core` fails identically with zero D4 changes (D4 touches only repomon-tui). The Rust in this diff is platform-portable (`cfg!(windows)` + `#[cfg(unix)]` gating only); Track A's `windows-latest` CI leg is the authoritative Windows compile signal.

Not executed under a real `pwsh` locally (none installed on this host); the emitted script is covered by content unit tests and should get a once-over in Wave 3's Windows E2E (`repomon shell-init powershell` is already on the E2E checklist).

## Merge notes — MERGE LAST among A/B/D4

Per the master plan's conflict rules, this PR touches both Wave-1 hotspot files (`crates/repomon-tui/src/cli.rs`, `crates/repomon-tui/src/lib.rs`) and must land **after** Tracks A and B. Expected rebase friction:

- `cli.rs`: Track A replaces the `/dev/urandom` read in `generate_token` (adjacent to `tailscale_ip`) with `getrandom`; Track B reworks the attach path near `cli.rs:484`. My hunks (ShellInit help line, `tailscale_candidates`, wrapper consts, `shell_init` match, tests) should rebase cleanly but sit close to A's entropy hunk.
- `lib.rs`: Track A adds Windows creation flags in `spawn_daemon` and may touch `REPOMON_CD_FILE`/detach wiring; my `emit_cd` hunk is self-contained at the bottom of the file.

Do not merge until A and B are in; I'll rebase on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)