### PR TITLE
refactor: extract SessionBackend trait from TmuxRuntime (Windows Track B)

### DIFF
--- a/crates/repomon-core/src/agent/backend.rs
+++ b/crates/repomon-core/src/agent/backend.rs
@@ -1,0 +1,263 @@
+//! The session-backend abstraction the daemon drives agents through.
+//!
+//! [`SessionBackend`] is the single choke point between repomon and whatever owns the agent
+//! processes. On macOS/Linux the implementation is [`TmuxRuntime`](super::tmux::TmuxRuntime)
+//! (a long-lived tmux server on a dedicated socket); a future Windows backend talks to
+//! per-agent host processes instead. Everything above this trait — the RPC handlers, the
+//! reaper, auto-continue, the usage probe, byte streaming — is backend-agnostic.
+//!
+//! The trait is deliberately **synchronous**: every daemon call site already runs backend IO
+//! inside `tokio::task::spawn_blocking`, and tmux itself is driven via blocking subprocess
+//! calls. Implementations must be `Send + Sync` so an `Arc<dyn SessionBackend>` can be shared
+//! across tasks.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+use crate::model::LaneId;
+
+use super::tmux::TmuxRuntime;
+
+/// How to launch an agent process, structurally — program, extra arguments, working directory,
+/// and environment overrides — instead of a pre-quoted shell string.
+///
+/// `program` is the base command line as configured by the user (on Unix it may be a shell
+/// fragment such as `CLAUDE_CONFIG_DIR='…' claude`, because tmux runs commands through `sh -c`
+/// and agent commands are user-configured shell strings). `args` are appended by the backend
+/// with backend-appropriate quoting (the tmux impl single-quotes them via
+/// [`shell_quote`](super::tmux::shell_quote)); `env` entries are prepended as `KEY=value`
+/// assignments by backends that launch through a shell, or set on the child process directly
+/// by backends that don't.
+#[derive(Clone, Debug, Default)]
+pub struct SpawnSpec {
+    /// Base command line (a shell fragment on Unix; never empty for a spawn).
+    pub program: String,
+    /// Extra arguments, quoted/passed by the backend.
+    pub args: Vec<String>,
+    /// Working directory for the agent process.
+    pub cwd: PathBuf,
+    /// Environment overrides applied to the agent process.
+    pub env: Vec<(String, String)>,
+}
+
+impl SpawnSpec {
+    /// A spec with just a program and a working directory (the common case).
+    pub fn new(program: impl Into<String>, cwd: impl Into<PathBuf>) -> Self {
+        SpawnSpec {
+            program: program.into(),
+            cwd: cwd.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+        }
+    }
+
+    /// Append an argument (backend-quoted at render time).
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+}
+
+/// Options for capturing a window's pane text. `Default` captures the visible pane.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CaptureOpts {
+    /// Capture starting `n` lines back into scrollback (tmux `-S -n`); `None` = visible pane.
+    pub last_lines: Option<u32>,
+}
+
+impl CaptureOpts {
+    /// Capture the visible pane only.
+    pub fn visible() -> Self {
+        CaptureOpts::default()
+    }
+
+    /// Capture the last `n` lines of scrollback plus the visible pane.
+    pub fn last(n: u32) -> Self {
+        CaptureOpts {
+            last_lines: Some(n),
+        }
+    }
+}
+
+/// A pane's visible cursor position, 0-based from the top-left of the pane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cursor {
+    pub col: u16,
+    pub row: u16,
+}
+
+/// One window as the orphan reaper sees it: its name, the pane's current working directory,
+/// and the last pane-activity time (Unix epoch seconds).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowActivity {
+    pub name: String,
+    pub cwd: PathBuf,
+    pub last_activity: i64,
+}
+
+/// Result of the cooperative single-owner guard (see
+/// [`SessionBackend::claim_or_verify_owner`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OwnerState {
+    /// This daemon owns the backend server (it claimed it, or re-verified its own stamp).
+    Owned,
+    /// Another daemon's stamp is on the server — back off from destructive sweeps.
+    OwnedByOther,
+}
+
+/// The exact command a client should run in a real terminal to attach to a target — e.g.
+/// `tmux -L <session> attach -t <target>` on Unix. Carried as the optional `attach` field of
+/// the `agent.target` / `terminal.target` / `orchestrator.target` RPC responses so clients
+/// don't have to know which backend is running.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttachCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+/// A live raw-PTY byte stream for one window, as handed out by
+/// [`SessionBackend::open_byte_stream`]. The backend owns the plumbing (tmux: `mkfifo` +
+/// `pipe-pane`, with a reader thread pumping the fifo); the consumer just drains `rx`. The
+/// channel closes when the stream ends — the pipe was turned off via
+/// [`SessionBackend::close_byte_stream`] or the window died.
+pub struct ByteStream {
+    /// Chunks of raw PTY output, bounded to a backend-chosen chunk size per message.
+    pub rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+}
+
+/// A durable, out-of-process agent-session runtime: spawn/capture/input/resize/kill windows
+/// that survive the daemon. See the module docs for the sync + `Send + Sync` contract.
+pub trait SessionBackend: Send + Sync {
+    /// Is the backend usable on this machine (e.g. tmux installed and runnable)?
+    fn available(&self) -> bool;
+
+    /// Human-readable identity of the backing server, for diagnostics/logging only
+    /// (tmux: the session name).
+    fn label(&self) -> String;
+
+    /// Does the backing session/server currently exist?
+    fn session_exists(&self) -> bool;
+
+    /// Cooperative single-owner guard: stamp the server with `me` if unowned, else verify the
+    /// existing stamp. Two daemons aimed at the same server must never run destructive sweeps
+    /// against each other's windows.
+    fn claim_or_verify_owner(&self, me: &str) -> OwnerState;
+
+    /// Window names currently live in the session. A vanished server reads as empty.
+    fn list_windows(&self) -> Result<Vec<String>>;
+
+    /// Every window's name, pane cwd, and last-activity time — the orphan reaper's view.
+    fn list_windows_with_activity(&self) -> Result<Vec<WindowActivity>>;
+
+    /// Launch an agent in `lane`'s first *free* slot window; returns the new window's exact
+    /// attach target. A running agent is never killed — spawning again runs a second agent
+    /// side by side.
+    fn spawn(&self, lane: LaneId, spec: &SpawnSpec) -> Result<String>;
+
+    /// Launch a command as an arbitrary named window (usage probe, orchestrator); returns the
+    /// window's exact attach target.
+    fn spawn_named(&self, window: &str, spec: &SpawnSpec) -> Result<String>;
+
+    /// Open a plain interactive shell (the user's default) in `cwd` as a named window; returns
+    /// its attach target.
+    fn open_named(&self, window: &str, cwd: &Path) -> Result<String>;
+
+    /// Capture the window's pane text, including ANSI color escapes. A vanished window reads
+    /// as empty output.
+    fn capture_named(&self, window: &str, opts: CaptureOpts) -> Result<String>;
+
+    /// The pane's visible cursor, or `None` when hidden or the window is gone.
+    fn cursor_named(&self, window: &str) -> Option<Cursor>;
+
+    /// The pane's current grid `(cols, rows)`, or `None` when the window is gone.
+    fn size_named(&self, window: &str) -> Option<(u16, u16)>;
+
+    /// Resize the window to `cols × rows` (mediated-view reflow; pins the size).
+    fn resize_named(&self, window: &str, cols: u16, rows: u16) -> Result<()>;
+
+    /// Undo a pinned size: let the window follow the attaching client's size again.
+    fn follow_client_named(&self, window: &str) -> Result<()>;
+
+    /// Whether the window's app is on the alternate screen (a full-screen TUI).
+    fn alternate_on_named(&self, window: &str) -> bool;
+
+    /// Forward `ticks` mouse-wheel events (up or down) to the window's app.
+    fn scroll_wheel_named(&self, window: &str, up: bool, ticks: u32) -> Result<()>;
+
+    /// Send a literal string (no trailing Enter) — one keystroke's worth of input.
+    fn send_literal_named(&self, window: &str, text: &str) -> Result<()>;
+
+    /// Type `text` into the window and press Enter.
+    fn send_text_named(&self, window: &str, text: &str) -> Result<()>;
+
+    /// Send a named key (e.g. `C-c`, `Enter`, `Escape`).
+    fn send_key_named(&self, window: &str, key: &str) -> Result<()>;
+
+    /// Terminate a named window (an agent slot, a terminal, the orchestrator).
+    fn kill_named(&self, window: &str) -> Result<()>;
+
+    /// Make the attached experience feel native (mouse, clipboard, scrollback, status bar).
+    /// Idempotent; a no-op for backends with nothing to configure.
+    fn configure(&self);
+
+    /// The attach target for a named window (tmux: `session:window`, prefix-matched).
+    fn target_named(&self, window: &str) -> String;
+
+    /// The *exact* attach target for a named window (tmux: `session:=window`), immune to
+    /// prefix-matching surprises.
+    fn exact_target_named(&self, window: &str) -> String;
+
+    /// The command a client runs in a real terminal to attach to `target`.
+    fn attach_command(&self, target: &str) -> AttachCommand;
+
+    /// Start streaming the window's raw PTY bytes. The backend owns the transport (tmux:
+    /// fifo + `pipe-pane` + reader thread); the returned [`ByteStream`]'s channel closes when
+    /// the stream ends. At most one stream per window (tmux allows a single `pipe-pane`) —
+    /// callers refcount watchers and share it.
+    fn open_byte_stream(&self, window: &str) -> Result<ByteStream>;
+
+    /// Stop streaming the window's bytes (EOFs the reader). Benign when the window — or the
+    /// whole server — is already gone.
+    fn close_byte_stream(&self, window: &str) -> Result<()>;
+
+    // ---- provided helpers (backend-agnostic, built on `list_windows` + the shared lane/window
+    // naming convention, which is identical across backends) ----
+
+    /// Is there a window with this exact name?
+    fn has_named(&self, name: &str) -> bool {
+        self.list_windows()
+            .map(|w| w.iter().any(|x| x == name))
+            .unwrap_or(false)
+    }
+
+    /// Does `lane`'s first agent slot window exist?
+    fn has_window(&self, lane: LaneId) -> bool {
+        self.has_named(&TmuxRuntime::window_name(lane))
+    }
+
+    /// `lane`'s live agent windows, in slot order.
+    fn windows_for(&self, lane: LaneId) -> Result<Vec<String>> {
+        Ok(TmuxRuntime::lane_windows_in(&self.list_windows()?, lane))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_spec_builder_collects_args() {
+        let spec = SpawnSpec::new("claude", "/tmp").arg("do the thing");
+        assert_eq!(spec.program, "claude");
+        assert_eq!(spec.cwd, PathBuf::from("/tmp"));
+        assert_eq!(spec.args, vec!["do the thing"]);
+        assert!(spec.env.is_empty());
+    }
+
+    #[test]
+    fn capture_opts_constructors() {
+        assert_eq!(CaptureOpts::visible().last_lines, None);
+        assert_eq!(CaptureOpts::last(45).last_lines, Some(45));
+        assert_eq!(CaptureOpts::default(), CaptureOpts::visible());
+    }
+}

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -7,6 +7,7 @@
 //! daemon also falls back to "is the tmux window alive?".
 
 pub mod attention;
+pub mod backend;
 pub mod claude;
 pub mod gate;
 pub mod limit;
@@ -22,6 +23,10 @@ use chrono::{DateTime, Utc};
 
 use crate::model::{AgentKind, AgentStatus};
 
+pub use backend::{
+    AttachCommand, ByteStream, CaptureOpts, Cursor, OwnerState, SessionBackend, SpawnSpec,
+    WindowActivity,
+};
 pub use claude::TranscriptSummary;
 pub use limit::{LimitMenu, UsageLimit, detect_usage_limit, menu_select_keys};
 pub use tmux::{TmuxRuntime, shell_quote};

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -8,9 +8,15 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::{Error, Result};
 use crate::model::LaneId;
+
+use super::backend::{
+    AttachCommand, ByteStream, CaptureOpts, Cursor, OwnerState, SessionBackend, SpawnSpec,
+    WindowActivity,
+};
 
 /// A handle to a managed tmux session. Cheap to clone.
 #[derive(Clone, Debug)]
@@ -650,6 +656,214 @@ pub fn shell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+/// Render a [`SpawnSpec`] to the single shell command string tmux runs via `sh -c`:
+/// `K='v' … program 'arg1' 'arg2'`. The program is the user-configured command line and is
+/// passed through verbatim (it may legitimately be a shell fragment); env assignments and
+/// extra args are single-quoted via [`shell_quote`].
+fn render_spawn_command(spec: &SpawnSpec) -> String {
+    let mut cmd = String::new();
+    for (k, v) in &spec.env {
+        cmd.push_str(k);
+        cmd.push('=');
+        cmd.push_str(&shell_quote(v));
+        cmd.push(' ');
+    }
+    cmd.push_str(&spec.program);
+    for a in &spec.args {
+        cmd.push(' ');
+        cmd.push_str(&shell_quote(a));
+    }
+    cmd
+}
+
+/// Largest chunk a byte stream delivers per channel message — keeps single `event.agent.bytes`
+/// events bounded while a busy pane floods.
+const BYTE_STREAM_CHUNK: usize = 16 * 1024;
+
+/// Monotonic tag baked into every byte-stream fifo NAME, so two pipe instances of the same
+/// window never share a path — a superseded reader's EOF unlink can then only ever remove its
+/// own fifo, never a successor's (see `repomon-daemon`'s `bytes_stream` module doc for the
+/// rapid unwatch→rewatch race this kills).
+static NEXT_STREAM_TAG: AtomicU64 = AtomicU64::new(0);
+
+impl SessionBackend for TmuxRuntime {
+    fn available(&self) -> bool {
+        TmuxRuntime::available()
+    }
+
+    fn label(&self) -> String {
+        self.session.clone()
+    }
+
+    fn session_exists(&self) -> bool {
+        TmuxRuntime::session_exists(self)
+    }
+
+    fn claim_or_verify_owner(&self, me: &str) -> OwnerState {
+        if TmuxRuntime::claim_or_verify_owner(self, me) {
+            OwnerState::Owned
+        } else {
+            OwnerState::OwnedByOther
+        }
+    }
+
+    fn list_windows(&self) -> Result<Vec<String>> {
+        TmuxRuntime::list_windows(self)
+    }
+
+    fn list_windows_with_activity(&self) -> Result<Vec<WindowActivity>> {
+        Ok(TmuxRuntime::list_windows_with_activity(self)?
+            .into_iter()
+            .map(|(name, cwd, last_activity)| WindowActivity {
+                name,
+                cwd,
+                last_activity,
+            })
+            .collect())
+    }
+
+    fn spawn(&self, lane: LaneId, spec: &SpawnSpec) -> Result<String> {
+        TmuxRuntime::spawn(self, lane, &spec.cwd, &render_spawn_command(spec))
+    }
+
+    fn spawn_named(&self, window: &str, spec: &SpawnSpec) -> Result<String> {
+        TmuxRuntime::spawn_named(self, window, &spec.cwd, &render_spawn_command(spec))
+    }
+
+    fn open_named(&self, window: &str, cwd: &Path) -> Result<String> {
+        TmuxRuntime::open_named(self, window, cwd)
+    }
+
+    fn capture_named(&self, window: &str, opts: CaptureOpts) -> Result<String> {
+        TmuxRuntime::capture_named(self, window, opts.last_lines)
+    }
+
+    fn cursor_named(&self, window: &str) -> Option<Cursor> {
+        TmuxRuntime::cursor_named(self, window).map(|(col, row)| Cursor { col, row })
+    }
+
+    fn size_named(&self, window: &str) -> Option<(u16, u16)> {
+        TmuxRuntime::size_named(self, window)
+    }
+
+    fn resize_named(&self, window: &str, cols: u16, rows: u16) -> Result<()> {
+        TmuxRuntime::resize_named(self, window, cols, rows)
+    }
+
+    fn follow_client_named(&self, window: &str) -> Result<()> {
+        TmuxRuntime::follow_client_named(self, window)
+    }
+
+    fn alternate_on_named(&self, window: &str) -> bool {
+        TmuxRuntime::alternate_on_named(self, window)
+    }
+
+    fn scroll_wheel_named(&self, window: &str, up: bool, ticks: u32) -> Result<()> {
+        TmuxRuntime::scroll_wheel_named(self, window, up, ticks)
+    }
+
+    fn send_literal_named(&self, window: &str, text: &str) -> Result<()> {
+        TmuxRuntime::send_literal_named(self, window, text)
+    }
+
+    fn send_text_named(&self, window: &str, text: &str) -> Result<()> {
+        TmuxRuntime::send_text_named(self, window, text)
+    }
+
+    fn send_key_named(&self, window: &str, key: &str) -> Result<()> {
+        TmuxRuntime::send_key_named(self, window, key)
+    }
+
+    fn kill_named(&self, window: &str) -> Result<()> {
+        TmuxRuntime::kill_named(self, window)
+    }
+
+    fn configure(&self) {
+        TmuxRuntime::configure(self)
+    }
+
+    fn target_named(&self, window: &str) -> String {
+        TmuxRuntime::target_named(self, window)
+    }
+
+    fn exact_target_named(&self, window: &str) -> String {
+        self.exact_target(window)
+    }
+
+    fn attach_command(&self, target: &str) -> AttachCommand {
+        AttachCommand {
+            program: "tmux".to_string(),
+            args: vec![
+                "-L".to_string(),
+                self.session.clone(),
+                "attach".to_string(),
+                "-t".to_string(),
+                target.to_string(),
+            ],
+        }
+    }
+
+    /// The fifo + `pipe-pane` rendezvous, absorbed from the daemon's old `bytes_stream::watch`:
+    /// create a uniquely-named fifo, start the reader thread FIRST (its `open()` is the
+    /// rendezvous with `cat`'s write-side open — tmux buffers pane output behind a stalled
+    /// pipe), then point `pipe-pane` at it. On EOF (pipe turned off or window died) the reader
+    /// removes its fifo — inherently safe: the tag-unique name means it can only ever be its
+    /// own, never a successor's — and drops the sender, closing the stream.
+    fn open_byte_stream(&self, window: &str) -> Result<ByteStream> {
+        let tag = NEXT_STREAM_TAG.fetch_add(1, Ordering::Relaxed);
+        let fifo = std::env::temp_dir().join(format!(
+            "repomon-bytes-{}-{window}-{tag}.fifo",
+            self.session
+        ));
+        // The pre-mkfifo unlink guards the one same-path case left — a leftover fifo from a
+        // previous daemon run (the tag counter restarts at 0).
+        let _ = std::fs::remove_file(&fifo);
+        let ok = Command::new("mkfifo")
+            .arg(&fifo)
+            .output()
+            .map_err(Error::Io)?
+            .status
+            .success();
+        if !ok {
+            return Err(Error::Agent(format!("mkfifo {} failed", fifo.display())));
+        }
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        {
+            let fifo = fifo.clone();
+            std::thread::spawn(move || {
+                use std::io::Read;
+                let Ok(mut f) = std::fs::File::open(&fifo) else {
+                    return;
+                };
+                let mut buf = vec![0u8; BYTE_STREAM_CHUNK];
+                loop {
+                    match f.read(&mut buf) {
+                        Ok(0) | Err(_) => break, // EOF: pipe turned off or window died
+                        Ok(n) => {
+                            if tx.send(buf[..n].to_vec()).is_err() {
+                                break; // consumer gone — stop pumping
+                            }
+                        }
+                    }
+                }
+                let _ = std::fs::remove_file(&fifo);
+            });
+        }
+        if let Err(e) = self.pipe_pane_named(window, &fifo) {
+            // The pipe never started: remove the fifo so it can't linger. (The reader, still
+            // blocked on open(), is a pre-existing leak parity — no `cat` ever opens the write
+            // side, same as before this moved out of the daemon.)
+            let _ = std::fs::remove_file(&fifo);
+            return Err(e);
+        }
+        Ok(ByteStream { rx })
+    }
+
+    fn close_byte_stream(&self, window: &str) -> Result<()> {
+        self.pipe_pane_off_named(window)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -658,6 +872,42 @@ mod tests {
     fn quotes_for_shell() {
         assert_eq!(shell_quote("hello"), "'hello'");
         assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn renders_spawn_specs_to_sh_command_strings() {
+        // Program alone passes through verbatim (it may be a user-configured shell fragment).
+        let bare = SpawnSpec::new("env -u CLAUDE_CONFIG_DIR claude", "/tmp");
+        assert_eq!(render_spawn_command(&bare), "env -u CLAUDE_CONFIG_DIR claude");
+        // Args are single-quoted and appended — byte-identical to the old
+        // `format!("{command} {}", shell_quote(task))` assembly.
+        let with_task = SpawnSpec::new("claude", "/tmp").arg("fix the bug");
+        assert_eq!(render_spawn_command(&with_task), "claude 'fix the bug'");
+        let quoted = SpawnSpec::new("claude", "/tmp").arg("it's tricky");
+        assert_eq!(render_spawn_command(&quoted), r"claude 'it'\''s tricky'");
+        // Env pairs become leading KEY='value' assignments.
+        let mut with_env = SpawnSpec::new("claude", "/tmp");
+        with_env.env.push(("FOO".into(), "a b".into()));
+        assert_eq!(render_spawn_command(&with_env), "FOO='a b' claude");
+    }
+
+    #[test]
+    fn backend_attach_command_matches_the_tmux_invocation() {
+        let rt = TmuxRuntime::new("repomon");
+        let cmd = SessionBackend::attach_command(&rt, "repomon:=lane-7");
+        assert_eq!(cmd.program, "tmux");
+        assert_eq!(
+            cmd.args,
+            vec!["-L", "repomon", "attach", "-t", "repomon:=lane-7"]
+        );
+    }
+
+    #[test]
+    fn backend_targets_match_the_inherent_formats() {
+        let rt = TmuxRuntime::new("repomon");
+        assert_eq!(SessionBackend::target_named(&rt, "term-1-1"), "repomon:term-1-1");
+        assert_eq!(rt.exact_target_named("lane-7"), "repomon:=lane-7");
+        assert_eq!(SessionBackend::label(&rt), "repomon");
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -878,7 +878,10 @@ mod tests {
     fn renders_spawn_specs_to_sh_command_strings() {
         // Program alone passes through verbatim (it may be a user-configured shell fragment).
         let bare = SpawnSpec::new("env -u CLAUDE_CONFIG_DIR claude", "/tmp");
-        assert_eq!(render_spawn_command(&bare), "env -u CLAUDE_CONFIG_DIR claude");
+        assert_eq!(
+            render_spawn_command(&bare),
+            "env -u CLAUDE_CONFIG_DIR claude"
+        );
         // Args are single-quoted and appended — byte-identical to the old
         // `format!("{command} {}", shell_quote(task))` assembly.
         let with_task = SpawnSpec::new("claude", "/tmp").arg("fix the bug");
@@ -905,7 +908,10 @@ mod tests {
     #[test]
     fn backend_targets_match_the_inherent_formats() {
         let rt = TmuxRuntime::new("repomon");
-        assert_eq!(SessionBackend::target_named(&rt, "term-1-1"), "repomon:term-1-1");
+        assert_eq!(
+            SessionBackend::target_named(&rt, "term-1-1"),
+            "repomon:term-1-1"
+        );
         assert_eq!(rt.exact_target_named("lane-7"), "repomon:=lane-7");
         assert_eq!(SessionBackend::label(&rt), "repomon");
     }

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod store;
 pub mod traits;
 pub mod watch;
 
-pub use agent::{AgentMonitor, ClaudeMonitor, TmuxRuntime};
+pub use agent::{AgentMonitor, ClaudeMonitor, SessionBackend, TmuxRuntime};
 pub use config::Config;
 pub use error::{Error, Result};
 pub use indexer::Indexer;

--- a/crates/repomon-daemon/src/auto_continue.rs
+++ b/crates/repomon-daemon/src/auto_continue.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use repomon_core::TmuxRuntime;
 use repomon_core::agent::{UsageLimit, detect_usage_limit, menu_select_keys};
+use repomon_core::agent::backend::CaptureOpts;
 use repomon_core::model::LaneId;
 
 use crate::{Ctx, pubsub};
@@ -183,7 +184,7 @@ pub async fn auto_continue_watcher(ctx: Arc<Ctx>) {
             (cfg.auto_continue, cfg.auto_continue_message.clone())
         };
 
-        let tmux = ctx.tmux.clone();
+        let tmux = ctx.backend.clone();
         let names = match tokio::task::spawn_blocking(move || tmux.list_windows()).await {
             Ok(Ok(v)) => v,
             _ => continue,
@@ -199,9 +200,9 @@ pub async fn auto_continue_watcher(ctx: Arc<Ctx>) {
         let now = Utc::now();
 
         for (window, lane) in windows {
-            let tmuxc = ctx.tmux.clone();
+            let tmuxc = ctx.backend.clone();
             let win = window.clone();
-            let capture = tokio::task::spawn_blocking(move || tmuxc.capture_named(&win, Some(120)));
+            let capture = tokio::task::spawn_blocking(move || tmuxc.capture_named(&win, CaptureOpts::last(120)));
             // Bound the capture so one wedged pane can't freeze the serialized per-window scan
             // and stall auto-continue for every other agent. On timeout (or any error) skip this
             // window this tick and try again next time.
@@ -273,7 +274,7 @@ async fn apply(
             // Walk the cursor to "Stop and wait …" and confirm — the exact keys were derived
             // from the menu's on-screen positions. A short gap between keys lets the menu's
             // renderer keep up with repeated arrows.
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let win = window.to_string();
             let _ = tokio::task::spawn_blocking(move || {
                 for (i, key) in keys.iter().enumerate() {
@@ -290,7 +291,7 @@ async fn apply(
             }
         }
         Action::Send => {
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let msg = message.to_string();
             let win = window.to_string();
             let _ = tokio::task::spawn_blocking(move || tmux.send_text_named(&win, &msg)).await;

--- a/crates/repomon-daemon/src/auto_continue.rs
+++ b/crates/repomon-daemon/src/auto_continue.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use repomon_core::TmuxRuntime;
-use repomon_core::agent::{UsageLimit, detect_usage_limit, menu_select_keys};
 use repomon_core::agent::backend::CaptureOpts;
+use repomon_core::agent::{UsageLimit, detect_usage_limit, menu_select_keys};
 use repomon_core::model::LaneId;
 
 use crate::{Ctx, pubsub};
@@ -202,7 +202,9 @@ pub async fn auto_continue_watcher(ctx: Arc<Ctx>) {
         for (window, lane) in windows {
             let tmuxc = ctx.backend.clone();
             let win = window.clone();
-            let capture = tokio::task::spawn_blocking(move || tmuxc.capture_named(&win, CaptureOpts::last(120)));
+            let capture = tokio::task::spawn_blocking(move || {
+                tmuxc.capture_named(&win, CaptureOpts::last(120))
+            });
             // Bound the capture so one wedged pane can't freeze the serialized per-window scan
             // and stall auto-continue for every other agent. On timeout (or any error) skip this
             // window this tick and try again next time.

--- a/crates/repomon-daemon/src/bytes_stream.rs
+++ b/crates/repomon-daemon/src/bytes_stream.rs
@@ -1,77 +1,65 @@
 //! Streaming one pane's raw PTY bytes — the embedded renderer's feed, shared across watchers.
 //!
-//! The mediated view is a poll → `capture-pane -e` → re-parse pipeline; the embedded renderer
-//! instead wants the pane's actual byte stream. `tmux pipe-pane` provides it: tmux runs a
-//! `cat > fifo` for the pane and every byte the pane emits flows through. The daemon owns the
-//! fifo and its reader; each chunk is broadcast as `event.agent.bytes` (base64 — PTY bytes are
-//! not valid UTF-8 at chunk boundaries).
+//! The mediated view is a poll → capture → re-parse pipeline; the embedded renderer instead
+//! wants the pane's actual byte stream. The backend provides it via
+//! [`SessionBackend::open_byte_stream`] (on tmux: `pipe-pane` into a daemon-owned fifo); each
+//! chunk is broadcast as `event.agent.bytes` (base64 — PTY bytes are not valid UTF-8 at chunk
+//! boundaries).
 //!
-//! ONE PIPE PER WINDOW, SHARED. tmux allows only one `pipe-pane` per pane, so a window can have
-//! exactly one fifo/reader no matter how many clients watch it. The event bus already broadcasts
-//! every chunk to every subscriber; who actually *receives* a window's bytes is decided per
-//! connection at the forwarding loops (a connection forwards `event.agent.bytes` only for windows
-//! in its `watched_bytes` set). This module therefore refcounts watchers per window: the first
-//! watcher starts the pipe, later watchers just join the readership, and the pipe is torn down
-//! only when the last watcher leaves. A phone, an iPad, and the Mac TUI can all watch the same
-//! (or different) windows at once — the old single global slot let any new watch kill the
-//! previous one, which is exactly what broke concurrency.
+//! ONE PIPE PER WINDOW, SHARED. The backend allows only one byte stream per window (tmux allows
+//! one `pipe-pane` per pane), so a window can have exactly one stream no matter how many clients
+//! watch it. The event bus already broadcasts every chunk to every subscriber; who actually
+//! *receives* a window's bytes is decided per connection at the forwarding loops (a connection
+//! forwards `event.agent.bytes` only for windows in its `watched_bytes` set). This module
+//! therefore refcounts watchers per window: the first watcher starts the stream, later watchers
+//! just join the readership, and the stream is torn down only when the last watcher leaves. A
+//! phone, an iPad, and the Mac TUI can all watch the same (or different) windows at once — the
+//! old single global slot let any new watch kill the previous one, which is exactly what broke
+//! concurrency.
 //!
-//! ORDERING: the reader must open the fifo before `pipe-pane` starts `cat` — the fifo open is the
-//! rendezvous — so tmux never buffers behind a dead pipe.
-//!
-//! GENERATION / EOF race: lifecycle is EOF-driven — `pipe-pane` (off) or the window dying kills
-//! the `cat`, whose write end closing EOFs the reader, which exits and removes the fifo. Each
-//! fresh pipe (a first watcher creating a new entry) gets a globally-unique `generation`, and the
-//! generation is embedded in the fifo FILENAME, so two pipe instances of the same window never
-//! share a path. That makes the reader's EOF unlink inherently safe: it can only ever remove its
-//! own fifo, never a successor's — without the unique name, a rapid unwatch→rewatch of the same
-//! window could have the dying reader unlink the NEW pipe's fifo just before `cat > fifo` opens
-//! it, turning the fifo into a plain file that streams nothing while the fresh reader leaks. The
-//! reader additionally drops its own map entry ONLY if the entry's generation still matches the
-//! one it was started with; without that, the same race would delete the freshly-started entry,
-//! leaving `watched_bytes` pointing at a live window whose entry is gone — it would accept refs
-//! and stream nothing.
+//! GENERATION / EOF race: lifecycle is EOF-driven — closing the stream (or the window dying)
+//! ends the backend's byte channel, whose closure the forwarder task sees, and it then removes
+//! its own map entry. Each fresh stream (a first watcher creating a new entry) gets a
+//! globally-unique `generation`, and the forwarder drops its entry ONLY if the entry's
+//! generation still matches the one it was started with; without that, a rapid unwatch→rewatch
+//! of the same window could have the dying forwarder delete the freshly-started entry, leaving
+//! `watched_bytes` pointing at a live window whose entry is gone — it would accept refs and
+//! stream nothing. (The matching fifo-path race is handled inside the tmux backend, which bakes
+//! its own unique tag into every fifo name.)
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::Engine;
-use repomon_core::TmuxRuntime;
+use repomon_core::SessionBackend;
 use repomon_core::model::LaneId;
 use repomon_core::protocol::Notification;
 use tokio::sync::Mutex;
 
 use crate::pubsub::{self, EventTx};
 
-/// One window's single shared pipe-pane and the connections watching it.
+/// One window's single shared byte stream and the connections watching it.
 pub struct WatchEntry {
     /// The lane this window belongs to (so `on:false`-without-window can match a session's watched
     /// windows to a lane by field, not by resolving a default window name).
     pub lane: LaneId,
-    /// The fifo tmux's `cat` writes into and the reader thread drains.
-    pub fifo: PathBuf,
-    /// Connection ids sharing this window's single pipe. The pipe stops when this empties.
+    /// Connection ids sharing this window's single stream. The stream stops when this empties.
     pub refs: HashSet<u64>,
-    /// Globally-unique tag for THIS pipe instance; guards EOF cleanup against a stop→restart race
-    /// (see the module doc).
+    /// Globally-unique tag for THIS stream instance; guards EOF cleanup against a stop→restart
+    /// race (see the module doc).
     pub generation: u64,
 }
 
-/// The registry of live byte watches, keyed by window. `Arc<Mutex<…>>` so an EOF reader thread can
-/// hold its own handle and remove its entry via `blocking_lock` when the pipe closes.
+/// The registry of live byte watches, keyed by window. `Arc<Mutex<…>>` so the forwarder task can
+/// hold its own handle and remove its entry when the stream closes.
 pub type Watches = Arc<Mutex<HashMap<String, WatchEntry>>>;
 
-/// Largest chunk broadcast per event — keeps single events bounded while a busy pane floods.
-const CHUNK: usize = 16 * 1024;
-
-/// Hands out a fresh generation to every new pipe instance. Global and monotonic: uniqueness
+/// Hands out a fresh generation to every new stream instance. Global and monotonic: uniqueness
 /// across all windows is all the EOF guard needs.
 static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
 
-/// Release `conn_id` from an entry's readership; returns true once no watcher remains (the pipe
+/// Release `conn_id` from an entry's readership; returns true once no watcher remains (the stream
 /// must then be torn down). Pure — the refcount transition unit tests drive this directly.
 ///
 /// An entry always holds at least one ref (it is created with one and removed the moment it
@@ -82,19 +70,19 @@ fn release_ref(entry: &mut WatchEntry, conn_id: u64) -> bool {
     entry.refs.is_empty()
 }
 
-/// Whether the reader that started at `generation` still owns `window`'s entry — the EOF-cleanup
-/// guard. False if the entry is gone or has been superseded by a newer pipe. Pure.
+/// Whether the forwarder that started at `generation` still owns `window`'s entry — the
+/// EOF-cleanup guard. False if the entry is gone or has been superseded by a newer stream. Pure.
 fn eof_entry_is_current(map: &HashMap<String, WatchEntry>, window: &str, generation: u64) -> bool {
     map.get(window).is_some_and(|e| e.generation == generation)
 }
 
 /// Start (or join) a byte watch on `window` for `conn_id`.
 ///
-/// - Entry exists → the pipe is already flowing; `conn_id` just joins the readership.
-/// - No entry → create the window's single pipe (remove any stale fifo, mkfifo, reader-first
-///   rendezvous, then `pipe-pane`) with a fresh generation and `refs = {conn_id}`.
+/// - Entry exists → the stream is already flowing; `conn_id` just joins the readership.
+/// - No entry → open the window's single backend byte stream with a fresh generation and
+///   `refs = {conn_id}`, and spawn the forwarder that broadcasts its chunks.
 pub async fn watch(
-    tmux: TmuxRuntime,
+    backend: Arc<dyn SessionBackend>,
     events: EventTx,
     watches: &Watches,
     lane: LaneId,
@@ -102,7 +90,8 @@ pub async fn watch(
     conn_id: u64,
 ) -> Result<(), String> {
     // Hold the lock across setup: a concurrent watcher of the SAME window must either join the
-    // entry we create or wait and find it — never start a second pipe (tmux allows only one).
+    // entry we create or wait and find it — never start a second stream (the backend allows only
+    // one per window).
     let mut map = watches.lock().await;
     if let Some(entry) = map.get_mut(&window) {
         entry.refs.insert(conn_id);
@@ -110,145 +99,107 @@ pub async fn watch(
     }
 
     let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
-    // The generation is part of the fifo NAME: pipe instances of the same window never collide on
-    // a path, so a superseded reader's EOF unlink can only ever remove its own fifo (see the
-    // module doc). The pre-mkfifo unlink still guards the one same-path case left — a leftover
-    // fifo from a previous daemon run (the counter restarts at 0).
-    let fifo = std::env::temp_dir().join(format!(
-        "repomon-bytes-{}-{window}-{generation}.fifo",
-        tmux.session()
-    ));
-    let _ = std::fs::remove_file(&fifo);
-    let ok = Command::new("mkfifo")
-        .arg(&fifo)
-        .output()
-        .map_err(|e| format!("mkfifo: {e}"))?
-        .status
-        .success();
-    if !ok {
-        return Err(format!("mkfifo {} failed", fifo.display()));
-    }
+    let stream = {
+        let backend = backend.clone();
+        let window = window.clone();
+        tokio::task::spawn_blocking(move || backend.open_byte_stream(&window))
+            .await
+            .map_err(|e| e.to_string())
+            .and_then(|r| r.map_err(|e| e.to_string()))?
+    };
 
     map.insert(
         window.clone(),
         WatchEntry {
             lane,
-            fifo: fifo.clone(),
             refs: HashSet::from([conn_id]),
             generation,
         },
     );
 
-    // Reader first: its open() is the rendezvous with cat's write-side open. On EOF it removes its
-    // fifo (safe unconditionally: the generation-unique name means it can only be its own, never a
-    // successor's) and drops its own entry, the latter only while the entry is still this pipe's
-    // (generation match) — a later watch of the same window supersedes it.
+    // The forwarder: drain the backend's chunks onto the event bus. When the channel closes
+    // (stream turned off or window died) it drops its own entry, but only while the entry is
+    // still this stream's (generation match) — a later watch of the same window supersedes it.
     {
         let window = window.clone();
-        let fifo = fifo.clone();
         let watches = watches.clone();
-        tokio::task::spawn_blocking(move || {
-            use std::io::Read;
-            let Ok(mut f) = std::fs::File::open(&fifo) else {
-                return;
-            };
-            let mut buf = vec![0u8; CHUNK];
-            loop {
-                match f.read(&mut buf) {
-                    Ok(0) | Err(_) => break, // EOF: pipe turned off or window died
-                    Ok(n) => {
-                        let data = base64::engine::general_purpose::STANDARD.encode(&buf[..n]);
-                        let note = Notification::new(
-                            pubsub::topic::AGENT_BYTES,
-                            serde_json::json!({
-                                "lane_id": lane,
-                                "window": window,
-                                "data": data,
-                            }),
-                        );
-                        if let Ok(value) = serde_json::to_value(&note) {
-                            let _ = events.send(value); // Err = no subscribers; fine
-                        }
-                    }
+        tokio::spawn(async move {
+            let mut rx = stream.rx;
+            while let Some(chunk) = rx.recv().await {
+                let data = base64::engine::general_purpose::STANDARD.encode(&chunk);
+                let note = Notification::new(
+                    pubsub::topic::AGENT_BYTES,
+                    serde_json::json!({
+                        "lane_id": lane,
+                        "window": window,
+                        "data": data,
+                    }),
+                );
+                if let Ok(value) = serde_json::to_value(&note) {
+                    let _ = events.send(value); // Err = no subscribers; fine
                 }
             }
-            let _ = std::fs::remove_file(&fifo);
-            let mut map = watches.blocking_lock();
+            let mut map = watches.lock().await;
             if eof_entry_is_current(&map, &window, generation) {
                 map.remove(&window);
             }
         });
     }
-
-    let t = tmux.clone();
-    let win = window.clone();
-    let fifo_w = fifo.clone();
-    let started = tokio::task::spawn_blocking(move || t.pipe_pane_named(&win, &fifo_w))
-        .await
-        .map_err(|e| e.to_string())
-        .and_then(|r| r.map_err(|e| e.to_string()));
-    if let Err(e) = started {
-        // The pipe never started: drop the entry so it can't accept refs and stream nothing, and
-        // remove the fifo (the reader, still blocked on open(), is a pre-existing leak parity —
-        // no `cat` ever opens the write side, same as the old single-slot `start`).
-        map.remove(&window);
-        let _ = std::fs::remove_file(&fifo);
-        return Err(e);
-    }
     Ok(())
 }
 
-/// Release `conn_id` from `window`'s watch. When the last watcher leaves, turn the pane's pipe off
-/// (EOFing the reader) and remove the fifo and entry. Idempotent: releasing an unwatched window,
-/// or a conn that wasn't a watcher, is a no-op.
-pub async fn unwatch(tmux: &TmuxRuntime, watches: &Watches, window: &str, conn_id: u64) {
+/// Release `conn_id` from `window`'s watch. When the last watcher leaves, close the window's
+/// stream (which EOFs the forwarder) and remove the entry. Idempotent: releasing an unwatched
+/// window, or a conn that wasn't a watcher, is a no-op.
+pub async fn unwatch(
+    backend: &Arc<dyn SessionBackend>,
+    watches: &Watches,
+    window: &str,
+    conn_id: u64,
+) {
     let mut map = watches.lock().await;
     let Some(entry) = map.get_mut(window) else {
         return;
     };
     if !release_ref(entry, conn_id) {
-        return; // other connections still share this window's pipe
+        return; // other connections still share this window's stream
     }
-    let entry = map
-        .remove(window)
+    map.remove(window)
         .expect("entry present under the same lock");
     drop(map);
-    let t = tmux.clone();
+    let backend = backend.clone();
     let win = window.to_string();
-    let _ = tokio::task::spawn_blocking(move || t.pipe_pane_off_named(&win)).await;
-    let _ = std::fs::remove_file(&entry.fifo);
+    let _ = tokio::task::spawn_blocking(move || backend.close_byte_stream(&win)).await;
 }
 
-/// Release `conn_id` from EVERY window it watches, stopping the pipes that thereby empty. Called
+/// Release `conn_id` from EVERY window it watches, closing the streams that thereby empty. Called
 /// from `Ctx::close_session` so a connection's byte watches die with it, whatever it was watching.
-pub async fn unwatch_all(tmux: &TmuxRuntime, watches: &Watches, conn_id: u64) {
-    let mut stopped: Vec<(String, PathBuf)> = Vec::new();
+pub async fn unwatch_all(backend: &Arc<dyn SessionBackend>, watches: &Watches, conn_id: u64) {
+    let mut stopped: Vec<String> = Vec::new();
     {
         let mut map = watches.lock().await;
         map.retain(|window, entry| {
             if release_ref(entry, conn_id) {
-                stopped.push((window.clone(), entry.fifo.clone()));
+                stopped.push(window.clone());
                 false // this window's last watcher left: drop the entry
             } else {
                 true
             }
         });
     }
-    for (window, fifo) in stopped {
-        let t = tmux.clone();
-        let win = window.clone();
-        let _ = tokio::task::spawn_blocking(move || t.pipe_pane_off_named(&win)).await;
-        let _ = std::fs::remove_file(&fifo);
+    for window in stopped {
+        let backend = backend.clone();
+        let _ = tokio::task::spawn_blocking(move || backend.close_byte_stream(&window)).await;
     }
 }
 
-/// Startup sweep: turn `pipe-pane` off on every window of our session. A daemon that died with
-/// a watch active leaves a `cat` blocked on a fifo nobody reads — tmux would buffer that
-/// pane's output in memory without bound.
-pub async fn sweep(tmux: TmuxRuntime) {
+/// Startup sweep: close the byte stream on every window of our session. A daemon that died with
+/// a watch active leaves the backend's pipe running with no reader — on tmux that makes the
+/// server buffer the pane's output in memory without bound.
+pub async fn sweep(backend: Arc<dyn SessionBackend>) {
     let _ = tokio::task::spawn_blocking(move || {
-        for w in tmux.list_windows().unwrap_or_default() {
-            let _ = tmux.pipe_pane_off_named(&w);
+        for w in backend.list_windows().unwrap_or_default() {
+            let _ = backend.close_byte_stream(&w);
         }
     })
     .await;
@@ -261,7 +212,6 @@ mod tests {
     fn entry(refs: &[u64], generation: u64) -> WatchEntry {
         WatchEntry {
             lane: 1,
-            fifo: PathBuf::from("/tmp/none.fifo"),
             refs: refs.iter().copied().collect(),
             generation,
         }
@@ -270,10 +220,10 @@ mod tests {
     #[test]
     fn release_ref_reports_empty_only_when_last_watcher_leaves() {
         let mut e = entry(&[1, 2], 0);
-        // Removing one of two watchers leaves the pipe live.
+        // Removing one of two watchers leaves the stream live.
         assert!(!release_ref(&mut e, 1));
         assert_eq!(e.refs.iter().copied().collect::<Vec<_>>(), vec![2]);
-        // Removing the last watcher empties it — the caller must stop the pipe.
+        // Removing the last watcher empties it — the caller must stop the stream.
         assert!(release_ref(&mut e, 2));
         assert!(e.refs.is_empty());
     }
@@ -287,12 +237,12 @@ mod tests {
     }
 
     #[test]
-    fn joining_watcher_shares_the_single_pipe() {
+    fn joining_watcher_shares_the_single_stream() {
         // Modelling `watch`'s "entry exists" branch: a second conn just joins the readership.
         let mut e = entry(&[1], 5);
         e.refs.insert(2);
         assert_eq!(e.refs.len(), 2);
-        // The generation is untouched — the same pipe, not a new one.
+        // The generation is untouched — the same stream, not a new one.
         assert_eq!(e.generation, 5);
     }
 
@@ -300,9 +250,9 @@ mod tests {
     fn eof_guard_removes_only_the_current_generation() {
         let mut map = HashMap::new();
         map.insert("lane-1".to_string(), entry(&[1], 3));
-        // A reader from the current pipe (gen 3) owns the entry.
+        // A forwarder from the current stream (gen 3) owns the entry.
         assert!(eof_entry_is_current(&map, "lane-1", 3));
-        // A stale reader (gen 2) from a superseded pipe must NOT delete the live entry.
+        // A stale forwarder (gen 2) from a superseded stream must NOT delete the live entry.
         assert!(!eof_entry_is_current(&map, "lane-1", 2));
         // A window with no entry at all.
         assert!(!eof_entry_is_current(&map, "lane-9", 3));

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -22,9 +22,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use repomon_core::agent::backend::{CaptureOpts, SessionBackend};
 use repomon_core::model::{Lane, LaneId};
 use repomon_core::protocol::Notification;
-use repomon_core::agent::backend::{CaptureOpts, SessionBackend};
 use repomon_core::{Config, Lanes, Registry, Store, TmuxRuntime, Watcher, config};
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock, broadcast};
@@ -269,7 +269,8 @@ impl Ctx {
     ) -> Arc<Self> {
         let registry = Registry::new(store.clone());
         let lanes = Lanes::new(store.clone(), config.clone());
-        let backend: Arc<dyn SessionBackend> = Arc::new(TmuxRuntime::new(config.tmux_session.clone()));
+        let backend: Arc<dyn SessionBackend> =
+            Arc::new(TmuxRuntime::new(config.tmux_session.clone()));
         // Make any already-running session attach-native (mouse, clipboard, deep scrollback);
         // spawns reapply it, but an existing tmux server outlives a daemon restart.
         if backend.session_exists() {
@@ -542,9 +543,9 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
             })
             .await
             {
-                    Ok(Ok(c)) => c,
-                    _ => continue,
-                };
+                Ok(Ok(c)) => c,
+                _ => continue,
+            };
             // Only the focused pane carries a cursor (the TUI renders it where you're typing) — one
             // extra tmux fork on a single pane, never on background/Grid tiles.
             let cursor = if is_focused {

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -24,6 +24,7 @@ use std::time::Instant;
 
 use repomon_core::model::{Lane, LaneId};
 use repomon_core::protocol::Notification;
+use repomon_core::agent::backend::{CaptureOpts, SessionBackend};
 use repomon_core::{Config, Lanes, Registry, Store, TmuxRuntime, Watcher, config};
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock, broadcast};
@@ -133,7 +134,7 @@ pub struct Ctx {
     pub config: RwLock<Config>,
     /// Where [`Config::save`] writes — `config::config_path()` in prod, a tempdir in tests.
     pub config_path: PathBuf,
-    pub tmux: TmuxRuntime,
+    pub backend: Arc<dyn SessionBackend>,
     pub started: Instant,
     pub db_path: Option<PathBuf>,
     pub events: pubsub::EventTx,
@@ -268,11 +269,11 @@ impl Ctx {
     ) -> Arc<Self> {
         let registry = Registry::new(store.clone());
         let lanes = Lanes::new(store.clone(), config.clone());
-        let tmux = TmuxRuntime::new(config.tmux_session.clone());
+        let backend: Arc<dyn SessionBackend> = Arc::new(TmuxRuntime::new(config.tmux_session.clone()));
         // Make any already-running session attach-native (mouse, clipboard, deep scrollback);
         // spawns reapply it, but an existing tmux server outlives a daemon restart.
-        if tmux.session_exists() {
-            tmux.configure();
+        if backend.session_exists() {
+            backend.configure();
         }
         let (events, _rx) = broadcast::channel(512);
         Arc::new(Ctx {
@@ -281,7 +282,7 @@ impl Ctx {
             lanes,
             config: RwLock::new(config),
             config_path,
-            tmux,
+            backend,
             started: Instant::now(),
             db_path,
             events,
@@ -342,7 +343,7 @@ impl Ctx {
         // the shared byte-stream registry (stopping the pipes no other connection still watches).
         // Keyed by connection id, so it cleans up whatever the session was watching without relying
         // on `watched_bytes` being in sync.
-        crate::bytes_stream::unwatch_all(&self.tmux, &self.bytes_watches, id).await;
+        crate::bytes_stream::unwatch_all(&self.backend, &self.bytes_watches, id).await;
     }
 
     /// Union of every live session's stream targets, plus the set of windows any fresh-beat session
@@ -534,22 +535,26 @@ pub async fn stream_output(ctx: Arc<Ctx>) {
                 break;
             }
             budget -= 1;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let w = window.clone();
-            let content =
-                match tokio::task::spawn_blocking(move || tmux.capture_named(&w, None)).await {
+            let content = match tokio::task::spawn_blocking(move || {
+                tmux.capture_named(&w, CaptureOpts::visible())
+            })
+            .await
+            {
                     Ok(Ok(c)) => c,
                     _ => continue,
                 };
             // Only the focused pane carries a cursor (the TUI renders it where you're typing) — one
             // extra tmux fork on a single pane, never on background/Grid tiles.
             let cursor = if is_focused {
-                let tmux = ctx.tmux.clone();
+                let tmux = ctx.backend.clone();
                 let cw = window.clone();
                 tokio::task::spawn_blocking(move || tmux.cursor_named(&cw))
                     .await
                     .ok()
                     .flatten()
+                    .map(|c| (c.col, c.row))
             } else {
                 None
             };
@@ -662,9 +667,9 @@ pub async fn stream_orchestrator(ctx: Arc<Ctx>) {
             continue;
         }
         last_cap = now;
-        let tmux = ctx.tmux.clone();
+        let tmux = ctx.backend.clone();
         let content = match tokio::task::spawn_blocking(move || {
-            tmux.capture_named(ORCHESTRATOR_WINDOW, None)
+            tmux.capture_named(ORCHESTRATOR_WINDOW, CaptureOpts::visible())
         })
         .await
         {
@@ -673,11 +678,12 @@ pub async fn stream_orchestrator(ctx: Arc<Ctx>) {
         };
         // Carry repomind's real cursor so the mediated pane draws it where you're typing (mirrors
         // the focused-lane path in `stream_output`). One extra tmux fork on the single pane.
-        let tmux = ctx.tmux.clone();
+        let tmux = ctx.backend.clone();
         let cursor = tokio::task::spawn_blocking(move || tmux.cursor_named(ORCHESTRATOR_WINDOW))
             .await
             .ok()
-            .flatten();
+            .flatten()
+            .map(|c| (c.col, c.row));
         // Re-push on a cursor-only move (arrowing within repomind's input box) so the rendered cursor
         // tracks even when the text is unchanged. Reset to the floor on any change; otherwise double
         // the (clamped) interval toward the cap so a settled pane stops being re-captured.

--- a/crates/repomon-daemon/src/main.rs
+++ b/crates/repomon-daemon/src/main.rs
@@ -133,7 +133,7 @@ async fn main() {
 
     // Sweep stale pipe-panes from a previous daemon: a watch left on with no reader would make
     // tmux buffer that pane's output in memory without bound.
-    tokio::spawn(repomon_daemon::bytes_stream::sweep(ctx.tmux.clone()));
+    tokio::spawn(repomon_daemon::bytes_stream::sweep(ctx.backend.clone()));
 
     // Stream the repomind orchestrator's pane to a watching command-center view (self-gates on a
     // running session + a watcher, so it's free until the orchestrator is opened).

--- a/crates/repomon-daemon/src/notify_watch.rs
+++ b/crates/repomon-daemon/src/notify_watch.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use repomon_core::Config;
 use repomon_core::agent;
+use repomon_core::agent::backend::CaptureOpts;
 use repomon_core::model::{AgentStatus, LaneId};
 use repomon_core::notify::{
     NotifKind, SessKey, SessState, activity_allows_refire, compose, diff_session_transitions,
@@ -317,9 +318,9 @@ async fn check_orchestrator_attention(
             // leak an end_of_turn into this one.
             *transcript_cache = None;
         }
-        let tmux = ctx.tmux.clone();
+        let tmux = ctx.backend.clone();
         let pane = tokio::task::spawn_blocking(move || {
-            tmux.capture_named(ORCHESTRATOR_WINDOW, Some(ORCH_CAPTURE_LINES))
+            tmux.capture_named(ORCHESTRATOR_WINDOW, CaptureOpts::last(ORCH_CAPTURE_LINES))
         })
         .await
         .ok()

--- a/crates/repomon-daemon/src/reap.rs
+++ b/crates/repomon-daemon/src/reap.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use repomon_core::agent::backend::OwnerState;
 use repomon_core::agent::tmux::TmuxRuntime;
 use repomon_core::model::LaneId;
 
@@ -90,7 +91,7 @@ fn canonical(p: &Path) -> PathBuf {
 /// worktree) and `rpc::agent.stop` (killing a live one on request) — same window-death
 /// bookkeeping either way, so a stopped agent's session can never be read back as still live.
 pub(crate) async fn kill_and_forget(ctx: &Ctx, window: &str) {
-    let tmux = ctx.tmux.clone();
+    let tmux = ctx.backend.clone();
     let w = window.to_string();
     let _ = tokio::task::spawn_blocking(move || tmux.kill_named(&w)).await;
     ctx.last_good_windows.lock().await.retain(|w| w != window);
@@ -109,7 +110,7 @@ pub async fn reap_orphan_windows(ctx: &Ctx) {
         .map(|l| (l.id, canonical(&l.worktree.path)))
         .collect();
 
-    let tmux = ctx.tmux.clone();
+    let tmux = ctx.backend.clone();
     let raw = match tokio::task::spawn_blocking(move || tmux.list_windows_with_activity()).await {
         Ok(Ok(w)) => w,
         _ => return,
@@ -117,10 +118,10 @@ pub async fn reap_orphan_windows(ctx: &Ctx) {
     let now = chrono::Utc::now().timestamp();
     let windows: Vec<Win> = raw
         .into_iter()
-        .map(|(name, cwd, activity)| Win {
-            name,
-            cwd: canonical(&cwd),
-            active: now.saturating_sub(activity) < RUNNING_GRACE.as_secs() as i64,
+        .map(|w| Win {
+            name: w.name,
+            cwd: canonical(&w.cwd),
+            active: now.saturating_sub(w.last_activity) < RUNNING_GRACE.as_secs() as i64,
         })
         .collect();
 
@@ -137,10 +138,11 @@ pub async fn reap_orphan_windows(ctx: &Ctx) {
     // sessions bug). The owner token is this daemon's db path: stable across restarts (so the real
     // daemon reclaims its own stamp) and distinct per instance (so a stray never matches).
     let me = owner_token(ctx);
-    let tmux_g = ctx.tmux.clone();
+    let tmux_g = ctx.backend.clone();
     let me_g = me.clone();
     let owns = tokio::task::spawn_blocking(move || tmux_g.claim_or_verify_owner(&me_g))
         .await
+        .map(|state| state == OwnerState::Owned)
         .unwrap_or(false);
 
     let orphans = orphan_lane_windows(&windows, &lane_paths);
@@ -151,7 +153,7 @@ pub async fn reap_orphan_windows(ctx: &Ctx) {
         tracing::warn!(
             ?orphans,
             owner = %me,
-            session = ctx.tmux.session(),
+            session = %ctx.backend.label(),
             "another repomond owns this tmux server; skipping reap (would kill its windows)"
         );
         return;

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -10,6 +10,7 @@ use repomon_core::model::{
     CreateLaneParams, Lane, RemoteDevice, RepoId, TimeRange,
 };
 use repomon_core::protocol::RpcError;
+use repomon_core::agent::backend::{CaptureOpts, SpawnSpec};
 use repomon_core::{Indexer, TmuxRuntime, analytics, session};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -999,7 +1000,7 @@ pub async fn dispatch(
             let path = ctx.lanes.focus(p.lane_id).await.map_err(internal)?;
             // Resolve the chosen name to a command: a config custom wins, then an autodetected
             // Claude variant (e.g. claude-work → `CLAUDE_CONFIG_DIR=… claude`), else the kind.
-            let mut command = {
+            let command = {
                 let cfg = ctx.config.read().await;
                 if let Some(c) = cfg.agents.get(&p.agent) {
                     c.clone()
@@ -1012,12 +1013,13 @@ pub async fn dispatch(
                     AgentKind::from_kind_str(&p.agent).command().to_string()
                 }
             };
+            let mut spec = SpawnSpec::new(command, path);
             if let Some(task) = p.task.as_deref().filter(|t| !t.is_empty()) {
-                command = format!("{command} {}", shell_quote(task));
+                spec = spec.arg(task);
             }
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let lane = p.lane_id;
-            let window = tokio::task::spawn_blocking(move || tmux.spawn(lane, &path, &command))
+            let window = tokio::task::spawn_blocking(move || tmux.spawn(lane, &spec))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
@@ -1055,29 +1057,33 @@ pub async fn dispatch(
                     return Err(RpcError::invalid_params("invalid session_id"));
                 }
             }
-            let detect = path.clone();
             let session_id = p.session_id.clone();
-            let command = tokio::task::spawn_blocking(move || {
+            let spec = tokio::task::spawn_blocking(move || {
                 // Which account (config dir) the session belongs to, and how to resume it.
                 let (config_dir, resume) = match &session_id {
                     Some(sid) => (
-                        agent::claude::config_base_for_session(&detect, sid).flatten(),
-                        // Validated above; quote anyway as defense-in-depth.
-                        format!("--resume {}", agent::tmux::shell_quote(sid)),
+                        agent::claude::config_base_for_session(&path, sid).flatten(),
+                        // Validated above; the backend quotes args as defense-in-depth anyway.
+                        vec!["--resume".to_string(), sid.clone()],
                     ),
                     None => (
-                        agent::claude::summary_for(&detect).and_then(|s| s.config_dir),
-                        "--continue".to_string(),
+                        agent::claude::summary_for(&path).and_then(|s| s.config_dir),
+                        vec!["--continue".to_string()],
                     ),
                 };
                 let base = adopt_base_command(&default_agent, &customs, &config_dir);
-                format!("{base} {resume}")
+                SpawnSpec {
+                    program: base,
+                    args: resume,
+                    cwd: path,
+                    env: Vec::new(),
+                }
             })
             .await
             .map_err(internal)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let lane = p.lane_id;
-            let window = tokio::task::spawn_blocking(move || tmux.spawn(lane, &path, &command))
+            let window = tokio::task::spawn_blocking(move || tmux.spawn(lane, &spec))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
@@ -1098,12 +1104,12 @@ pub async fn dispatch(
         }
         "agent.capture" => {
             let p: AgentCapture = parse(params)?;
-            let tmux = ctx.tmux.clone();
-            let lines = p.lines;
+            let tmux = ctx.backend.clone();
+            let opts = CaptureOpts { last_lines: p.lines };
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
-            let content = tokio::task::spawn_blocking(move || tmux.capture_named(&window, lines))
+            let content = tokio::task::spawn_blocking(move || tmux.capture_named(&window, opts))
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
@@ -1111,7 +1117,7 @@ pub async fn dispatch(
         }
         "agent.send_input" => {
             let p: AgentInput = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let (lane, text, enter) = (p.lane_id, p.text, p.enter);
             let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             let win = window.clone();
@@ -1130,7 +1136,7 @@ pub async fn dispatch(
         }
         "agent.signal" => {
             let p: AgentSignal = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let (lane, key) = (p.lane_id, p.key);
             let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             let win = window.clone();
@@ -1143,7 +1149,7 @@ pub async fn dispatch(
         }
         "agent.key" => {
             let p: AgentKey = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let (lane, key, literal) = (p.lane_id, p.key, p.literal);
             let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             let win = window.clone();
@@ -1173,7 +1179,7 @@ pub async fn dispatch(
                     .clone()
                     .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
                 crate::bytes_stream::watch(
-                    ctx.tmux.clone(),
+                    ctx.backend.clone(),
                     ctx.events.clone(),
                     &ctx.bytes_watches,
                     p.lane_id,
@@ -1186,7 +1192,7 @@ pub async fn dispatch(
                 // The ack carries the pane's grid so a remote emulator renders at exactly
                 // this size instead of resizing the real pane (which would squeeze a
                 // simultaneously attached TUI's mediated view). Shape UNCHANGED (iOS depends on it).
-                let tmux = ctx.tmux.clone();
+                let tmux = ctx.backend.clone();
                 let dims = tokio::task::spawn_blocking(move || tmux.size_named(&window))
                     .await
                     .map_err(internal)?;
@@ -1220,21 +1226,21 @@ pub async fn dispatch(
                 }
             };
             for window in targets {
-                crate::bytes_stream::unwatch(&ctx.tmux, &ctx.bytes_watches, &window, sess.id).await;
+                crate::bytes_stream::unwatch(&ctx.backend, &ctx.bytes_watches, &window, sess.id).await;
                 sess.watched_bytes.lock().unwrap().remove(&window);
             }
             Ok(Value::Null)
         }
         "agent.prompt" => {
             let p: AgentPrompt = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
             let win = window.clone();
             // A fresh capture, not the sniff cache: the popup must show what's on the pane NOW.
             let dialog = tokio::task::spawn_blocking(move || {
-                tmux.capture_named(&win, Some(45))
+                tmux.capture_named(&win, CaptureOpts::last(45))
                     .map(|pane| agent::prompt::detect_dialog(&pane))
             })
             .await
@@ -1248,7 +1254,7 @@ pub async fn dispatch(
         }
         "agent.answer" => {
             let p: AgentAnswer = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
@@ -1258,7 +1264,7 @@ pub async fn dispatch(
             let cap_tmux = tmux.clone();
             let dialog = tokio::task::spawn_blocking(move || {
                 cap_tmux
-                    .capture_named(&win, Some(45))
+                    .capture_named(&win, CaptureOpts::last(45))
                     .map(|pane| agent::prompt::detect_dialog(&pane))
             })
             .await
@@ -1323,7 +1329,7 @@ pub async fn dispatch(
             // read this agent back as still live while waiting out `resolve_windows`'s
             // total-vanish debounce. See `reap::kill_and_forget`.
             crate::reap::kill_and_forget(ctx, &window).await;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let remaining = tokio::task::spawn_blocking(move || {
                 tmux.windows_for(lane).unwrap_or_default().len()
             })
@@ -1348,7 +1354,7 @@ pub async fn dispatch(
         }
         "agent.target" => {
             let p: AgentTarget = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
@@ -1363,12 +1369,12 @@ pub async fn dispatch(
             })
             .await
             .map_err(internal)?;
-            let target = format!("{}:={}", ctx.tmux.session(), window);
+            let target = ctx.backend.exact_target_named(&window);
             Ok(json!({ "target": target, "available": available }))
         }
         "agent.resize" => {
             let p: AgentResize = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
@@ -1395,7 +1401,7 @@ pub async fn dispatch(
             let others = other_session_snapshots(ctx, sess.id).await;
             let allowed = fit_allowed(&caller, &others, &window, now);
             if !allowed {
-                let tmux = ctx.tmux.clone();
+                let tmux = ctx.backend.clone();
                 let w = window.clone();
                 let dims = tokio::task::spawn_blocking(move || tmux.size_named(&w))
                     .await
@@ -1407,7 +1413,7 @@ pub async fn dispatch(
                 }));
             }
             let (cols, rows) = (p.cols.max(20), p.rows.max(4));
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let w = window.clone();
             tokio::task::spawn_blocking(move || tmux.resize_named(&w, cols, rows))
                 .await
@@ -1420,7 +1426,7 @@ pub async fn dispatch(
         }
         "agent.scroll" => {
             let p: AgentScroll = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let lane = p.lane_id;
             let window = p.window.unwrap_or_else(|| TmuxRuntime::window_name(lane));
             let (up, ticks) = (p.up, p.ticks.min(40));
@@ -1476,7 +1482,7 @@ pub async fn dispatch(
             let p: LaneId = parse(params)?;
             let path = ctx.lanes.focus(p.lane_id).await.map_err(internal)?;
             let prefix = format!("term-{}-", p.lane_id);
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             // Next free sequence for this lane's terminals.
             let existing = {
                 let t = tmux.clone();
@@ -1504,7 +1510,7 @@ pub async fn dispatch(
         "terminal.list" => {
             let p: LaneId = parse(params)?;
             let prefix = format!("term-{}-", p.lane_id);
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let wins = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
                 .await
                 .map_err(internal)?;
@@ -1518,7 +1524,7 @@ pub async fn dispatch(
         "terminal.list_all" => {
             // Every lane's open plain terminals — what the Grid tiles. Fleet-wide (unlike
             // `terminal.list`) so one call covers every visible lane.
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let wins = tokio::task::spawn_blocking(move || tmux.list_windows().unwrap_or_default())
                 .await
                 .map_err(internal)?;
@@ -1539,19 +1545,19 @@ pub async fn dispatch(
         }
         "terminal.close" => {
             let p: TerminalId = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let id = p.id;
             let _ = tokio::task::spawn_blocking(move || tmux.kill_named(&id)).await;
             Ok(Value::Null)
         }
         "terminal.target" => {
             let p: TerminalId = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let id = p.id.clone();
             let available = tokio::task::spawn_blocking(move || tmux.has_named(&id))
                 .await
                 .map_err(internal)?;
-            Ok(json!({ "target": ctx.tmux.target_named(&p.id), "available": available }))
+            Ok(json!({ "target": ctx.backend.target_named(&p.id), "available": available }))
         }
 
         // ---- interactive repo browser ----
@@ -1843,7 +1849,7 @@ pub async fn dispatch(
             // A window may survive a daemon restart (tmux outlives us). Adopt it instead of
             // spawning a duplicate `orchestrator` window.
             {
-                let tmux = ctx.tmux.clone();
+                let tmux = ctx.backend.clone();
                 let exists =
                     tokio::task::spawn_blocking(move || tmux.has_named(ORCHESTRATOR_WINDOW))
                         .await
@@ -1912,13 +1918,12 @@ pub async fn dispatch(
             let home = std::env::var("HOME")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| PathBuf::from("/"));
-            let tmux = ctx.tmux.clone();
-            tokio::task::spawn_blocking(move || {
-                tmux.spawn_named(ORCHESTRATOR_WINDOW, &home, &command)
-            })
-            .await
-            .map_err(internal)?
-            .map_err(internal)?;
+            let spec = SpawnSpec::new(command, home);
+            let tmux = ctx.backend.clone();
+            tokio::task::spawn_blocking(move || tmux.spawn_named(ORCHESTRATOR_WINDOW, &spec))
+                .await
+                .map_err(internal)?
+                .map_err(internal)?;
             let session = crate::OrchestratorSession {
                 agent,
                 model,
@@ -1939,7 +1944,7 @@ pub async fn dispatch(
             // first against nothing, or kills the fully-recorded window — never a window that a
             // mid-flight start is about to record (which would leave an untracked orphan running).
             let mut orch = ctx.orchestrator.lock().await;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let _ = tokio::task::spawn_blocking(move || tmux.kill_named(ORCHESTRATOR_WINDOW)).await;
             // Unlike `agent.stop` (see `reap::kill_and_forget`), no cache reconciliation is needed
             // after this kill: `prompt_cache` only ever holds lane-window sniffs (`overlay_agents`
@@ -1960,7 +1965,7 @@ pub async fn dispatch(
         "orchestrator.target" => {
             // Clear + broadcast stopped if the window died, so a stale "running" can't linger.
             reconcile_orchestrator(ctx).await;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             // Restore client-follow sizing before the attaching terminal renders it (mirrors
             // `agent.target`).
             let available = tokio::task::spawn_blocking(move || {
@@ -1969,7 +1974,7 @@ pub async fn dispatch(
             })
             .await
             .map_err(internal)?;
-            let target = format!("{}:={}", ctx.tmux.session(), ORCHESTRATOR_WINDOW);
+            let target = ctx.backend.exact_target_named(ORCHESTRATOR_WINDOW);
             Ok(json!({ "target": target, "available": available }))
         }
         "orchestrator.send_input" => {
@@ -1981,7 +1986,7 @@ pub async fn dispatch(
                     "repomind isn't running — start it from the command-center or 'repomon orchestrate'",
                 ));
             }
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let (text, enter) = (p.text, p.enter);
             tokio::task::spawn_blocking(move || {
                 if enter {
@@ -2007,7 +2012,7 @@ pub async fn dispatch(
                     "repomind isn't running — start it from the command-center or 'repomon orchestrate'",
                 ));
             }
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let (key, literal) = (p.key, p.literal);
             tokio::task::spawn_blocking(move || {
                 if literal {
@@ -2035,7 +2040,7 @@ pub async fn dispatch(
         // `agent.resize`; `orchestrator.target` restores client-follow before a real attach.
         "orchestrator.resize" => {
             let p: OrchestratorResize = parse(params)?;
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             // Clamp to a sane floor so a momentary tiny layout can't shrink the window to nothing.
             let (cols, rows) = (p.cols.max(20), p.rows.max(4));
             tokio::task::spawn_blocking(move || tmux.resize_named(ORCHESTRATOR_WINDOW, cols, rows))
@@ -2140,7 +2145,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let metas = ctx.store.list_lane_meta().await.unwrap_or_default();
     // User-set session labels (keyed by transcript session_id), overlaid below.
     let labels = ctx.store.list_session_labels().await.unwrap_or_default();
-    let tmux = ctx.tmux.clone();
+    let tmux = ctx.backend.clone();
     // Distinguish a *failed* probe from a genuinely empty server: on failure reuse the last-good
     // window set for this tick (a transient tmux fork/connection fault must not momentarily drop
     // every managed agent — that flips sessions to `external`, detaches the focused TUI, and fires
@@ -2431,7 +2436,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             }
         }
         if !misses.is_empty() {
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let miss_windows: Vec<String> =
                 misses.iter().map(|&i| candidates[i].2.clone()).collect();
             // Each fresh capture yields the parsed dialog AND a content hash — the hash feeds
@@ -2440,7 +2445,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 tokio::task::spawn_blocking(move || {
                     miss_windows
                         .iter()
-                        .map(|w| match tmux.capture_named(w, Some(45)) {
+                        .map(|w| match tmux.capture_named(w, CaptureOpts::last(45)) {
                             Ok(pane) => {
                                 use std::hash::{Hash, Hasher};
                                 let mut h = std::collections::hash_map::DefaultHasher::new();
@@ -3439,7 +3444,7 @@ pub(crate) async fn reconcile_orchestrator(ctx: &Ctx) -> bool {
     if ctx.orchestrator.lock().await.is_none() {
         return false;
     }
-    let tmux = ctx.tmux.clone();
+    let tmux = ctx.backend.clone();
     // On a probe failure keep the session: don't declare it dead on a transient tmux hiccup.
     let alive = tokio::task::spawn_blocking(move || tmux.has_named(ORCHESTRATOR_WINDOW))
         .await

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use repomon_core::agent::backend::{CaptureOpts, SpawnSpec};
 use repomon_core::agent::{self, shell_quote};
 use repomon_core::git::{diff, reader};
 use repomon_core::model::{
@@ -10,7 +11,6 @@ use repomon_core::model::{
     CreateLaneParams, Lane, RemoteDevice, RepoId, TimeRange,
 };
 use repomon_core::protocol::RpcError;
-use repomon_core::agent::backend::{CaptureOpts, SpawnSpec};
 use repomon_core::{Indexer, TmuxRuntime, analytics, session};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -1105,7 +1105,9 @@ pub async fn dispatch(
         "agent.capture" => {
             let p: AgentCapture = parse(params)?;
             let tmux = ctx.backend.clone();
-            let opts = CaptureOpts { last_lines: p.lines };
+            let opts = CaptureOpts {
+                last_lines: p.lines,
+            };
             let window = p
                 .window
                 .unwrap_or_else(|| TmuxRuntime::window_name(p.lane_id));
@@ -1226,7 +1228,8 @@ pub async fn dispatch(
                 }
             };
             for window in targets {
-                crate::bytes_stream::unwatch(&ctx.backend, &ctx.bytes_watches, &window, sess.id).await;
+                crate::bytes_stream::unwatch(&ctx.backend, &ctx.bytes_watches, &window, sess.id)
+                    .await;
                 sess.watched_bytes.lock().unwrap().remove(&window);
             }
             Ok(Value::Null)

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1370,7 +1370,8 @@ pub async fn dispatch(
             .await
             .map_err(internal)?;
             let target = ctx.backend.exact_target_named(&window);
-            Ok(json!({ "target": target, "available": available }))
+            let attach = attach_json(&*ctx.backend, &target);
+            Ok(json!({ "target": target, "available": available, "attach": attach }))
         }
         "agent.resize" => {
             let p: AgentResize = parse(params)?;
@@ -1505,7 +1506,8 @@ pub async fn dispatch(
                     .map_err(internal)?
                     .map_err(internal)?
             };
-            Ok(json!({ "id": name, "target": target }))
+            let attach = attach_json(&*ctx.backend, &target);
+            Ok(json!({ "id": name, "target": target, "attach": attach }))
         }
         "terminal.list" => {
             let p: LaneId = parse(params)?;
@@ -1557,7 +1559,9 @@ pub async fn dispatch(
             let available = tokio::task::spawn_blocking(move || tmux.has_named(&id))
                 .await
                 .map_err(internal)?;
-            Ok(json!({ "target": ctx.backend.target_named(&p.id), "available": available }))
+            let target = ctx.backend.target_named(&p.id);
+            let attach = attach_json(&*ctx.backend, &target);
+            Ok(json!({ "target": target, "available": available, "attach": attach }))
         }
 
         // ---- interactive repo browser ----
@@ -1975,7 +1979,8 @@ pub async fn dispatch(
             .await
             .map_err(internal)?;
             let target = ctx.backend.exact_target_named(ORCHESTRATOR_WINDOW);
-            Ok(json!({ "target": target, "available": available }))
+            let attach = attach_json(&*ctx.backend, &target);
+            Ok(json!({ "target": target, "available": available, "attach": attach }))
         }
         "orchestrator.send_input" => {
             let p: OrchestratorInput = parse(params)?;
@@ -2052,6 +2057,15 @@ pub async fn dispatch(
 
         other => Err(RpcError::method_not_found(other)),
     }
+}
+
+/// The optional `attach` field of the `agent.target` / `terminal.target` /
+/// `orchestrator.target` responses: the exact command a client should run in a real terminal
+/// to attach to `target`, so clients stop hard-coding `tmux … attach` themselves. Additive —
+/// older clients keep deriving the tmux invocation from `target` alone.
+fn attach_json(backend: &dyn repomon_core::SessionBackend, target: &str) -> Value {
+    let cmd = backend.attach_command(target);
+    json!({ "program": cmd.program, "args": cmd.args })
 }
 
 /// Overlay live agent sessions onto lanes: rich status from the monitors (Claude transcript,

--- a/crates/repomon-daemon/src/usage_watch.rs
+++ b/crates/repomon-daemon/src/usage_watch.rs
@@ -269,7 +269,9 @@ fn probe_once(
             break;
         }
         sleep(Duration::from_millis(500));
-        let pane = tmux.capture_named(window, CaptureOpts::visible()).unwrap_or_default();
+        let pane = tmux
+            .capture_named(window, CaptureOpts::visible())
+            .unwrap_or_default();
         match probe_state(&pane, spec) {
             ProbeState::Ready => {
                 ready = true;
@@ -301,7 +303,9 @@ fn probe_once(
                     break 'attempts;
                 }
                 sleep(Duration::from_millis(450));
-                let pane = tmux.capture_named(window, CaptureOpts::visible()).unwrap_or_default();
+                let pane = tmux
+                    .capture_named(window, CaptureOpts::visible())
+                    .unwrap_or_default();
                 if let Some(r) = (spec.parse)(&pane) {
                     report = Some(r);
                     break 'attempts;

--- a/crates/repomon-daemon/src/usage_watch.rs
+++ b/crates/repomon-daemon/src/usage_watch.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use repomon_core::TmuxRuntime;
+use repomon_core::SessionBackend;
+use repomon_core::agent::backend::{CaptureOpts, SpawnSpec};
 use repomon_core::agent::{self, UsageReport, parse_codex_status, parse_usage};
 
 use crate::Ctx;
@@ -103,14 +104,14 @@ pub async fn usage_watcher(ctx: Arc<Ctx>) {
         let accounts = accounts();
         let live: HashSet<String> = accounts.iter().map(|a| a.key.clone()).collect();
         for acct in accounts {
-            let tmux = ctx.tmux.clone();
+            let tmux = ctx.backend.clone();
             let window = probe_window(&acct.label);
             let cwd = probe_cwd();
             let spec = acct.spec;
             let cancel = Cancel::new(PROBE_TIMEOUT);
             let probe_cancel = cancel.clone();
             let probe = tokio::task::spawn_blocking(move || {
-                probe_once(&tmux, &window, &cwd, &spec, &probe_cancel)
+                probe_once(&*tmux, &window, &cwd, &spec, &probe_cancel)
             });
             let report = match tokio::time::timeout(PROBE_TIMEOUT, probe).await {
                 Ok(join) => join.ok().flatten(),
@@ -248,7 +249,7 @@ fn probe_window(label: &str) -> String {
 /// dismiss and kill the window. Blocking (tmux IO + waits) — call from `spawn_blocking`. Returns
 /// `None` on any failure (the caller keeps the previous reading).
 fn probe_once(
-    tmux: &TmuxRuntime,
+    tmux: &dyn SessionBackend,
     window: &str,
     cwd: &Path,
     spec: &ProbeSpec,
@@ -257,7 +258,8 @@ fn probe_once(
     use std::thread::sleep;
 
     let _ = tmux.kill_named(window);
-    tmux.spawn_named(window, cwd, &spec.command).ok()?;
+    tmux.spawn_named(window, &SpawnSpec::new(spec.command.clone(), cwd))
+        .ok()?;
 
     let mut ready = false;
     for _ in 0..40 {
@@ -267,7 +269,7 @@ fn probe_once(
             break;
         }
         sleep(Duration::from_millis(500));
-        let pane = tmux.capture_named(window, None).unwrap_or_default();
+        let pane = tmux.capture_named(window, CaptureOpts::visible()).unwrap_or_default();
         match probe_state(&pane, spec) {
             ProbeState::Ready => {
                 ready = true;
@@ -299,7 +301,7 @@ fn probe_once(
                     break 'attempts;
                 }
                 sleep(Duration::from_millis(450));
-                let pane = tmux.capture_named(window, None).unwrap_or_default();
+                let pane = tmux.capture_named(window, CaptureOpts::visible()).unwrap_or_default();
                 if let Some(r) = (spec.parse)(&pane) {
                     report = Some(r);
                     break 'attempts;
@@ -334,6 +336,8 @@ fn probe_state(pane: &str, spec: &ProbeSpec) -> ProbeState {
 
 #[cfg(test)]
 mod tests {
+    use repomon_core::TmuxRuntime;
+
     use super::*;
 
     #[test]

--- a/crates/repomon-daemon/tests/orchestrator.rs
+++ b/crates/repomon-daemon/tests/orchestrator.rs
@@ -9,8 +9,8 @@
 use std::process::Command;
 use std::time::Duration;
 
-use repomon_core::protocol::{self, Request, Response};
 use repomon_core::agent::backend::SpawnSpec;
+use repomon_core::protocol::{self, Request, Response};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;

--- a/crates/repomon-daemon/tests/orchestrator.rs
+++ b/crates/repomon-daemon/tests/orchestrator.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::agent::backend::SpawnSpec;
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;
@@ -135,8 +136,8 @@ async fn orchestrator_adopts_a_surviving_window() {
     // 3. Spawn a fake orchestrator window directly via the same TmuxRuntime the daemon uses —
     // as if a window from a previous daemon lifetime survived a restart.
     let home = std::env::temp_dir();
-    ctx.tmux
-        .spawn_named("orchestrator", &home, "sleep 30")
+    ctx.backend
+        .spawn_named("orchestrator", &SpawnSpec::new("sleep 30", &home))
         .expect("spawn fake orchestrator window");
 
     // 4. orchestrator.start adopts the surviving window: running:true, and does not spawn a
@@ -166,7 +167,7 @@ async fn orchestrator_adopts_a_surviving_window() {
         "adopted session's session_id should be unknown (this process never captured the prior \
          process's --session-id): {status}"
     );
-    let windows = ctx.tmux.list_windows().unwrap();
+    let windows = ctx.backend.list_windows().unwrap();
     let orchestrator_windows = windows.iter().filter(|w| *w == "orchestrator").count();
     assert_eq!(
         orchestrator_windows, 1,
@@ -184,7 +185,7 @@ async fn orchestrator_adopts_a_surviving_window() {
     assert!(r.error.is_none(), "send_input errored: {:?}", r.error);
 
     // 6. Kill the window out from under the daemon.
-    ctx.tmux
+    ctx.backend
         .kill_named("orchestrator")
         .expect("kill fake orchestrator window");
 

--- a/crates/repomon-daemon/tests/orchestrator_concurrent.rs
+++ b/crates/repomon-daemon/tests/orchestrator_concurrent.rs
@@ -111,7 +111,7 @@ async fn concurrent_starts_spawn_exactly_one_orchestrator() {
         .expect("start b must report the spawned session's id");
     assert_eq!(ida, idb, "both starts must resolve to one session");
 
-    let windows = ctx.tmux.list_windows().unwrap();
+    let windows = ctx.backend.list_windows().unwrap();
     let count = windows.iter().filter(|w| *w == "orchestrator").count();
     assert_eq!(
         count, 1,

--- a/crates/repomon-daemon/tests/remote.rs
+++ b/crates/repomon-daemon/tests/remote.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
+use repomon_core::agent::backend::SpawnSpec;
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::bytes_stream::WatchEntry;
 use repomon_daemon::conn::{ConnKind, ConnSession};
@@ -897,7 +898,6 @@ async fn close_session_releases_only_this_connections_watches() {
             "lane-1".to_string(),
             WatchEntry {
                 lane: 1,
-                fifo: std::env::temp_dir().join("repomon-test-a4-1.fifo"),
                 refs: [a.id, b.id].into_iter().collect(),
                 generation: 0,
             },
@@ -907,7 +907,6 @@ async fn close_session_releases_only_this_connections_watches() {
             "lane-2".to_string(),
             WatchEntry {
                 lane: 2,
-                fifo: std::env::temp_dir().join("repomon-test-a4-2.fifo"),
                 refs: [a.id].into_iter().collect(),
                 generation: 1,
             },
@@ -951,8 +950,8 @@ async fn fit_arbitrates_between_two_remote_sessions() {
 
     // A real, uncontested window for the apply case.
     let cwd = std::env::temp_dir();
-    ctx.tmux
-        .spawn_named("lane-2", &cwd, "sleep 30")
+    ctx.backend
+        .spawn_named("lane-2", &SpawnSpec::new("sleep 30", &cwd))
         .expect("spawn uncontested window");
 
     let a = ctx
@@ -1038,8 +1037,8 @@ async fn watch_bytes_off_without_window_releases_only_that_lanes_watches() {
     // Real windows to pipe: two on lane 1 (default-named and a second slot), one on lane 2.
     let cwd = std::env::temp_dir();
     for w in ["lane-1", "lane-1-2", "lane-2"] {
-        ctx.tmux
-            .spawn_named(w, &cwd, "sleep 30")
+        ctx.backend
+            .spawn_named(w, &SpawnSpec::new("sleep 30", &cwd))
             .expect("spawn window");
     }
 

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -414,8 +414,9 @@ pub struct App {
     /// Last terminal title emitted (OSC 2), to skip redundant writes.
     last_title: String,
     attach_request: Option<LaneId>,
-    /// A tmux target (e.g. a terminal window) the loop should attach to next.
-    attach_target: Option<String>,
+    /// An attach the loop should perform next (e.g. a terminal window): the target plus the
+    /// command to run for it.
+    attach_target: Option<AttachSpec>,
     /// When set, the stdin-reader thread pauses (so tmux owns the terminal during an attach).
     input_suspended: Arc<AtomicBool>,
     /// Set by the reader thread once it has actually entered its paused branch — so an attach waits
@@ -3572,7 +3573,7 @@ impl App {
                     .and_then(|a| a.as_bool())
                     .unwrap_or(false);
                 if available && !target.is_empty() {
-                    self.attach_target = Some(target);
+                    self.attach_target = Some(AttachSpec::from_parts(target, v.get("attach")));
                 } else {
                     self.status = "repomind isn't running yet".into();
                 }
@@ -3673,8 +3674,8 @@ impl App {
             .call("terminal.target", Some(json!({ "id": window })))
             .await
         {
-            if let Some(t) = v.get("target").and_then(|t| t.as_str()) {
-                self.attach_target = Some(t.to_string());
+            if let Some(spec) = AttachSpec::from_response(&v) {
+                self.attach_target = Some(spec);
             }
         }
     }
@@ -4051,8 +4052,8 @@ impl App {
             .await
         {
             Ok(v) => {
-                if let Some(t) = v.get("target").and_then(|t| t.as_str()) {
-                    self.attach_target = Some(t.to_string());
+                if let Some(spec) = AttachSpec::from_response(&v) {
+                    self.attach_target = Some(spec);
                 }
                 self.terminals_lane = None; // refetch the list after we return
             }
@@ -4077,8 +4078,8 @@ impl App {
                     .call("terminal.target", Some(json!({ "id": name })))
                     .await;
                 if let Ok(v) = resp {
-                    if let Some(t) = v.get("target").and_then(|t| t.as_str()) {
-                        self.attach_target = Some(t.to_string());
+                    if let Some(spec) = AttachSpec::from_response(&v) {
+                        self.attach_target = Some(spec);
                     }
                 }
             }
@@ -5056,8 +5057,8 @@ async fn event_loop(
             while in_rx.try_recv().is_ok() {} // drop anything queued before the reader parked
             continue;
         }
-        if let Some(target) = app.attach_target.take() {
-            do_attach_target(terminal, app, &target).await;
+        if let Some(spec) = app.attach_target.take() {
+            do_attach_target(terminal, app, &spec).await;
             while in_rx.try_recv().is_ok() {}
             continue;
         }
@@ -5155,25 +5156,27 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
             Some(json!({ "lane_id": lane, "window": window })),
         )
         .await;
-    let (target, available) = match resp {
-        Ok(v) => (
-            v.get("target")
-                .and_then(|t| t.as_str())
-                .unwrap_or("")
-                .to_string(),
-            v.get("available")
-                .and_then(|a| a.as_bool())
-                .unwrap_or(false),
-        ),
+    let v = match resp {
+        Ok(v) => v,
         Err(e) => {
             app.status = format!("attach failed: {e}");
             return;
         }
     };
+    let target = v
+        .get("target")
+        .and_then(|t| t.as_str())
+        .unwrap_or("")
+        .to_string();
+    let available = v
+        .get("available")
+        .and_then(|a| a.as_bool())
+        .unwrap_or(false);
     if !available || target.is_empty() {
         app.status = "no agent running in this lane".into();
         return;
     }
+    let spec = AttachSpec::from_parts(target, v.get("attach"));
     app.input_suspended.store(true, Ordering::Relaxed);
     // Tell the daemon we're parking now so it takes over desktop popups on its next tick rather
     // than waiting out LOCAL_TTL for our heartbeat to go stale — closes the handoff gap.
@@ -5183,7 +5186,7 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     disable_mouse();
     ratatui::restore();
     let keepalive = spawn_attach_keepalive(&app.client);
-    tmux_attach(&target);
+    run_attach(&spec);
     keepalive.abort();
     // Diagnostic: time the terminal re-init + first paint after a detach. None of these touch the
     // daemon, so a stall here (vs a slow RPC) points at ratatui::init / drain / draw rather than the
@@ -5219,9 +5222,9 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     }
 }
 
-/// Suspend the TUI, attach to an arbitrary tmux target (e.g. a plain terminal), then re-enter.
-async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target: &str) {
-    if target.is_empty() {
+/// Suspend the TUI, attach to an arbitrary target (e.g. a plain terminal), then re-enter.
+async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, spec: &AttachSpec) {
+    if spec.target.is_empty() {
         return;
     }
     app.input_suspended.store(true, Ordering::Relaxed);
@@ -5232,7 +5235,7 @@ async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, target:
     disable_mouse();
     ratatui::restore();
     let keepalive = spawn_attach_keepalive(&app.client);
-    tmux_attach(target);
+    run_attach(spec);
     keepalive.abort();
     *terminal = ratatui::init();
     enable_bracketed_paste();
@@ -5269,7 +5272,7 @@ const DETACH_MSG_CLEANUP: &str = "\x1b[1A\x1b[2K\r";
 /// the full ~15s client timeout (confirmed: silent connection closed at exactly 120.0s). A
 /// `watcher.park` ping every 45s keeps the connection live AND re-asserts the parked state, so the
 /// daemon keeps owning desktop popups. The runtime is multi-threaded, so this task runs on another
-/// worker while `tmux_attach` blocks the event loop's worker; the client's reader task (still
+/// worker while `run_attach` blocks the event loop's worker; the client's reader task (still
 /// draining the socket while parked) resolves each ping's response. Abort it on return.
 fn spawn_attach_keepalive(client: &DaemonClient) -> tokio::task::JoinHandle<()> {
     let client = client.clone();
@@ -5283,15 +5286,76 @@ fn spawn_attach_keepalive(client: &DaemonClient) -> tokio::task::JoinHandle<()> 
     })
 }
 
-/// Attach to a `session:window` target on repomon's dedicated tmux socket (the socket label is
-/// the session name). `$TMUX` is dropped so this works even when repomon runs inside tmux —
-/// otherwise tmux refuses to attach ("sessions should be nested with care").
-fn tmux_attach(target: &str) {
-    let socket = target.split(':').next().unwrap_or("repomon");
+/// How to go "all the way in" to a window from the real terminal: the daemon-provided attach
+/// command when the response carried one (the optional `attach` field of the `*.target`
+/// responses — the backend knows how to attach to itself), else the classic tmux invocation
+/// derived from the target (older daemons without the field).
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AttachSpec {
+    /// The `session:window` target, kept for logging.
+    target: String,
+    program: String,
+    args: Vec<String>,
+}
+
+impl AttachSpec {
+    /// From a `*.target`-shaped response: `{ target, attach? }`. `None` without a non-empty
+    /// target (the caller's availability checks still apply).
+    fn from_response(v: &serde_json::Value) -> Option<Self> {
+        let target = v.get("target")?.as_str()?;
+        if target.is_empty() {
+            return None;
+        }
+        Some(Self::from_parts(target.to_string(), v.get("attach")))
+    }
+
+    /// Build from a known target plus the response's optional `attach` field.
+    fn from_parts(target: String, attach: Option<&serde_json::Value>) -> Self {
+        if let Some((program, args)) = attach.and_then(parse_attach_field) {
+            return AttachSpec {
+                target,
+                program,
+                args,
+            };
+        }
+        // Fallback: repomon's dedicated tmux socket is labelled with the session name — the
+        // target's prefix (exactly what this client always ran before the `attach` field).
+        let socket = target.split(':').next().unwrap_or("repomon").to_string();
+        AttachSpec {
+            program: "tmux".into(),
+            args: vec![
+                "-L".into(),
+                socket,
+                "attach".into(),
+                "-t".into(),
+                target.clone(),
+            ],
+            target,
+        }
+    }
+}
+
+/// Parse the `attach` response field (`{ program, args }`) if well-formed.
+fn parse_attach_field(a: &serde_json::Value) -> Option<(String, Vec<String>)> {
+    let program = a.get("program")?.as_str()?.to_string();
+    let args = a
+        .get("args")?
+        .as_array()?
+        .iter()
+        .map(|s| Some(s.as_str()?.to_string()))
+        .collect::<Option<Vec<_>>>()?;
+    Some((program, args))
+}
+
+/// Run the attach command in the real terminal. `$TMUX` is dropped so a tmux-backed attach
+/// works even when repomon runs inside tmux — otherwise tmux refuses to attach ("sessions
+/// should be nested with care").
+fn run_attach(spec: &AttachSpec) {
+    let target = &spec.target;
     tui_log(&format!("attach -> {target}"));
     let start = std::time::Instant::now();
-    let status = std::process::Command::new("tmux")
-        .args(["-L", socket, "attach", "-t", target])
+    let status = std::process::Command::new(&spec.program)
+        .args(&spec.args)
         .env_remove("TMUX")
         .status();
     // Log when (and how) the attach ended so an *unexpected* detach is traceable after the fact:
@@ -5514,6 +5578,43 @@ async fn next_note(rx: &mut broadcast::Receiver<Notification>) -> Option<Notific
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn attach_spec_prefers_the_daemon_provided_command() {
+        // A modern daemon's `*.target` response carries the exact attach invocation.
+        let v = serde_json::json!({
+            "target": "repomon:=lane-7",
+            "available": true,
+            "attach": { "program": "tmux", "args": ["-L", "repomon", "attach", "-t", "repomon:=lane-7"] },
+        });
+        let spec = AttachSpec::from_response(&v).expect("target present");
+        assert_eq!(spec.target, "repomon:=lane-7");
+        assert_eq!(spec.program, "tmux");
+        assert_eq!(
+            spec.args,
+            vec!["-L", "repomon", "attach", "-t", "repomon:=lane-7"]
+        );
+    }
+
+    #[test]
+    fn attach_spec_falls_back_to_the_classic_tmux_invocation() {
+        // An older daemon without the `attach` field: derive `tmux -L <session> attach -t <target>`
+        // from the target's session prefix, exactly as this client always did.
+        let v = serde_json::json!({ "target": "mysess:=lane-1", "available": true });
+        let spec = AttachSpec::from_response(&v).expect("target present");
+        assert_eq!(spec.program, "tmux");
+        assert_eq!(
+            spec.args,
+            vec!["-L", "mysess", "attach", "-t", "mysess:=lane-1"]
+        );
+        // A malformed `attach` field (wrong shape) also falls back rather than erroring.
+        let bad = serde_json::json!({ "target": "s:=w", "attach": { "program": 7 } });
+        let spec = AttachSpec::from_response(&bad).expect("target present");
+        assert_eq!(spec.program, "tmux");
+        // No target → no attach.
+        assert!(AttachSpec::from_response(&serde_json::json!({ "target": "" })).is_none());
+        assert!(AttachSpec::from_response(&serde_json::json!({})).is_none());
+    }
 
     #[test]
     fn detach_cleanup_erases_line_in_place_not_fullscreen() {

--- a/crates/repomon-tui/src/cli.rs
+++ b/crates/repomon-tui/src/cli.rs
@@ -475,17 +475,41 @@ async fn handle_orchestrate(
         ));
     }
 
-    attach_tmux_target(&target)
+    attach_tmux_target(&target, resp.get("attach"))
 }
 
-/// Attach this process to a `session:window` target on repomon's dedicated tmux socket (the socket
-/// label is the session name). `$TMUX` is dropped so this works even from inside tmux. On unix we
-/// `exec` tmux so it owns the terminal directly (like a raw attach); detaching ends the command.
-fn attach_tmux_target(target: &str) -> Result<()> {
-    let socket_label = target.split(':').next().unwrap_or("repomon");
-    let mut cmd = std::process::Command::new("tmux");
-    cmd.args(["-L", socket_label, "attach", "-t", target])
-        .env_remove("TMUX");
+/// Attach this process to a `session:window` target. Prefers the daemon-provided attach command
+/// (the optional `attach` response field: `{ program, args }`); falls back to the classic tmux
+/// invocation on repomon's dedicated socket (the socket label is the session name — the target's
+/// prefix) for daemons without the field. `$TMUX` is dropped so this works even from inside tmux.
+/// On unix we `exec` the attach program so it owns the terminal directly (like a raw attach);
+/// detaching ends the command.
+fn attach_tmux_target(target: &str, attach: Option<&Value>) -> Result<()> {
+    let parsed = attach.and_then(|a| {
+        let program = a.get("program")?.as_str()?.to_string();
+        let args = a
+            .get("args")?
+            .as_array()?
+            .iter()
+            .map(|s| Some(s.as_str()?.to_string()))
+            .collect::<Option<Vec<_>>>()?;
+        Some((program, args))
+    });
+    let (program, args) = parsed.unwrap_or_else(|| {
+        let socket_label = target.split(':').next().unwrap_or("repomon");
+        (
+            "tmux".to_string(),
+            vec![
+                "-L".to_string(),
+                socket_label.to_string(),
+                "attach".to_string(),
+                "-t".to_string(),
+                target.to_string(),
+            ],
+        )
+    });
+    let mut cmd = std::process::Command::new(program);
+    cmd.args(args).env_remove("TMUX");
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -127,15 +127,15 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `agent.stop` | `{ lane_id, window? }` | `null` (stops one specific agent window; `None` = the lane's first slot) |
 | `agent.pin` | `{ lane_id, pinned }` | `null` |
 | `session.rename` | `{ session_id, label? }` | `null` (set/clear a user label for a session, keyed by its durable transcript id; empty/absent `label` clears it; overlaid onto `AgentSession.custom_label`) |
-| `agent.target` | `{ lane_id, window? }` | `{ target, available }` (also resets the window to follow the attaching client's size) |
+| `agent.target` | `{ lane_id, window? }` | `{ target, available, attach? }` (also resets the window to follow the attaching client's size; `attach` — optional, additive — is `{ program, args }`, the exact command to run in a real terminal to attach; clients without it keep deriving the tmux invocation from `target`) |
 | `agent.resize` | `{ lane_id, cols, rows, window? }` | `null` (resize the agent's pane so the mediated view reflows to fit; clamped to a floor) |
 | `agent.fit` | `{ lane_id, cols, rows, window? }` | `{ applied, cols, rows }` — the arbitrated resize for remote viewers: reflows the shared pane to the caller's grid ONLY while no live local viewport focus owns the window (the TUI heartbeats its viewport every ~5s; ownership lapses 15s after the last beat, and a clean TUI quit releases it immediately) AND no other remote session that's also focused on this window right now drove the agent more recently than the caller (last-interaction-wins among remotes; an applied fit counts as an interaction). Refused (`applied: false`) it answers with the pane's current grid so the caller renders pinned at the shared size instead of fighting. Poll it (~10s) to adapt when the TUI starts or stops viewing. |
 | `agent.scroll` | `{ lane_id, up, ticks=1, window? }` | `{ forwarded }` (forward `ticks` wheel events to a full-screen agent so it scrolls its own history; `forwarded:false` when the pane isn't on the alternate screen — the client then scrolls the captured buffer itself) |
-| `terminal.open` | `{ lane_id }` | `{ id, target }` (a new plain shell window in the worktree) |
+| `terminal.open` | `{ lane_id }` | `{ id, target, attach? }` (a new plain shell window in the worktree; `attach` as in `agent.target`) |
 | `terminal.list` | `{ lane_id }` | `[String]` (open terminal window names for the lane) |
 | `terminal.list_all` | — | `[{ lane_id, id }]` (every lane's open terminals, sorted — what the Grid tiles) |
 | `terminal.close` | `{ id }` | `null` |
-| `terminal.target` | `{ id }` | `{ target, available }` |
+| `terminal.target` | `{ id }` | `{ target, available, attach? }` (`attach` as in `agent.target`) |
 | `fs.browse` | `{ path? }` | `BrowseResult` (subdirs, repos, added flags) |
 | `viewport.set` | `{ lane_ids, focus_lane?, focus_window?, windows? }` | `null` (`focus_lane`/`focus_window` pick which agent window the focused lane streams; others stream their first slot. `windows` names plain-terminal windows — `term-{lane}-{n}` — to stream as extra panes alongside the lanes, e.g. the Grid's shell tiles; non-terminal names are ignored. Per-connection: each connection owns its own viewport and focus; the capture loop streams the union across every live connection, and `event.agent.output` is filtered to the connections whose viewport actually covers it) |
 | `subscribe` | `{ topics? }` | `null` |
@@ -152,7 +152,7 @@ Error codes: `-32700` parse error, `-32601` method not found, `-32602` invalid p
 | `orchestrator.transcript` | `{ limit? }` | `[TranscriptItem]` (repomind's conversation, same `{ role, text, at? }` shape as `agent.transcript`, so a client can render it as a chat instead of mirroring the pane; pinned to the orchestrator's own `session_id` when known, else falls back to the newest `$HOME` Claude transcript with real content across accounts. Always `[]` while `backend` is `"codex"` — codex's on-disk session format is not parsed; treat it as "no chat view for this backend" and render the `event.orchestrator.output` pane stream instead, never as an error/loading state) |
 | `orchestrator.start` | `{ agent?, model?, autonomy?, max_agents?, prompt? }` | `{ running, agent?, model?, backend?, window?, autonomy?, session_id?, attention, headline? }` (spawn or adopt the singleton `orchestrator` window wired to the repomon MCP server; idempotent; re-spawns if the prior window died. `agent` picks the backend: a Claude account / custom agent name / `codex`; an agent with no MCP client — e.g. `aider` — is rejected with `invalid_params` instead of spawning a broken window) |
 | `orchestrator.stop` | — | `{ running:false, attention:"none", headline:null, … }` (kill the orchestrator window) |
-| `orchestrator.target` | — | `{ target, available }` (attach target for the orchestrator window; resets it to follow the attaching client's size) |
+| `orchestrator.target` | — | `{ target, available, attach? }` (attach target for the orchestrator window; resets it to follow the attaching client's size; `attach` as in `agent.target`) |
 | `orchestrator.send_input` | `{ text, enter=true }` | `null` (type an instruction to repomind, then Enter unless `enter=false`) |
 | `orchestrator.key` | `{ key, literal=false }` | `null` (one keystroke to repomind: literal char or key name) |
 | `orchestrator.watch` | `{ on }` | `null` (gate the pane stream; the TUI sets it `true` while the command-center view is open and `false` on leaving) |


### PR DESCRIPTION
## Summary

Track B of the native-Windows plan (`docs/superpowers/plans/2026-07-19-repomon-native-windows.md`): a **pure refactor** that puts all tmux knowledge behind a `SessionBackend` trait so Track I can drop in a `WindowsBackend`. **Zero behavior change on macOS/Linux.**

- **New `crates/repomon-core/src/agent/backend.rs`**: `SessionBackend` (sync, `Send + Sync`, object-safe; call sites already run in `spawn_blocking`) plus `SpawnSpec`, `CaptureOpts`, `Cursor`, `WindowActivity`, `OwnerState`, `AttachCommand`, `ByteStream`. Signatures lifted mechanically from `tmux.rs`.
- **`impl SessionBackend for TmuxRuntime` by delegation** — inherent methods and their unit tests untouched. The tmux impl renders `SpawnSpec` to the *identical* `sh -c` string via the existing `shell_quote` (unit-tested byte-for-byte for the spawn+task case).
- **`Ctx.tmux: TmuxRuntime` → `Ctx.backend: Arc<dyn SessionBackend>`** with a mechanical call-site sweep across `rpc.rs`, `reap.rs`, `auto_continue.rs`, `usage_watch.rs`, `notify_watch.rs`, `main.rs`, and the stream loops.
- **`open_byte_stream`/`close_byte_stream` absorb the fifo**: `mkfifo` + `pipe-pane` + the reader thread moved from `bytes_stream.rs` into the tmux impl (with the unique-fifo-name race guard); `bytes_stream.rs` keeps only the refcount/generation registry and consumes the backend's `ByteStream`.
- **Attach**: `agent.target` / `terminal.target` / `orchestrator.target` / `terminal.open` responses gain an **additive optional** `attach: { program, args }` field (from `SessionBackend::attach_command`). The TUI and `repomon orchestrate` prefer it and fall back to the classic client-built `tmux -L <session> attach -t <target>` for older daemons. Wire protocol otherwise frozen (iOS-safe); `docs/protocol.md` updated.

**One-choke-point property verified**: no tmux/`mkfifo`/`pipe-pane` invocations outside `agent/tmux.rs` (remaining grep hits are comments and the pre-existing `#[ignore]`d manual probes' isolated-server teardown in `usage_watch` tests).

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ — 366 passed, 0 failed (incl. live tmux integration tests and the TUI render tests, all unchanged: `git diff main -- crates/repomon-tui/tests crates/repomon-core/src/agent/fixtures` is empty — the zero-behavior-change proof)
- `cargo check --target x86_64-pc-windows-msvc`: **not runnable on this host** — C build scripts (`ring`, `libsqlite3-sys` bundled) can't cross-compile from macOS without MSVC headers, and unmodified `main` fails identically (pre-existing environment limitation, matches prior findings on macOS cross-checks). No `#[cfg]`-sensitive code was added; Track A's `windows-latest` CI leg is the real gate for this.

## Merge notes (integrator)

- **Merge AFTER Track A** (`ci/windows-ci-leg` + `feat/win-a-transport`); this branch is based on current `main` and will likely need a rebase once A lands. Expected touch points with A: `crates/repomon-tui/src/cli.rs` (A: entropy/transport; B: `attach_tmux_target` signature) and possibly daemon test scaffolding — both small, mechanical resolutions. `crates/repomon-tui/src/lib.rs` is untouched by this PR.
- No new dependencies; `Cargo.lock` unchanged, so no lockfile conflicts from this branch.
- D4 (shell-init) also touches `cli.rs`; this PR's `cli.rs` diff is confined to the orchestrate-attach helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)