### PR TITLE
feat(tui): open a just-created agent typing-ready (Focus + insert)

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -3922,18 +3922,42 @@ impl App {
                 match self.client.call("lane.create", Some(params)).await {
                     Ok(lane) => {
                         // Spin up the chosen agent in the new lane straight away.
-                        if let Some(id) = lane.get("id").and_then(|v| v.as_i64()) {
-                            let _ = self
-                                .client
-                                .call(
-                                    "agent.spawn",
-                                    Some(json!({ "lane_id": id, "agent": agent })),
-                                )
-                                .await;
-                        }
-                        self.status = format!("created lane {} + spawned {agent}", self.nl_branch);
-                        self.view = View::Fleet;
+                        let spawned = match lane.get("id").and_then(|v| v.as_i64()) {
+                            Some(id) => Some((
+                                id,
+                                self.client
+                                    .call(
+                                        "agent.spawn",
+                                        Some(json!({ "lane_id": id, "agent": agent })),
+                                    )
+                                    .await,
+                            )),
+                            None => None,
+                        };
+                        // Refresh BEFORE landing so the new lane exists in `self.lanes` for the
+                        // fleet-cursor move.
                         self.refresh().await;
+                        match spawned {
+                            // Land on the new agent typing-ready — creating it IS opening it.
+                            Some((id, Ok(v))) => {
+                                self.status =
+                                    format!("created lane {} + spawned {agent}", self.nl_branch);
+                                let window =
+                                    v.get("window").and_then(|w| w.as_str()).map(str::to_string);
+                                self.land_on_spawned(id, window);
+                            }
+                            // No agent to type to — stay on the fleet, but say why (this error
+                            // was previously swallowed).
+                            Some((_, Err(e))) => {
+                                self.status =
+                                    format!("created lane {}; spawn failed: {e}", self.nl_branch);
+                                self.view = View::Fleet;
+                            }
+                            None => {
+                                self.status = format!("created lane {}", self.nl_branch);
+                                self.view = View::Fleet;
+                            }
+                        }
                     }
                     Err(e) => self.status = format!("create failed: {e}"),
                 }
@@ -3964,10 +3988,25 @@ impl App {
         self.view = View::SpawnPick;
     }
 
-    /// Spawn `agent` into `lane`: on success drop into Focus on the *new* agent, ready to drive
-    /// it. The daemon surfaces the new window right away (a window-only placeholder until its
-    /// transcript lands), so an immediate refresh plus the pending-focus intent put the cursor on
-    /// it instead of leaving you on the lane's existing agent.
+    /// Land on a just-spawned agent, typing-ready: select its lane in the fleet, arm the
+    /// pending-focus intent (which also routes keys to the window before its session shows up
+    /// in `lane.list` — see [`Self::selected_window`]), and enter Focus with insert mode on —
+    /// creating an agent needs no manual open before talking to it.
+    fn land_on_spawned(&mut self, lane: LaneId, window: Option<String>) {
+        self.select_lane_session(lane, None);
+        if let Some(w) = window {
+            self.pending_focus_window = Some((lane, w));
+            self.pending_focus_ticks = 0;
+        }
+        self.reset_scroll(); // live tail, mirroring what `i` does
+        self.view = View::Focus;
+        self.focus_insert = true;
+    }
+
+    /// Spawn `agent` into `lane`: on success drop into Focus on the *new* agent with insert on,
+    /// typing straight to it. The daemon surfaces the new window right away (a window-only
+    /// placeholder until its transcript lands), so an immediate refresh plus the pending-focus
+    /// intent put the cursor on it instead of leaving you on the lane's existing agent.
     async fn do_spawn(&mut self, id: LaneId, agent: &str) {
         match self
             .client
@@ -3979,12 +4018,8 @@ impl App {
         {
             Ok(v) => {
                 self.status = format!("spawned {agent}");
-                self.view = View::Focus;
-                self.focus_insert = false;
-                if let Some(window) = v.get("window").and_then(|w| w.as_str()) {
-                    self.pending_focus_window = Some((id, window.to_string()));
-                    self.pending_focus_ticks = 0;
-                }
+                let window = v.get("window").and_then(|w| w.as_str()).map(str::to_string);
+                self.land_on_spawned(id, window);
                 self.refresh_lanes().await;
             }
             Err(e) => self.status = format!("spawn failed: {e}"),
@@ -6060,6 +6095,46 @@ mod tests {
             "a window that never appears must not pin routing forever"
         );
         // With the intent gone, routing falls back to the actually-selected session.
+        assert_eq!(app.selected_window().as_deref(), Some("lane-7"));
+    }
+
+    #[tokio::test]
+    async fn spawn_lands_in_focus_typing_ready() {
+        let mut app = app_on_lane_7().await;
+        // `e` on lane 7 spawned a second agent into window lane-7-2.
+        app.land_on_spawned(7, Some("lane-7-2".into()));
+        assert_eq!(app.view, View::Focus);
+        assert!(
+            app.focus_insert,
+            "typing must reach the agent with no `i` press"
+        );
+        assert_eq!(app.pending_focus_window, Some((7, "lane-7-2".into())));
+        // Keys route to the new window even before its session shows up in lane.list.
+        assert_eq!(app.selected_window().as_deref(), Some("lane-7-2"));
+    }
+
+    #[tokio::test]
+    async fn new_lane_landing_moves_the_fleet_cursor_to_the_new_lane() {
+        let mut app = app_on_lane_7().await;
+        // A New Lane submit just created lane 8 and spawned its agent (window lane-8); the
+        // lane is in the refreshed list but its session hasn't appeared yet.
+        app.lanes.push(test_lane(8));
+        app.land_on_spawned(8, Some("lane-8".into()));
+        assert_eq!(app.selected_lane().map(|l| l.id), Some(8));
+        assert_eq!(app.view, View::Focus);
+        assert!(app.focus_insert);
+        assert_eq!(app.selected_window().as_deref(), Some("lane-8"));
+    }
+
+    #[tokio::test]
+    async fn landing_without_a_window_still_opens_focus_insert() {
+        let mut app = app_on_lane_7().await;
+        // A malformed spawn response (no window name): no intent to arm, but the user still
+        // lands typing-ready on the lane's selected session.
+        app.land_on_spawned(7, None);
+        assert_eq!(app.view, View::Focus);
+        assert!(app.focus_insert);
+        assert!(app.pending_focus_window.is_none());
         assert_eq!(app.selected_window().as_deref(), Some("lane-7"));
     }
 

--- a/docs/superpowers/specs/2026-07-19-auto-open-spawned-agent-design.md
+++ b/docs/superpowers/specs/2026-07-19-auto-open-spawned-agent-design.md
@@ -1,0 +1,83 @@
+# Auto-open the just-created agent
+
+**Date:** 2026-07-19
+**Status:** Approved
+
+## Problem
+
+Creating an agent leaves a manual step before you can talk to it:
+
+- `e` spawn (Fleet/Split/Focus, with or without the picker) lands in Focus on the
+  new agent but with insert mode off — you must press `i` before typing.
+- New Lane + agent (`submit_new_lane`) spawns the agent, then returns to **Fleet**
+  with no selection change: you must find the lane, open Focus, and press `i`.
+
+The user's intent: after creating an agent, land in the Focus view with `INSERT`
+active — typing goes straight to the new agent, zero extra keypresses.
+
+## Design
+
+### Shared landing helper
+
+Extract `do_spawn`'s post-spawn landing into one helper on `App`:
+
+```rust
+/// Land on a just-spawned agent, typing-ready: select its lane in the fleet,
+/// arm the pending-focus intent (which also routes keys to the window before
+/// lane.list shows it), and enter Focus with insert mode on.
+fn land_on_spawned(&mut self, lane: LaneId, window: Option<String>)
+```
+
+Behavior:
+
+1. `select_lane_session(lane, None)` — point the fleet cursor at the lane
+   (matters for the New Lane path; a same-lane `e` spawn is a no-op).
+2. If `window` is `Some`, set `pending_focus_window = (lane, window)` and reset
+   `pending_focus_ticks` — the cursor snaps to the new agent's session when it
+   appears in `lane.list`, and `selected_window()` routes keystrokes to it
+   immediately (PR #65).
+3. `reset_scroll()` — show the live tail, mirroring what `i` does today.
+4. `view = View::Focus`, `focus_insert = true`.
+
+`focus_managed` needs no handling: `check_focus_alive` derives it per tick.
+
+### Call sites
+
+- **`do_spawn`** (all `e`-spawn paths): replace the current inline landing
+  (`view = Focus; focus_insert = false; pending_focus_window = …`) with the
+  helper. Net behavior change: insert mode starts on.
+- **`submit_new_lane`**: capture the `agent.spawn` response instead of
+  discarding it (`let _ =`). On spawn success: keep the status line, `refresh()`
+  first (so the new lane exists in `self.lanes` for `select_lane_session`),
+  then call the helper with the returned window. On spawn **failure**: keep
+  today's behavior (Fleet + refresh) — there is no agent to type to; surface
+  the spawn error in `status` instead of swallowing it.
+
+### Trade-off (accepted)
+
+With insert on by default, command keys (`e`, `s`, `m`, …) right after a spawn
+require `^O` first. That is what "open and typing-ready" means; Esc continues to
+forward to the agent (existing design, guarded by `esc_is_forwarded_not_captured`).
+
+## Testing
+
+Unit tests in `app.rs::tests` using the existing dummy-client harness
+(`app_on_lane_7`), driving the helper directly (the RPC halves of `do_spawn` /
+`submit_new_lane` stay thin):
+
+1. **`e`-spawn landing:** `land_on_spawned(7, Some("lane-7-2"))` → view is
+   Focus, `focus_insert` on, `pending_focus_window` armed,
+   `selected_window() == "lane-7-2"` before the session appears in `lane.list`.
+2. **New-lane landing:** app with two lanes, selection on the first;
+   `land_on_spawned(8, Some("lane-8"))` → fleet selection moves to lane 8,
+   Focus + insert on, keys route to `lane-8`.
+3. **No window (spawn response malformed):** lands in Focus + insert with no
+   pending intent, routing falls back to the selected session.
+
+Existing PR #65 tests already cover intent resolution, expiry, and Tab cancel.
+
+## Out of scope
+
+- Full tmux attach on spawn (rejected: heavier than the Focus view the user
+  chose; attaching mid-boot is janky).
+- Auto-insert when merely *navigating* to an agent (only creation opens it).


### PR DESCRIPTION
## Summary
- Creating an agent no longer needs a manual open: you land in Focus on the new agent with `INSERT` already active — the first keystroke goes to it.
- `e` spawns (Fleet/Split/Focus, with or without the picker) previously landed in Focus with insert off; New Lane + agent previously returned to Fleet with no selection change.
- New shared `land_on_spawned()` helper: fleet-cursor move (`select_lane_session`), pending-focus intent (instant key routing from #65), scroll reset, `View::Focus` + `focus_insert = true`.
- `submit_new_lane` now refreshes before landing (so the new lane is selectable) and surfaces a spawn failure in the status line instead of swallowing it — staying on Fleet in that case, since there's no agent to type to.

Design spec: `docs/superpowers/specs/2026-07-19-auto-open-spawned-agent-design.md` (committed here).

Trade-off (per design): with insert on after a spawn, command keys need `^O` first; Esc continues to forward to the agent.

## Test plan
- [x] 3 new unit tests: `e`-spawn landing (Focus + insert + immediate routing to the new window), New Lane landing moves the fleet cursor to the new lane, and a window-less spawn response still opens Focus + insert with fallback routing.
- [x] `cargo test -p repomon-tui --lib`: 41 passed. Clippy + rustfmt clean.
- [x] 5 `tests/tui.rs` integration failures are pre-existing on `main` in this sandbox (need real tmux) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)