### PR TITLE
feat(core): Windows service management via Task Scheduler (Track D3)

### DIFF
--- a/crates/repomon-core/src/service.rs
+++ b/crates/repomon-core/src/service.rs
@@ -109,6 +109,60 @@ pub fn systemctl_user_args(op: ServiceOp) -> Vec<&'static str> {
     }
 }
 
+/// The Task Scheduler task name (Windows twin of [`LABEL`] / [`UNIT_NAME`]).
+pub const TASK_NAME: &str = "RepomonDaemon";
+
+/// The `/TR` command line for the logon task: `"program" --socket "socket"`. Both sides are
+/// quoted so `C:\Program Files\…` paths and pipe names survive Task Scheduler's re-parse.
+pub fn task_run_command(program: &Path, socket: &Path) -> String {
+    format!(
+        r#""{program}" --socket "{socket}""#,
+        program = program.display(),
+        socket = socket.display(),
+    )
+}
+
+/// The operations `repomon daemon …` drives through `schtasks` (Windows twin of [`ServiceOp`]).
+pub enum TaskOp {
+    Delete,
+    Run,
+    End,
+    Query,
+}
+
+/// The `schtasks` argv for an operation — pure, so the shapes are testable on every platform.
+/// Query uses `/FO CSV /NH` because the status field's *position* is locale-independent even
+/// where `/FO LIST`'s labels are not.
+pub fn schtasks_args(op: TaskOp) -> Vec<&'static str> {
+    match op {
+        TaskOp::Delete => vec!["/Delete", "/TN", TASK_NAME, "/F"],
+        TaskOp::Run => vec!["/Run", "/TN", TASK_NAME],
+        TaskOp::End => vec!["/End", "/TN", TASK_NAME],
+        TaskOp::Query => vec!["/Query", "/TN", TASK_NAME, "/FO", "CSV", "/NH"],
+    }
+}
+
+/// The `schtasks /Create` argv registering the logon task (`/SC ONLOGON`; `/F` overwrites a
+/// stale registration, the parity of the launchd bootout-before-bootstrap dance).
+pub fn schtasks_create_args(task_run: &str) -> Vec<String> {
+    ["/Create", "/TN", TASK_NAME, "/SC", "ONLOGON", "/TR", task_run, "/F"]
+        .into_iter()
+        .map(String::from)
+        .collect()
+}
+
+/// Extract the status field ("Ready", "Running", …) from `schtasks /Query /FO CSV /NH` output:
+/// the last field of the first row (`"TaskName","Next Run Time","Status"`).
+pub fn parse_query_status(csv: &str) -> Option<String> {
+    let row = csv.lines().find(|l| !l.trim().is_empty())?;
+    let status = row.rsplit(',').next()?.trim().trim_matches('"').trim();
+    if status.is_empty() {
+        None
+    } else {
+        Some(status.to_string())
+    }
+}
+
 #[cfg(target_os = "macos")]
 mod platform {
     use super::*;
@@ -417,5 +471,53 @@ mod tests {
     #[test]
     fn service_file_is_the_user_unit() {
         assert!(service_file_path().ends_with("systemd/user/repomon.service"));
+    }
+
+    #[test]
+    fn schtasks_create_argv_is_a_logon_task() {
+        let run = task_run_command(
+            Path::new(r"C:\Users\u\.cargo\bin\repomond.exe"),
+            Path::new(r"\\.\pipe\repomon-u"),
+        );
+        assert_eq!(
+            run,
+            r#""C:\Users\u\.cargo\bin\repomond.exe" --socket "\\.\pipe\repomon-u""#
+        );
+        let args = schtasks_create_args(&run);
+        assert_eq!(
+            args,
+            [
+                "/Create",
+                "/TN",
+                "RepomonDaemon",
+                "/SC",
+                "ONLOGON",
+                "/TR",
+                run.as_str(),
+                "/F"
+            ]
+        );
+    }
+
+    #[test]
+    fn schtasks_argv_shapes() {
+        assert_eq!(
+            schtasks_args(TaskOp::Delete),
+            ["/Delete", "/TN", "RepomonDaemon", "/F"]
+        );
+        assert_eq!(schtasks_args(TaskOp::Run), ["/Run", "/TN", "RepomonDaemon"]);
+        assert_eq!(schtasks_args(TaskOp::End), ["/End", "/TN", "RepomonDaemon"]);
+        assert_eq!(
+            schtasks_args(TaskOp::Query),
+            ["/Query", "/TN", "RepomonDaemon", "/FO", "CSV", "/NH"]
+        );
+    }
+
+    #[test]
+    fn query_status_parses_csv_row() {
+        let csv = "\"RepomonDaemon\",\"7/19/2026 9:00:00 AM\",\"Ready\"\r\n";
+        assert_eq!(parse_query_status(csv).as_deref(), Some("Ready"));
+        assert_eq!(parse_query_status(""), None);
+        assert_eq!(parse_query_status("\r\n"), None);
     }
 }

--- a/crates/repomon-core/src/service.rs
+++ b/crates/repomon-core/src/service.rs
@@ -1,4 +1,5 @@
-//! Daemon service management (launchd on macOS, systemd user units on Linux).
+//! Daemon service management (launchd on macOS, systemd user units on Linux, a Task Scheduler
+//! logon task on Windows).
 //!
 //! Lives in `repomon-core` because the `repomon daemon …` subcommands run from the TUI
 //! binary and must drive install/start/stop without depending on the daemon crate. A
@@ -145,10 +146,12 @@ pub fn schtasks_args(op: TaskOp) -> Vec<&'static str> {
 /// The `schtasks /Create` argv registering the logon task (`/SC ONLOGON`; `/F` overwrites a
 /// stale registration, the parity of the launchd bootout-before-bootstrap dance).
 pub fn schtasks_create_args(task_run: &str) -> Vec<String> {
-    ["/Create", "/TN", TASK_NAME, "/SC", "ONLOGON", "/TR", task_run, "/F"]
-        .into_iter()
-        .map(String::from)
-        .collect()
+    [
+        "/Create", "/TN", TASK_NAME, "/SC", "ONLOGON", "/TR", task_run, "/F",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
 }
 
 /// Extract the status field ("Ready", "Running", …) from `schtasks /Query /FO CSV /NH` output:
@@ -367,13 +370,82 @@ mod platform {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(windows)]
+mod platform {
+    use super::*;
+    use std::process::Command;
+
+    /// The task's path in the Task Scheduler library — no file on disk, but callers print it
+    /// after install the way the Unix arms print the plist/unit path.
+    pub fn service_file_path() -> PathBuf {
+        PathBuf::from(format!(r"\{TASK_NAME}"))
+    }
+
+    fn schtasks(args: &[&str]) -> Result<String> {
+        let out = Command::new("schtasks")
+            .args(args)
+            .output()
+            .map_err(Error::Io)?;
+        if !out.status.success() {
+            return Err(Error::Other(format!(
+                "schtasks {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    fn schtasks_op(op: TaskOp) -> Result<String> {
+        schtasks(&schtasks_args(op))
+    }
+
+    pub fn install(program: &Path, socket: &Path) -> Result<()> {
+        std::fs::create_dir_all(log_dir())?;
+        let run = task_run_command(program, socket);
+        let args = schtasks_create_args(&run);
+        let argv: Vec<&str> = args.iter().map(String::as_str).collect();
+        schtasks(&argv)?;
+        // Start it now too — parity with launchd bootstrap and `systemctl enable --now`.
+        schtasks_op(TaskOp::Run)?;
+        Ok(())
+    }
+
+    pub fn uninstall() -> Result<()> {
+        if schtasks_op(TaskOp::Query).is_err() {
+            // Not installed — nothing to do, like the Unix arms.
+            return Ok(());
+        }
+        let _ = schtasks_op(TaskOp::End);
+        schtasks_op(TaskOp::Delete)?;
+        Ok(())
+    }
+
+    pub fn start() -> Result<()> {
+        // End-then-run = start-or-restart, the parity of `launchctl kickstart -k`.
+        let _ = schtasks_op(TaskOp::End);
+        schtasks_op(TaskOp::Run).map(|_| ())
+    }
+
+    pub fn stop() -> Result<()> {
+        schtasks_op(TaskOp::End).map(|_| ())
+    }
+
+    pub fn status() -> Result<String> {
+        match schtasks_op(TaskOp::Query) {
+            Err(_) => Ok("not installed".to_string()),
+            Ok(out) => Ok(parse_query_status(&out).unwrap_or_else(|| "unknown".to_string())),
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
 mod platform {
     use super::*;
 
     fn unsupported() -> Error {
         Error::Other(
-            "service management is supported on macOS (launchd) and Linux (systemd user units)"
+            "service management is supported on macOS (launchd), Linux (systemd user units), and Windows (Task Scheduler)"
                 .into(),
         )
     }
@@ -409,7 +481,8 @@ pub fn log_file() -> PathBuf {
 pub fn repomond_path() -> PathBuf {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            let cand = dir.join("repomond");
+            // EXE_SUFFIX is ".exe" on Windows and "" on Unix.
+            let cand = dir.join(format!("repomond{}", std::env::consts::EXE_SUFFIX));
             if cand.exists() {
                 return cand;
             }


### PR DESCRIPTION
## Summary

Wave-1 Track D3 of the native Windows plan: `repomon daemon install|uninstall|start|stop|status` manages a Task Scheduler logon task on Windows, mirroring the launchd (macOS) and systemd (Linux) arms in `crates/repomon-core/src/service.rs`.

Follows the file's existing pattern exactly: pure, unit-testable builders at module top level (compiled and tested on every OS), plus a thin `#[cfg(windows)]` execution shim.

- `TASK_NAME` (`RepomonDaemon`), `task_run_command()` (quoted `/TR` line), `TaskOp` + `schtasks_args()` (Delete/Run/End/Query), `schtasks_create_args()` (`/Create /SC ONLOGON /F`), `parse_query_status()` (CSV query output; position-based so it survives localized `schtasks`).
- `#[cfg(windows)] mod platform`: install registers the logon task and runs it immediately (parity with launchd bootstrap / `systemctl enable --now`); start is end-then-run (`launchctl kickstart -k` parity); status maps a failed query to `not installed`. `service_file_path()` returns the task's library path `\RepomonDaemon` for the post-install message.
- Fallback module cfg widened to exclude `windows`; its advice string now mentions Task Scheduler.
- `repomond_path()` sibling lookup appends `std::env::consts::EXE_SUFFIX` so it finds `repomond.exe` (empty suffix on Unix; zero behavior change).

Touches only `crates/repomon-core/src/service.rs` per the track's isolation rules.

## Testing

- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo test --workspace --locked`: 362 passed, 0 failed (new all-OS builder tests: `schtasks_create_argv_is_a_logon_task`, `schtasks_argv_shapes`, `query_status_parses_csv_row`).
- `cargo check --target x86_64-pc-windows-msvc`: blocked on this macOS host by the pre-existing `libsqlite3-sys`/`ring` C build-script cross-compile failure, verified identical on unmodified `main` (Track A's `windows-latest` CI leg is the real gate). As a supplement, the full `service.rs` was type-checked and clippy-linted for `x86_64-pc-windows-msvc` via a pure-Rust harness crate: clean.

E2E (`repomon service install` registers a logon task on a real Windows box) lands with Track G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)