### PR TITLE
feat(core): WinRT toast notifications on Windows (Track D2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tauri-winrt-notification",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2986,6 +2987,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37a6c354fd28fc9e322ed9bd47e3959576dad28c9d58ea1cf888cce1c7ccb36"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -3564,6 +3576,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,6 +3607,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3603,6 +3647,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3713,6 +3767,24 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/repomon-core/Cargo.toml
+++ b/crates/repomon-core/Cargo.toml
@@ -25,5 +25,8 @@ notify = { workspace = true }
 notify-debouncer-full = { workspace = true }
 globset = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+tauri-winrt-notification = "0.8"
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -394,14 +394,17 @@ pub fn play_chime() {
             .arg(NOTIFY_SOUND_FILE)
             .output();
     });
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
+    std::thread::spawn(|| show_toast(chime_toast_spec()));
+    #[cfg(not(any(target_os = "macos", windows)))]
     std::thread::spawn(play_sound_blocking);
 }
 
 /// Fire a native desktop notification, best-effort and without blocking the caller (the actual
-/// `osascript`/`notify-send` invocation runs on a detached thread). `click_focus` makes the popup
-/// click-to-focus the terminal when `terminal-notifier` is installed (macOS only — on Linux
-/// there is no portable way to focus a terminal from a background process, so it's ignored).
+/// `osascript`/`notify-send`/WinRT-toast delivery runs on a detached thread). `click_focus` makes
+/// the popup click-to-focus the terminal when `terminal-notifier` is installed (macOS only — on
+/// Linux there is no portable way to focus a terminal from a background process, and on Windows
+/// toast activation would need a registered AUMID/COM handler, so it's ignored on both).
 pub fn send_native(title: &str, body: &str, sound: bool, click_focus: bool) {
     let (title, body) = (title.to_string(), body.to_string());
     std::thread::spawn(move || {
@@ -490,10 +493,29 @@ fn terminal_bundle_id(term_program: &str) -> Option<&'static str> {
     }
 }
 
+/// Deliver as a WinRT toast. Sound rides on the toast itself (`audible` → the default toast
+/// audio) — the Windows counterpart of the afplay/paplay chime, with no separate player process.
+#[cfg(windows)]
+fn run_native(title: &str, body: &str, sound: bool, _click_focus: bool) {
+    show_toast(toast_spec(title, body, sound));
+}
+
+/// Post a [`ToastSpec`] via the WinRT toast API, best-effort (delivery runs under the PowerShell
+/// AUMID so an unpackaged binary can toast without registering its own app id).
+#[cfg(windows)]
+fn show_toast(spec: ToastSpec) {
+    use tauri_winrt_notification::{Sound, Toast};
+    let _ = Toast::new(Toast::POWERSHELL_APP_ID)
+        .title(&spec.title)
+        .text1(&spec.body)
+        .sound(spec.audible.then_some(Sound::Default))
+        .show();
+}
+
 /// Deliver via `notify-send` (libnotify/DBus). The `sound-name` hint covers desktops that honor
 /// it; the local player in [`play_sound_blocking`] covers the rest. Both are best-effort no-ops
 /// on headless boxes.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn run_native(title: &str, body: &str, sound: bool, _click_focus: bool) {
     let _ = std::process::Command::new("notify-send")
         .args(notify_send_args(title, body, sound))
@@ -551,7 +573,7 @@ pub fn chime_toast_spec() -> ToastSpec {
 
 /// The local chime player, probed once per process: canberra (plays the themed event sound),
 /// else `paplay` with a freedesktop sound file that exists. `None` = no way to play a sound.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn sound_argv() -> Option<&'static [String]> {
     fn locate() -> Option<Vec<String>> {
         let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect();
@@ -575,7 +597,7 @@ fn sound_argv() -> Option<&'static [String]> {
 }
 
 /// Play the notification chime through whatever player this box has, if any.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn play_sound_blocking() {
     if let Some(argv) = sound_argv() {
         let _ = std::process::Command::new(&argv[0])

--- a/crates/repomon-core/src/notify.rs
+++ b/crates/repomon-core/src/notify.rs
@@ -521,6 +521,34 @@ pub fn notify_send_args(title: &str, body: &str, sound: bool) -> Vec<String> {
     args
 }
 
+/// What a Windows toast will show and whether it carries the system toast audio. Like
+/// [`notify_send_args`], the builder is pure and compiled everywhere so the shape is tested on
+/// every platform; only the delivery (`show_toast`) is `cfg(windows)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToastSpec {
+    pub title: String,
+    pub body: String,
+    /// Play the default toast sound with the popup — this *is* the Windows sound path (the
+    /// afplay/paplay equivalent): toast audio, not a separate player process.
+    pub audible: bool,
+}
+
+/// The toast for a regular notification: title/body verbatim, audio iff `sound` is on.
+pub fn toast_spec(title: &str, body: &str, sound: bool) -> ToastSpec {
+    ToastSpec {
+        title: title.to_string(),
+        body: body.to_string(),
+        audible: sound,
+    }
+}
+
+/// The toast behind [`play_chime`]'s Windows arm. WinRT has no bare play-a-sound API — toast
+/// audio only plays attached to a toast — so the Settings sound preview posts a minimal,
+/// always-audible toast instead (which also *shows* what an audible alert will look like).
+pub fn chime_toast_spec() -> ToastSpec {
+    toast_spec("repomon", "Notification sound", true)
+}
+
 /// The local chime player, probed once per process: canberra (plays the themed event sound),
 /// else `paplay` with a freedesktop sound file that exists. `None` = no way to play a sound.
 #[cfg(not(target_os = "macos"))]
@@ -582,6 +610,23 @@ mod tests {
         let args = notify_send_args("T", "B", false);
         assert!(!args.iter().any(|a| a.contains("sound-name")));
         assert_eq!(&args[args.len() - 3..], ["--", "T", "B"]);
+    }
+
+    #[test]
+    fn toast_spec_carries_text_and_audibility() {
+        let t = toast_spec("Title", "Body", true);
+        assert_eq!(t.title, "Title");
+        assert_eq!(t.body, "Body");
+        assert!(t.audible);
+        assert!(!toast_spec("T", "B", false).audible);
+    }
+
+    #[test]
+    fn chime_toast_spec_is_always_audible() {
+        let t = chime_toast_spec();
+        assert!(t.audible, "a chime preview must carry toast audio");
+        assert_eq!(t.title, "repomon");
+        assert!(!t.body.is_empty());
     }
 
     /// A snapshot state with the stall flag off — the common case in transition tests.


### PR DESCRIPTION
Wave 1, Track D2 of the native Windows plan: local desktop notifications gain a Windows delivery arm. The decision of WHETHER to notify (transition diffing, quiet gating, debounce, activity latch) is untouched; only delivery changes.

## What

- `#[cfg(windows)] run_native` posts a toast via `tauri-winrt-notification` under `Toast::POWERSHELL_APP_ID` (so the unpackaged binary can toast without registering an AUMID), replacing the osascript/notify-send paths on Windows.
- Toast audio replaces the afplay/paplay sound path: `sound: true` rides as `Sound::Default` on the toast itself, with no separate player process. `sound_argv`/`play_sound_blocking` and the notify-send arm narrow from `not(macos)` to `not(any(macos, windows))`.
- `play_chime`'s Windows arm posts a minimal always-audible preview toast, since WinRT has no bare play-a-sound API; toast audio only plays attached to a toast.
- Pure cross-OS builders `ToastSpec`/`toast_spec`/`chime_toast_spec`, mirroring the `notify_send_args` / `service.rs` testable-builder pattern, with unit tests that run on every OS.
- The dependency is `[target.'cfg(windows)'.dependencies]`-only; `cargo tree -p repomon-core` on Unix shows no winrt crates. Cargo.lock updated in the same commit.

## Verification

- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- `cargo test --workspace --locked` (macOS): all suites report `0 failed` (361 passed, 2 ignored).
- Windows target: `cargo check --target x86_64-pc-windows-msvc` cannot complete for the whole workspace yet, because `client.rs` still imports `tokio::net::UnixStream` unconditionally (Track A's deliverable). Ran via cargo-xwin on this branch and on `main`: identical single pre-existing error, nothing new from this change. The exact windows arm (`show_toast` + `tauri-winrt-notification 0.8.1`) was additionally type-checked against `x86_64-pc-windows-msvc` in a standalone probe crate: clean.

## Merge notes

- File-disjoint from Tracks A/B/D4 hotspots (`tui/src/lib.rs`, `tui/src/cli.rs` untouched); lands in any order per the master plan. Cargo.lock conflicts with sibling PRs are expected; integrator resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)