### PR TITLE
feat(core): portable IPC transport - named pipes on Windows, UDS on unix

### DIFF
--- a/crates/repomon-core/src/client.rs
+++ b/crates/repomon-core/src/client.rs
@@ -22,24 +22,17 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-#[cfg(unix)]
-use std::sync::Weak;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
-#[cfg(unix)]
-use anyhow::Context;
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-#[cfg(unix)]
-use tokio::net::UnixStream;
 use tokio::sync::{broadcast, mpsc, oneshot};
 
-use crate::protocol::{Notification, Request, Response};
-#[cfg(unix)]
-use crate::protocol::{read_frame, write_frame};
+use crate::protocol::{Notification, Request, Response, read_frame, write_frame};
+use crate::transport::{self, Endpoint, IpcStream};
 
 /// Keepalive cadence. Must stay comfortably under the daemon's 120s idle-connection reaper so an
 /// otherwise-silent client (e.g. the MCP bridge, which mostly just receives events) is never reaped.
@@ -57,9 +50,6 @@ pub struct DaemonClient {
     inner: Arc<Inner>,
 }
 
-// On Windows the connect/reconnect paths are stubbed out until the named-pipe transport lands,
-// so some fields (`path`, `epoch`) are only read by unix-gated code.
-#[cfg_attr(windows, allow(dead_code))]
 struct Inner {
     path: PathBuf,
     pending: Pending,
@@ -93,20 +83,8 @@ impl DaemonClient {
         Self::connect_inner(path, Some(KEEPALIVE_INTERVAL)).await
     }
 
-    /// Windows stub until the named-pipe transport lands (next PR in this track): connecting is
-    /// not yet possible, so every entry point fails with a clear error instead of failing to
-    /// compile the whole workspace.
-    #[cfg(windows)]
-    async fn connect_inner(path: &Path, _keepalive: Option<Duration>) -> Result<Self> {
-        Err(anyhow!(
-            "connecting to the daemon at {} is not yet supported on Windows (the named-pipe transport lands in a follow-up PR)",
-            path.display()
-        ))
-    }
-
-    #[cfg(unix)]
     async fn connect_inner(path: &Path, keepalive: Option<Duration>) -> Result<Self> {
-        let stream = UnixStream::connect(path)
+        let stream = transport::connect(&Endpoint::from_path(path))
             .await
             .with_context(|| format!("connecting to daemon at {}", path.display()))?;
 
@@ -215,9 +193,8 @@ impl DaemonClient {
 impl Inner {
     /// Spawn the reader + writer tasks for `stream`, install its outbound channel, and mark the
     /// connection live. Reused for the initial connect and every reconnect.
-    #[cfg(unix)]
-    fn spawn_io(self: &Arc<Self>, stream: UnixStream) {
-        let (mut rd, mut wr) = stream.into_split();
+    fn spawn_io(self: &Arc<Self>, stream: IpcStream) {
+        let (mut rd, mut wr) = tokio::io::split(stream);
         let (out_tx, mut out_rx) = mpsc::channel::<Vec<u8>>(128);
         *self.out_tx.lock().unwrap() = out_tx;
         self.connected.store(true, Ordering::SeqCst);
@@ -262,24 +239,14 @@ impl Inner {
         });
     }
 
-    /// Windows stub until the named-pipe transport lands: see [`DaemonClient::connect_inner`].
-    #[cfg(windows)]
-    async fn reconnect(self: &Arc<Self>) -> Result<()> {
-        Err(anyhow!(
-            "reconnecting to the daemon at {} is not yet supported on Windows (the named-pipe transport lands in a follow-up PR)",
-            self.path.display()
-        ))
-    }
-
     /// Re-establish the connection. Serialized so concurrent callers open one socket; a no-op if
     /// another caller already reconnected.
-    #[cfg(unix)]
     async fn reconnect(self: &Arc<Self>) -> Result<()> {
         let _guard = self.reconnecting.lock().await;
         if self.connected.load(Ordering::SeqCst) {
             return Ok(());
         }
-        let stream = UnixStream::connect(&self.path)
+        let stream = transport::connect(&Endpoint::from_path(&self.path))
             .await
             .with_context(|| format!("reconnecting to daemon at {}", self.path.display()))?;
         self.spawn_io(stream);
@@ -319,7 +286,6 @@ impl Inner {
 
 /// Keepalive: ping under the daemon's idle reaper so a quiet client is never dropped. Exits when
 /// the last `DaemonClient` is dropped (the `Weak` stops upgrading).
-#[cfg(unix)]
 async fn keepalive_loop(weak: Weak<Inner>, interval: Duration) {
     let mut tick = tokio::time::interval(interval);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -333,26 +299,26 @@ async fn keepalive_loop(weak: Weak<Inner>, interval: Duration) {
     }
 }
 
-// Unix-only until the client is generic over the IPC transport (next PR in this track).
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::protocol::write_message;
     use std::sync::atomic::AtomicUsize;
-    use tokio::net::UnixListener;
 
     /// A keepalive client must ping an idle connection on its own, so the daemon never reaps it.
     #[tokio::test]
     async fn keepalive_pings_idle_connection() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("d.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
+        let mut listener = transport::listen(&Endpoint::from_path(&sock))
+            .await
+            .unwrap();
 
         let pings = Arc::new(AtomicUsize::new(0));
         let pings_srv = pings.clone();
         tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            let (mut rd, mut wr) = stream.into_split();
+            let stream = listener.accept().await.unwrap();
+            let (mut rd, mut wr) = tokio::io::split(stream);
             while let Ok(Some(frame)) = read_frame(&mut rd).await {
                 if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
                     if req.method == "ping" {
@@ -383,7 +349,9 @@ mod tests {
     async fn reconnect_replays_subscribe_and_active_watch() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("d.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
+        let mut listener = transport::listen(&Endpoint::from_path(&sock))
+            .await
+            .unwrap();
 
         // Methods seen on the LATEST server-side connection (reset on each accept).
         let latest: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -393,12 +361,12 @@ mod tests {
             let accepts = accepts.clone();
             tokio::spawn(async move {
                 loop {
-                    let (stream, _) = listener.accept().await.unwrap();
+                    let stream = listener.accept().await.unwrap();
                     accepts.fetch_add(1, Ordering::SeqCst);
                     latest.lock().unwrap().clear();
                     let latest = latest.clone();
                     tokio::spawn(async move {
-                        let (mut rd, mut wr) = stream.into_split();
+                        let (mut rd, mut wr) = tokio::io::split(stream);
                         while let Ok(Some(frame)) = read_frame(&mut rd).await {
                             if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
                                 latest.lock().unwrap().push(req.method.clone());
@@ -459,18 +427,20 @@ mod tests {
     async fn reconnect_does_not_replay_a_stopped_watch() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("d.sock");
-        let listener = UnixListener::bind(&sock).unwrap();
+        let mut listener = transport::listen(&Endpoint::from_path(&sock))
+            .await
+            .unwrap();
 
         let latest: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         {
             let latest = latest.clone();
             tokio::spawn(async move {
                 loop {
-                    let (stream, _) = listener.accept().await.unwrap();
+                    let stream = listener.accept().await.unwrap();
                     latest.lock().unwrap().clear();
                     let latest = latest.clone();
                     tokio::spawn(async move {
-                        let (mut rd, mut wr) = stream.into_split();
+                        let (mut rd, mut wr) = tokio::io::split(stream);
                         while let Ok(Some(frame)) = read_frame(&mut rd).await {
                             if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
                                 latest.lock().unwrap().push(req.method.clone());
@@ -518,8 +488,8 @@ mod tests {
     /// already live.
     #[tokio::test]
     async fn stale_reader_does_not_clobber_new_connection() {
-        let (a_client, a_server) = UnixStream::pair().unwrap();
-        let (b_client, _b_server) = UnixStream::pair().unwrap();
+        let (a_client, a_server) = IpcStream::pair();
+        let (b_client, _b_server) = IpcStream::pair();
 
         let (events_tx, _rx) = broadcast::channel(8);
         let (placeholder, _) = mpsc::channel(1);

--- a/crates/repomon-core/src/config.rs
+++ b/crates/repomon-core/src/config.rs
@@ -276,7 +276,9 @@ impl Config {
     }
 }
 
-fn home() -> PathBuf {
+/// The user's home directory (portable — `$HOME` on unix, the profile dir on Windows).
+/// Shared by every path that used to read `$HOME` directly.
+pub fn home() -> PathBuf {
     directories::BaseDirs::new()
         .map(|b| b.home_dir().to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."))
@@ -324,9 +326,23 @@ pub fn socket_path(cfg: &Config) -> PathBuf {
 }
 
 fn current_user() -> String {
-    std::env::var("USER")
-        .or_else(|_| std::env::var("LOGNAME"))
-        .unwrap_or_else(|_| "user".to_string())
+    current_user_from(
+        std::env::var("USER").ok(),
+        std::env::var("LOGNAME").ok(),
+        std::env::var("USERNAME").ok(),
+    )
+}
+
+/// `USER`/`LOGNAME` are the unix conventions; `USERNAME` is the Windows one. Factored pure so
+/// the fallback order is unit-testable without mutating the process environment.
+fn current_user_from(
+    user: Option<String>,
+    logname: Option<String>,
+    username: Option<String>,
+) -> String {
+    user.or(logname)
+        .or(username)
+        .unwrap_or_else(|| "user".to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -334,7 +350,14 @@ fn default_socket_path() -> PathBuf {
     PathBuf::from(format!("/tmp/repomon-{}.sock", current_user()))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(windows)]
+fn default_socket_path() -> PathBuf {
+    // Interpreted as a named-pipe name by `crate::transport` (already in canonical
+    // `\\.\pipe\` form, so it passes through `pipe_name_from_path` verbatim).
+    PathBuf::from(format!(r"\\.\pipe\repomon-{}", current_user()))
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
 fn default_socket_path() -> PathBuf {
     if let Ok(x) = std::env::var("XDG_RUNTIME_DIR") {
         if !x.is_empty() {
@@ -441,6 +464,26 @@ mod tests {
         assert!(!leftover_tmp, "a .tmp file was left behind after save");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn current_user_fallback_order() {
+        let s = |v: &str| Some(v.to_string());
+        assert_eq!(current_user_from(s("ali"), s("log"), s("win")), "ali");
+        assert_eq!(current_user_from(None, s("log"), s("win")), "log");
+        assert_eq!(current_user_from(None, None, s("win")), "win");
+        assert_eq!(current_user_from(None, None, None), "user");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_default_socket_path_is_a_pipe_name() {
+        let p = default_socket_path();
+        let s = p.to_string_lossy();
+        assert!(
+            s.starts_with(r"\\.\pipe\repomon-"),
+            "expected a \\\\.\\pipe\\repomon-<user> name, got {s}"
+        );
     }
 
     #[test]

--- a/crates/repomon-core/src/exec.rs
+++ b/crates/repomon-core/src/exec.rs
@@ -127,9 +127,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("shim.cmd"), "@echo off\r\n").unwrap();
         let path_var = std::env::join_paths([dir.path()]).unwrap();
-        assert_eq!(
-            find_in(&path_var, "shim"),
-            Some(dir.path().join("shim.cmd"))
+        // PATHEXT candidates carry the list's (upper)case; NTFS matches case-insensitively,
+        // so compare the same way instead of pinning the extension's case.
+        let found = find_in(&path_var, "shim").expect("shim.cmd is found via PATHEXT");
+        let want = dir.path().join("shim.cmd");
+        assert!(
+            found
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&want.to_string_lossy()),
+            "found {found:?}, want (case-insensitive) {want:?}"
         );
     }
 

--- a/crates/repomon-core/src/exec.rs
+++ b/crates/repomon-core/src/exec.rs
@@ -8,10 +8,52 @@ pub fn find_in_path(bin: &str) -> Option<PathBuf> {
     find_in(std::env::var_os("PATH")?.as_os_str(), bin)
 }
 
+#[cfg(not(windows))]
 fn find_in(path_var: &OsStr, bin: &str) -> Option<PathBuf> {
     std::env::split_paths(path_var)
         .map(|dir| dir.join(bin))
         .find(|cand| is_executable(cand))
+}
+
+/// Windows: executables are found by extension, per `PATHEXT` — `claude` is really
+/// `claude.cmd` (the npm shim), `git` is `git.exe`, `wt` is `wt.exe`. Each PATH entry is
+/// probed with every candidate name before moving on, so the first PATH entry that has the
+/// tool wins (matching the unix behavior and `CreateProcess` semantics).
+#[cfg(windows)]
+fn find_in(path_var: &OsStr, bin: &str) -> Option<PathBuf> {
+    let pathext = std::env::var("PATHEXT").ok().filter(|v| !v.is_empty());
+    let names = candidate_names(bin, pathext.as_deref().unwrap_or(DEFAULT_PATHEXT));
+    std::env::split_paths(path_var)
+        .flat_map(|dir| names.iter().map(move |name| dir.join(name)))
+        .find(|cand| is_executable(cand))
+}
+
+/// The stock Windows default, used when `PATHEXT` is unset/empty.
+#[cfg(any(windows, test))]
+const DEFAULT_PATHEXT: &str = ".COM;.EXE;.BAT;.CMD";
+
+/// The filenames to try for `bin` under a `PATHEXT` value, in order. A name that already
+/// carries an extension is tried as given first (like `CreateProcess`); an extensionless name
+/// tries each PATHEXT extension first and the bare name last (best-effort for extensionless
+/// scripts, and harmless because real Windows tools always match an extension earlier).
+/// Pure string logic so it is unit-testable on every OS.
+#[cfg(any(windows, test))]
+fn candidate_names(bin: &str, pathext: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let has_ext = std::path::Path::new(bin).extension().is_some();
+    if has_ext {
+        names.push(bin.to_string());
+    }
+    for ext in pathext.split(';') {
+        let ext = ext.trim();
+        if !ext.is_empty() {
+            names.push(format!("{bin}{ext}"));
+        }
+    }
+    if !has_ext {
+        names.push(bin.to_string());
+    }
+    names
 }
 
 #[cfg(unix)]
@@ -56,6 +98,39 @@ mod tests {
         std::fs::write(dir.path().join("plainfile"), "data").unwrap();
         let path_var = std::env::join_paths([dir.path()]).unwrap();
         assert_eq!(find_in(&path_var, "plainfile"), None);
+    }
+
+    #[test]
+    fn pathext_candidates_prefer_extensions_for_bare_names() {
+        assert_eq!(
+            candidate_names("claude", DEFAULT_PATHEXT),
+            vec![
+                "claude.COM",
+                "claude.EXE",
+                "claude.BAT",
+                "claude.CMD",
+                "claude"
+            ]
+        );
+        // An explicit extension is honored as given, first.
+        assert_eq!(
+            candidate_names("tool.exe", ".COM;.EXE"),
+            vec!["tool.exe", "tool.exe.COM", "tool.exe.EXE"]
+        );
+        // Empty PATHEXT segments are skipped.
+        assert_eq!(candidate_names("x", ".EXE;;"), vec!["x.EXE", "x"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_find_in_resolves_a_cmd_shim() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("shim.cmd"), "@echo off\r\n").unwrap();
+        let path_var = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(
+            find_in(&path_var, "shim"),
+            Some(dir.path().join("shim.cmd"))
+        );
     }
 
     #[test]

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod service;
 pub mod session;
 pub mod store;
 pub mod traits;
+pub mod transport;
 pub mod watch;
 
 pub use agent::{AgentMonitor, ClaudeMonitor, TmuxRuntime};

--- a/crates/repomon-core/src/transport.rs
+++ b/crates/repomon-core/src/transport.rs
@@ -1,0 +1,339 @@
+//! Portable local IPC: Unix domain sockets on unix, named pipes on Windows.
+//!
+//! Everything that used to talk `tokio::net::UnixListener`/`UnixStream` directly (the daemon's
+//! socket server, the shared [`crate::client::DaemonClient`], tests) goes through this module
+//! instead, so the JSON-RPC framing in [`crate::protocol`] runs unchanged over whichever
+//! transport the platform provides. Only the byte pipe differs per OS; the wire protocol is
+//! identical (and frozen — the iOS companion mirrors it).
+//!
+//! Endpoints are still configured as paths (`config::socket_path`). On unix that path is the
+//! socket file; on Windows it is interpreted as a named-pipe name (see
+//! [`pipe_name_from_path`]).
+
+use std::io;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// A resolved local IPC endpoint: a socket path on unix, a pipe name on Windows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Endpoint {
+    #[cfg(unix)]
+    Unix(std::path::PathBuf),
+    #[cfg(windows)]
+    Pipe(String),
+}
+
+impl Endpoint {
+    /// Interpret a configured "socket path" for this platform.
+    pub fn from_path(path: &Path) -> Self {
+        #[cfg(unix)]
+        {
+            Endpoint::Unix(path.to_path_buf())
+        }
+        #[cfg(windows)]
+        {
+            Endpoint::Pipe(pipe_name_from_path(path))
+        }
+    }
+}
+
+/// Map a configured "socket path" to a Windows named-pipe name.
+///
+/// A value that already names a pipe (`\\.\pipe\...`) is used verbatim — the default
+/// `config::default_socket_path()` on Windows produces exactly that. Anything else (say a
+/// unix-style `socket_path` override carried over in a shared config) is flattened into a pipe
+/// name: path separators and other non-name characters become `-`, and the `\\.\pipe\` prefix
+/// is prepended. Pure string logic so it is unit-testable on every OS.
+pub fn pipe_name_from_path(path: &Path) -> String {
+    const PIPE_PREFIX: &str = r"\\.\pipe\";
+    let s = path.to_string_lossy();
+    if s.starts_with(PIPE_PREFIX) {
+        return s.into_owned();
+    }
+    let flat: String = s
+        .chars()
+        .map(|c| match c {
+            '\\' | '/' | ':' | ' ' => '-',
+            other => other,
+        })
+        .collect();
+    format!("{PIPE_PREFIX}{}", flat.trim_matches('-'))
+}
+
+enum ListenerInner {
+    #[cfg(unix)]
+    Unix(tokio::net::UnixListener),
+    #[cfg(windows)]
+    Pipe {
+        name: String,
+        /// The pre-created pipe instance the next client will hit. Windows named pipes have no
+        /// single listening object: each accepted connection consumes one server instance, so
+        /// `accept` creates the following instance *before* handing the connected one out —
+        /// that way there is never a window with no instance for a client to reach.
+        next: Option<tokio::net::windows::named_pipe::NamedPipeServer>,
+    },
+}
+
+/// A bound local IPC listener. Obtain with [`listen`], then call [`IpcListener::accept`].
+pub struct IpcListener {
+    inner: ListenerInner,
+}
+
+/// Bind a local IPC listener at `endpoint`.
+///
+/// Unix: creates the parent directory and clears a stale socket file from a previous run
+/// before binding. Windows: creates the first pipe instance (exclusively — a second listener
+/// on the same name fails, mirroring the unix bind conflict) and rejects remote clients.
+pub async fn listen(endpoint: &Endpoint) -> io::Result<IpcListener> {
+    match endpoint {
+        #[cfg(unix)]
+        Endpoint::Unix(path) => {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if path.exists() {
+                let _ = std::fs::remove_file(path);
+            }
+            Ok(IpcListener {
+                inner: ListenerInner::Unix(tokio::net::UnixListener::bind(path)?),
+            })
+        }
+        #[cfg(windows)]
+        Endpoint::Pipe(name) => {
+            use tokio::net::windows::named_pipe::ServerOptions;
+            let first = ServerOptions::new()
+                .first_pipe_instance(true)
+                .reject_remote_clients(true)
+                .create(name)?;
+            Ok(IpcListener {
+                inner: ListenerInner::Pipe {
+                    name: name.clone(),
+                    next: Some(first),
+                },
+            })
+        }
+    }
+}
+
+impl IpcListener {
+    /// Wait for and return the next client connection.
+    pub async fn accept(&mut self) -> io::Result<IpcStream> {
+        match &mut self.inner {
+            #[cfg(unix)]
+            ListenerInner::Unix(listener) => {
+                let (stream, _addr) = listener.accept().await?;
+                Ok(IpcStream::Unix(stream))
+            }
+            #[cfg(windows)]
+            ListenerInner::Pipe { name, next } => {
+                use tokio::net::windows::named_pipe::ServerOptions;
+                let server = match next.take() {
+                    Some(server) => server,
+                    // The previous accept failed to pre-create an instance (e.g. a transient
+                    // resource error); retry here rather than being wedged forever.
+                    None => ServerOptions::new()
+                        .reject_remote_clients(true)
+                        .create(&*name)?,
+                };
+                server.connect().await?;
+                *next = ServerOptions::new()
+                    .reject_remote_clients(true)
+                    .create(&*name)
+                    .ok();
+                Ok(IpcStream::PipeServer(server))
+            }
+        }
+    }
+}
+
+/// Connect to a local IPC endpoint.
+///
+/// Windows: `ERROR_PIPE_BUSY` (every instance momentarily taken — the accept loop pre-creates
+/// the next instance, so this is a tiny race window) is retried briefly with backoff; other
+/// errors (notably "not found" while the daemon is still starting) surface immediately so
+/// callers' existing connect-retry loops behave exactly as they do on unix.
+pub async fn connect(endpoint: &Endpoint) -> io::Result<IpcStream> {
+    match endpoint {
+        #[cfg(unix)]
+        Endpoint::Unix(path) => Ok(IpcStream::Unix(
+            tokio::net::UnixStream::connect(path).await?,
+        )),
+        #[cfg(windows)]
+        Endpoint::Pipe(name) => {
+            use tokio::net::windows::named_pipe::ClientOptions;
+            const ERROR_PIPE_BUSY: i32 = 231;
+            let mut delay = std::time::Duration::from_millis(10);
+            let mut waited = std::time::Duration::ZERO;
+            const BUSY_CEILING: std::time::Duration = std::time::Duration::from_secs(2);
+            loop {
+                match ClientOptions::new().open(name) {
+                    Ok(client) => return Ok(IpcStream::PipeClient(client)),
+                    Err(e)
+                        if e.raw_os_error() == Some(ERROR_PIPE_BUSY) && waited < BUSY_CEILING =>
+                    {
+                        tokio::time::sleep(delay).await;
+                        waited += delay;
+                        delay = (delay * 2).min(std::time::Duration::from_millis(100));
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    }
+}
+
+/// A connected local IPC stream: `AsyncRead + AsyncWrite + Unpin + Send`, whatever the
+/// platform transport underneath. The `Duplex` variant is an in-memory pair for tests
+/// ([`IpcStream::pair`]), replacing the old `UnixStream::pair()`.
+pub enum IpcStream {
+    #[cfg(unix)]
+    Unix(tokio::net::UnixStream),
+    #[cfg(windows)]
+    PipeServer(tokio::net::windows::named_pipe::NamedPipeServer),
+    #[cfg(windows)]
+    PipeClient(tokio::net::windows::named_pipe::NamedPipeClient),
+    Duplex(tokio::io::DuplexStream),
+}
+
+impl IpcStream {
+    /// An in-memory connected pair (for tests), like `UnixStream::pair()` but portable.
+    pub fn pair() -> (IpcStream, IpcStream) {
+        let (a, b) = tokio::io::duplex(64 * 1024);
+        (IpcStream::Duplex(a), IpcStream::Duplex(b))
+    }
+}
+
+macro_rules! with_stream {
+    ($self:ident, $s:ident => $e:expr) => {
+        match Pin::get_mut($self) {
+            #[cfg(unix)]
+            IpcStream::Unix($s) => $e,
+            #[cfg(windows)]
+            IpcStream::PipeServer($s) => $e,
+            #[cfg(windows)]
+            IpcStream::PipeClient($s) => $e,
+            IpcStream::Duplex($s) => $e,
+        }
+    };
+}
+
+impl AsyncRead for IpcStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        with_stream!(self, s => Pin::new(s).poll_read(cx, buf))
+    }
+}
+
+impl AsyncWrite for IpcStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        with_stream!(self, s => Pin::new(s).poll_write(cx, buf))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        with_stream!(self, s => Pin::new(s).poll_flush(cx))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        with_stream!(self, s => Pin::new(s).poll_shutdown(cx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{read_frame, write_frame};
+
+    /// A unique per-test endpoint on whichever transport this platform uses.
+    fn test_endpoint(tag: &str) -> Endpoint {
+        #[cfg(unix)]
+        {
+            Endpoint::Unix(
+                std::env::temp_dir().join(format!("repomon-tr-{tag}-{}.sock", std::process::id())),
+            )
+        }
+        #[cfg(windows)]
+        {
+            Endpoint::Pipe(format!(r"\\.\pipe\repomon-tr-{tag}-{}", std::process::id()))
+        }
+    }
+
+    /// The core contract: a length-prefixed protocol frame round-trips over the real platform
+    /// transport (UDS here on unix, a named pipe on Windows CI).
+    #[tokio::test]
+    async fn round_trips_a_frame_over_the_platform_transport() {
+        let ep = test_endpoint("rt");
+        let mut listener = listen(&ep).await.unwrap();
+        let server = tokio::spawn(async move {
+            let mut s = listener.accept().await.unwrap();
+            let frame = read_frame(&mut s).await.unwrap().expect("a frame");
+            write_frame(&mut s, &frame).await.unwrap(); // echo it back
+        });
+
+        let mut client = connect(&ep).await.unwrap();
+        let payload = br#"{"jsonrpc":"2.0","method":"ping","id":1}"#;
+        write_frame(&mut client, payload).await.unwrap();
+        let echoed = read_frame(&mut client).await.unwrap().expect("echo");
+        assert_eq!(echoed, payload);
+        server.await.unwrap();
+    }
+
+    /// The listener must keep accepting: two clients in a row (this exercises the Windows
+    /// "pre-create the next pipe instance" path; on unix it is a plain double accept).
+    #[tokio::test]
+    async fn accepts_sequential_clients() {
+        let ep = test_endpoint("seq");
+        let mut listener = listen(&ep).await.unwrap();
+        let server = tokio::spawn(async move {
+            for i in 0..2u8 {
+                let mut s = listener.accept().await.unwrap();
+                write_frame(&mut s, &[b'0' + i]).await.unwrap();
+            }
+        });
+
+        for i in 0..2u8 {
+            let mut c = connect(&ep).await.unwrap();
+            let got = read_frame(&mut c).await.unwrap().expect("frame");
+            assert_eq!(got, vec![b'0' + i]);
+        }
+        server.await.unwrap();
+    }
+
+    /// The in-memory pair used by unit tests behaves like a connected socket.
+    #[tokio::test]
+    async fn round_trips_over_a_duplex_pair() {
+        let (mut a, mut b) = IpcStream::pair();
+        write_frame(&mut a, b"hello").await.unwrap();
+        let got = read_frame(&mut b).await.unwrap().expect("frame");
+        assert_eq!(got, b"hello");
+    }
+
+    /// Pipe-name mapping is pure string logic, verified on every OS.
+    #[test]
+    fn pipe_name_mapping() {
+        // A real pipe name passes through verbatim.
+        assert_eq!(
+            pipe_name_from_path(Path::new(r"\\.\pipe\repomon-ali")),
+            r"\\.\pipe\repomon-ali"
+        );
+        // A unix-style path is flattened into a name under \\.\pipe\.
+        assert_eq!(
+            pipe_name_from_path(Path::new("/tmp/repomon-ali.sock")),
+            r"\\.\pipe\tmp-repomon-ali.sock"
+        );
+        // Windows filesystem paths lose the drive colon and separators too.
+        assert_eq!(
+            pipe_name_from_path(Path::new(r"C:\Temp\repomon.sock")),
+            r"\\.\pipe\C--Temp-repomon.sock"
+        );
+    }
+}

--- a/crates/repomon-core/tests/client_reconnect.rs
+++ b/crates/repomon-core/tests/client_reconnect.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! Regression test for the "daemon connection closed" bug.
 //!
 //! The daemon reaps idle client connections after 120s (see `repomon-daemon` socket.rs). A
@@ -12,12 +9,12 @@ use std::time::Duration;
 
 use repomon_core::client::DaemonClient;
 use repomon_core::protocol::{Notification, Request, Response, read_frame, write_message};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use serde_json::json;
-use tokio::net::{UnixListener, UnixStream};
 
 /// Answer every request frame on `stream` with `Response::ok(id, "pong")` until the peer closes.
-async fn serve_pings(stream: UnixStream) {
-    let (mut rd, mut wr) = stream.into_split();
+async fn serve_pings(stream: IpcStream) {
+    let (mut rd, mut wr) = tokio::io::split(stream);
     while let Ok(Some(frame)) = read_frame(&mut rd).await {
         if let Ok(req) = serde_json::from_slice::<Request>(&frame) {
             let resp = Response::ok(req.id, json!("pong"));
@@ -32,21 +29,23 @@ async fn serve_pings(stream: UnixStream) {
 async fn call_reconnects_after_daemon_drops_connection() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("daemon.sock");
-    let listener = UnixListener::bind(&sock).unwrap();
+    let mut listener = transport::listen(&Endpoint::from_path(&sock))
+        .await
+        .unwrap();
 
     // Mock daemon: serve exactly one ping on the first connection, then drop it (the 120s reap).
     // A correct client reconnects, and the second connection is served normally.
     tokio::spawn(async move {
-        let (s1, _) = listener.accept().await.unwrap();
+        let s1 = listener.accept().await.unwrap();
         {
-            let (mut rd, mut wr) = s1.into_split();
+            let (mut rd, mut wr) = tokio::io::split(s1);
             if let Ok(Some(frame)) = read_frame(&mut rd).await {
                 let req: Request = serde_json::from_slice(&frame).unwrap();
                 let _ = write_message(&mut wr, &Response::ok(req.id, json!("pong"))).await;
             }
             // s1 is dropped here -> the client's connection closes, simulating the reap.
         }
-        let (s2, _) = listener.accept().await.unwrap();
+        let s2 = listener.accept().await.unwrap();
         serve_pings(s2).await;
     });
 
@@ -71,8 +70,8 @@ async fn call_reconnects_after_daemon_drops_connection() {
 /// Answer every request by id, and if the request is `subscribe`, also push one
 /// `event.test` notification — standing in for the daemon's per-connection `forwarding` flag
 /// (only connections that sent `subscribe` get events; see `repomon-daemon` socket.rs).
-async fn serve_and_notify_on_subscribe(stream: UnixStream) {
-    let (mut rd, mut wr) = stream.into_split();
+async fn serve_and_notify_on_subscribe(stream: IpcStream) {
+    let (mut rd, mut wr) = tokio::io::split(stream);
     while let Ok(Some(frame)) = read_frame(&mut rd).await {
         let Ok(req) = serde_json::from_slice::<Request>(&frame) else {
             continue;
@@ -96,15 +95,17 @@ async fn serve_and_notify_on_subscribe(stream: UnixStream) {
 async fn subscribe_survives_reconnect() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("daemon.sock");
-    let listener = UnixListener::bind(&sock).unwrap();
+    let mut listener = transport::listen(&Endpoint::from_path(&sock))
+        .await
+        .unwrap();
 
     // Mock daemon: connection 1 acks the `subscribe` call (like the real daemon) and is then
     // dropped, simulating the 120s reap. Connection 2 is where the client must replay
     // `subscribe` on its own — the daemon only forwards events on connections that asked.
     tokio::spawn(async move {
-        let (s1, _) = listener.accept().await.unwrap();
+        let s1 = listener.accept().await.unwrap();
         {
-            let (mut rd, mut wr) = s1.into_split();
+            let (mut rd, mut wr) = tokio::io::split(s1);
             if let Ok(Some(frame)) = read_frame(&mut rd).await {
                 let req: Request = serde_json::from_slice(&frame).unwrap();
                 assert_eq!(req.method, "subscribe");
@@ -112,7 +113,7 @@ async fn subscribe_survives_reconnect() {
             }
             // s1 is dropped here -> the client's connection closes, simulating the reap.
         }
-        let (s2, _) = listener.accept().await.unwrap();
+        let s2 = listener.accept().await.unwrap();
         serve_and_notify_on_subscribe(s2).await;
     });
 

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -10,7 +10,7 @@ use repomon_core::model::{
     CreateLaneParams, Lane, RemoteDevice, RepoId, TimeRange,
 };
 use repomon_core::protocol::RpcError;
-use repomon_core::{Indexer, TmuxRuntime, analytics, session};
+use repomon_core::{Indexer, TmuxRuntime, analytics, config, session};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
@@ -1908,10 +1908,8 @@ pub async fn dispatch(
                     None,
                 ),
             };
-            // cwd = $HOME, so repomind starts from the user's home rather than the daemon's cwd.
-            let home = std::env::var("HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| PathBuf::from("/"));
+            // cwd = the user's home, so repomind starts from there rather than the daemon's cwd.
+            let home = config::home();
             let tmux = ctx.tmux.clone();
             tokio::task::spawn_blocking(move || {
                 tmux.spawn_named(ORCHESTRATOR_WINDOW, &home, &command)
@@ -2761,13 +2759,10 @@ fn vanish_reason(
     }
 }
 
-/// List the subdirectories of `start` (default: $HOME) for the repo browser, marking which
-/// are git repos and which are already registered.
+/// List the subdirectories of `start` (default: the user's home) for the repo browser, marking
+/// which are git repos and which are already registered.
 fn browse_dir(start: Option<PathBuf>, added: &std::collections::HashSet<PathBuf>) -> BrowseResult {
-    let path = start
-        .filter(|p| p.is_dir())
-        .or_else(|| std::env::var("HOME").ok().map(PathBuf::from))
-        .unwrap_or_else(|| PathBuf::from("/"));
+    let path = start.filter(|p| p.is_dir()).unwrap_or_else(config::home);
     let path = path.canonicalize().unwrap_or(path);
     let parent = path.parent().map(Path::to_path_buf);
 
@@ -3089,11 +3084,19 @@ fn reuse_per_path_on_failure<T: Clone>(
     }
 }
 
+/// Windows: there is no ps/lsof//proc probe yet — the session-backend track gives hosts an
+/// authoritative child-alive answer. `None` means "probe unavailable, don't filter", the same
+/// safe degradation the unix arms use when `ps` fails.
+#[cfg(windows)]
+fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
+    None
+}
+
 /// How many live `claude` CLI processes have each working directory. claude doesn't hold its
 /// transcript open, but its cwd is the worktree it runs in — so the count per worktree bounds
 /// how many of that worktree's sessions are actually running. `None` if the probe couldn't
 /// run (then we don't filter); `Some({})` means no claude is running.
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
     use std::process::Command;
     // Enumerate `claude` processes via `ps`, matching the executable basename. `pgrep -x claude`
@@ -3427,8 +3430,7 @@ fn pick_orchestrator_transcript_in(
 pub(crate) fn pick_orchestrator_transcript(
     session_id: Option<&str>,
 ) -> Option<agent::TranscriptSummary> {
-    let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
-    pick_orchestrator_transcript_in(&home, session_id)
+    pick_orchestrator_transcript_in(&config::home(), session_id)
 }
 
 /// Drop a stale orchestrator session: if we think one is running but its tmux window is gone (killed

--- a/crates/repomon-daemon/src/socket.rs
+++ b/crates/repomon-daemon/src/socket.rs
@@ -1,4 +1,5 @@
-//! The Unix-domain-socket JSON-RPC server.
+//! The local-IPC JSON-RPC server (a Unix domain socket on unix, a named pipe on Windows —
+//! see `repomon_core::transport`).
 //!
 //! Each connection runs a dedicated reader task (so `read_frame`, which isn't
 //! cancel-safe, always runs to completion) that feeds incoming frames over an mpsc. The
@@ -7,62 +8,35 @@
 
 use std::path::Path;
 use std::sync::Arc;
-#[cfg(unix)]
 use std::time::Duration;
 
-#[cfg(unix)]
 use repomon_core::protocol::{self, Request, Response, RpcError};
-#[cfg(unix)]
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use serde_json::Value;
-#[cfg(unix)]
-use tokio::net::{UnixListener, UnixStream};
-#[cfg(unix)]
 use tokio::sync::broadcast::error::RecvError;
-#[cfg(unix)]
 use tokio::sync::mpsc;
 
-use crate::Ctx;
-#[cfg(unix)]
-use crate::rpc;
+use crate::{Ctx, rpc};
 
 /// How long the reader will wait on a silent socket before tearing itself down. A half-open client
 /// (gone away but still holding the fd) otherwise parks the reader task forever, leaking one task
 /// per reconnect. Generous — well past the TUI's 1s `lane.list` poll, so a healthy idle client is
 /// never dropped; the connection task simply re-accepts on the next request.
-#[cfg(unix)]
 const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Windows stub until the named-pipe transport lands (next PR in this track): the local IPC
-/// server cannot bind yet, so it fails with a clear error instead of failing to compile.
-#[cfg(windows)]
-pub async fn serve(_ctx: Arc<Ctx>, socket_path: &Path) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        format!(
-            "serving local IPC at {} is not yet supported on Windows (the named-pipe transport lands in a follow-up PR)",
-            socket_path.display()
-        ),
-    ))
-}
-
-/// Bind the socket and serve until shutdown is requested.
-#[cfg(unix)]
+/// Bind the local IPC endpoint and serve until shutdown is requested. `socket_path` is the
+/// socket file on unix and is interpreted as a named-pipe name on Windows (stale-file cleanup
+/// and parent-dir creation happen inside `transport::listen`; pipes need neither).
 pub async fn serve(ctx: Arc<Ctx>, socket_path: &Path) -> std::io::Result<()> {
-    if let Some(parent) = socket_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    // Clear a stale socket from a previous run.
-    if socket_path.exists() {
-        let _ = std::fs::remove_file(socket_path);
-    }
-    let listener = UnixListener::bind(socket_path)?;
+    let endpoint = Endpoint::from_path(socket_path);
+    let mut listener = transport::listen(&endpoint).await?;
     tracing::info!("listening on {}", socket_path.display());
 
     loop {
         tokio::select! {
             _ = ctx.shutdown.notified() => break,
             accepted = listener.accept() => match accepted {
-                Ok((stream, _addr)) => {
+                Ok(stream) => {
                     let ctx = ctx.clone();
                     tokio::spawn(async move { handle_conn(ctx, stream).await });
                 }
@@ -71,13 +45,14 @@ pub async fn serve(ctx: Arc<Ctx>, socket_path: &Path) -> std::io::Result<()> {
         }
     }
 
+    // Remove the socket file so the next daemon start binds cleanly (pipes vanish on close).
+    #[cfg(unix)]
     let _ = std::fs::remove_file(socket_path);
     Ok(())
 }
 
-#[cfg(unix)]
-async fn handle_conn(ctx: Arc<Ctx>, stream: UnixStream) {
-    let (mut read_half, mut write_half) = stream.into_split();
+async fn handle_conn(ctx: Arc<Ctx>, stream: IpcStream) {
+    let (mut read_half, mut write_half) = tokio::io::split(stream);
 
     // Reader task: read_frame to completion, hand frames to the connection task.
     let (in_tx, mut in_rx) = mpsc::channel::<Vec<u8>>(128);

--- a/crates/repomon-daemon/tests/integration.rs
+++ b/crates/repomon-daemon/tests/integration.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! End-to-end: start the daemon on a temp socket and exercise the JSON-RPC surface.
 
 use std::path::Path;
@@ -8,10 +5,22 @@ use std::process::Command;
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;
-use tokio::net::UnixStream;
+
+/// Connect to the daemon's IPC endpoint, retrying while it binds. (A socket-file existence
+/// check doesn't port: Windows named pipes have no filesystem presence.)
+async fn connect_retry(sock: &std::path::Path) -> IpcStream {
+    for _ in 0..100 {
+        if let Ok(s) = transport::connect(&Endpoint::from_path(sock)).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon endpoint {} never came up", sock.display());
+}
 
 fn git(dir: &Path, args: &[&str]) {
     let ok = Command::new("git")
@@ -49,7 +58,7 @@ fn git_dated(dir: &Path, args: &[&str], date: &str) {
 }
 
 async fn call(
-    stream: &mut UnixStream,
+    stream: &mut IpcStream,
     id: u64,
     method: &str,
     params: Option<serde_json::Value>,
@@ -78,14 +87,7 @@ async fn daemon_serves_repo_and_lane_methods() {
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
 
-    // Wait for the socket to come up.
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // Empty fleet to start.
     let r = call(&mut stream, 1, "repo.list", None).await;
@@ -152,13 +154,7 @@ async fn daemon_spawns_and_drives_an_agent() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // Register a repo and grab its lane.
     let repo_dir = tempfile::tempdir().unwrap();
@@ -301,13 +297,7 @@ async fn streams_agent_output_for_visible_lanes() {
     // The output streamer is what we're testing.
     tokio::spawn(repomon_daemon::stream_output(ctx.clone()));
 
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // Do all request/response setup BEFORE subscribing, so responses aren't interleaved
     // with pushed event notifications.
@@ -426,13 +416,7 @@ async fn dashboard_timeline_sessions_search() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     let from = (chrono::Utc::now() - chrono::Duration::days(1)).to_rfc3339();
     let to = chrono::Utc::now().to_rfc3339();
@@ -504,13 +488,7 @@ async fn fs_browse_marks_repos_and_added() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // root/{myrepo(.git), plain, .hidden}
     let root = tempfile::tempdir().unwrap();
@@ -586,13 +564,7 @@ async fn agent_detect_lists_builtins_and_customs() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     let r = call(&mut stream, 1, "agent.detect", None).await;
     let choices = r.result.unwrap();
@@ -640,13 +612,7 @@ async fn agent_spawn_uses_custom_command() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
@@ -706,13 +672,7 @@ async fn agent_manager_add_set_default_and_remove() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // Add a custom agent → it appears in detect, marked custom, and is persisted to disk.
     let r = call(
@@ -836,13 +796,7 @@ async fn commit_recent_returns_latest_even_when_none_today() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // A repo whose only commits are from last year — nothing "today".
     let repo_dir = tempfile::tempdir().unwrap();
@@ -912,13 +866,7 @@ async fn orchestrator_input_errors_loudly_when_not_running() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // Typing to a dead orchestrator must fail loudly instead of silently no-op'ing at the tmux
     // layer.
@@ -964,13 +912,7 @@ async fn lane_diff_reports_commits_ahead_and_uncommitted_stat() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // A repo with one commit on main.
     let repo_dir = tempfile::tempdir().unwrap();

--- a/crates/repomon-daemon/tests/mcp_stdio.rs
+++ b/crates/repomon-daemon/tests/mcp_stdio.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! End-to-end: a real `repomond mcp` child process speaking MCP over stdio against a real
 //! in-process daemon. This is the orchestrator's actual transport, so it's the one place we
 //! exercise the whole chain: daemon socket -> `repomond mcp` -> newline-delimited JSON-RPC.
@@ -11,12 +8,24 @@ use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use repomon_core::{Config, Store};
 use repomon_daemon::{Ctx, serve};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+
+/// Connect to the daemon's IPC endpoint, retrying while it binds. (A socket-file existence
+/// check doesn't port: Windows named pipes have no filesystem presence.)
+async fn connect_retry(sock: &std::path::Path) -> IpcStream {
+    for _ in 0..100 {
+        if let Ok(s) = transport::connect(&Endpoint::from_path(sock)).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon endpoint {} never came up", sock.display());
+}
 
 /// Every read (daemon socket or MCP child) is guarded by this — a hang must fail the test, not
 /// wedge CI.
@@ -41,7 +50,7 @@ fn git(dir: &Path, args: &[&str]) {
 /// Call the daemon directly over its length-prefixed JSON-RPC socket — same helper as
 /// tests/integration.rs's `call()`. Used to seed a repo before the MCP child ever connects.
 async fn daemon_call(
-    stream: &mut UnixStream,
+    stream: &mut IpcStream,
     id: u64,
     method: &str,
     params: Option<Value>,
@@ -58,7 +67,7 @@ async fn daemon_call(
 
 /// Boot an in-process daemon on a short temp socket path (macOS caps UDS paths at ~104 chars),
 /// exactly like tests/integration.rs, and return a connected control stream for seeding state.
-async fn boot_daemon(tag: &str) -> (PathBuf, UnixStream) {
+async fn boot_daemon(tag: &str) -> (PathBuf, IpcStream) {
     let store = Store::open_in_memory().unwrap();
     let ctx = Ctx::new(store, Config::default(), None);
 
@@ -69,18 +78,12 @@ async fn boot_daemon(tag: &str) -> (PathBuf, UnixStream) {
     let server_sock = sock.clone();
     tokio::spawn(async move { serve(ctx, &server_sock).await });
 
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let stream = UnixStream::connect(&sock).await.expect("connect to daemon");
+    let stream = connect_retry(&sock).await;
     (sock, stream)
 }
 
 /// Register a repo with one commit and return its (tempdir, main lane id).
-async fn seed_repo_lane(stream: &mut UnixStream) -> (tempfile::TempDir, i64) {
+async fn seed_repo_lane(stream: &mut IpcStream) -> (tempfile::TempDir, i64) {
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
     git(repo_dir.path(), &["commit", "--allow-empty", "-m", "init"]);

--- a/crates/repomon-daemon/tests/orchestrator.rs
+++ b/crates/repomon-daemon/tests/orchestrator.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! Orchestrator lifecycle: a genuine `orchestrator.start` (no window pre-exists) must record the
 //! requested autonomy on the session; a tmux window named `orchestrator` that survives a daemon
 //! (re)start must be adopted by `orchestrator.start` rather than duplicated, with its autonomy
@@ -13,13 +10,25 @@ use std::process::Command;
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;
-use tokio::net::UnixStream;
+
+/// Connect to the daemon's IPC endpoint, retrying while it binds. (A socket-file existence
+/// check doesn't port: Windows named pipes have no filesystem presence.)
+async fn connect_retry(sock: &std::path::Path) -> IpcStream {
+    for _ in 0..100 {
+        if let Ok(s) = transport::connect(&Endpoint::from_path(sock)).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon endpoint {} never came up", sock.display());
+}
 
 async fn call(
-    stream: &mut UnixStream,
+    stream: &mut IpcStream,
     id: u64,
     method: &str,
     params: Option<serde_json::Value>,
@@ -60,13 +69,7 @@ async fn orchestrator_adopts_a_surviving_window() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // A genuine `orchestrator.start` below writes its `--mcp-config` file under
     // `config::config_dir()`; redirect that to a tempdir so the test doesn't touch the

--- a/crates/repomon-daemon/tests/orchestrator_codex.rs
+++ b/crates/repomon-daemon/tests/orchestrator_codex.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! The codex orchestrator backend, exercised through the daemon's own RPC surface: a start with
 //! `agent: "codex"` must record the codex backend with no session id (codex can't pin one),
 //! `orchestrator.transcript` must read as an empty chat (codex's on-disk session format is not
@@ -15,13 +12,25 @@ use std::process::Command;
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;
-use tokio::net::UnixStream;
+
+/// Connect to the daemon's IPC endpoint, retrying while it binds. (A socket-file existence
+/// check doesn't port: Windows named pipes have no filesystem presence.)
+async fn connect_retry(sock: &std::path::Path) -> IpcStream {
+    for _ in 0..100 {
+        if let Ok(s) = transport::connect(&Endpoint::from_path(sock)).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon endpoint {} never came up", sock.display());
+}
 
 async fn call(
-    stream: &mut UnixStream,
+    stream: &mut IpcStream,
     id: u64,
     method: &str,
     params: Option<serde_json::Value>,
@@ -58,17 +67,11 @@ async fn codex_backend_degrades_and_mcpless_agents_are_rejected() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
     let cfg_home = tempfile::tempdir().expect("tempdir");
     unsafe {
         std::env::set_var("XDG_CONFIG_HOME", cfg_home.path());
     }
-    let mut stream = UnixStream::connect(&sock).await.expect("connect");
+    let mut stream = connect_retry(&sock).await;
 
     // An agent with no MCP client can't drive the fleet: loud invalid_params, nothing spawned.
     let r = call(

--- a/crates/repomon-daemon/tests/orchestrator_concurrent.rs
+++ b/crates/repomon-daemon/tests/orchestrator_concurrent.rs
@@ -1,6 +1,3 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! Two `orchestrator.start` calls racing on separate connections must resolve to a single
 //! orchestrator: one spawn, both responses describing the same session. Before the handler held
 //! the session lock across its check → spawn → record sequence, the second caller could observe
@@ -14,13 +11,25 @@ use std::process::Command;
 use std::time::Duration;
 
 use repomon_core::protocol::{self, Request, Response};
+use repomon_core::transport::{self, Endpoint, IpcStream};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
 use serde_json::json;
-use tokio::net::UnixStream;
+
+/// Connect to the daemon's IPC endpoint, retrying while it binds. (A socket-file existence
+/// check doesn't port: Windows named pipes have no filesystem presence.)
+async fn connect_retry(sock: &std::path::Path) -> IpcStream {
+    for _ in 0..100 {
+        if let Ok(s) = transport::connect(&Endpoint::from_path(sock)).await {
+            return s;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon endpoint {} never came up", sock.display());
+}
 
 async fn call(
-    stream: &mut UnixStream,
+    stream: &mut IpcStream,
     id: u64,
     method: &str,
     params: Option<serde_json::Value>,
@@ -59,13 +68,6 @@ async fn concurrent_starts_spawn_exactly_one_orchestrator() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-
     // Redirect the `--mcp-config` write away from the developer's real `~/.config/repomon`.
     let cfg_home = tempfile::tempdir().expect("tempdir");
     unsafe {
@@ -84,8 +86,8 @@ async fn concurrent_starts_spawn_exactly_one_orchestrator() {
         );
     }
 
-    let mut a = UnixStream::connect(&sock).await.expect("connect a");
-    let mut b = UnixStream::connect(&sock).await.expect("connect b");
+    let mut a = connect_retry(&sock).await;
+    let mut b = connect_retry(&sock).await;
     let params = json!({ "agent": "slowpoke", "autonomy": "supervised" });
     let (ra, rb) = tokio::join!(
         call(&mut a, 1, "orchestrator.start", Some(params.clone())),

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -4764,8 +4764,12 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
     enable_bracketed_paste();
     // Log panics to a file before the terminal is restored (which would otherwise scroll the
     // message off-screen, leaving a crash undiagnosable). Chains to ratatui's restore hook.
+    // Lives in the portable log dir (`<data_dir>/logs`), not /tmp, which Windows lacks.
     {
         let prev = std::panic::take_hook();
+        let log_dir = repomon_core::service::log_dir();
+        let _ = std::fs::create_dir_all(&log_dir);
+        let panic_log = log_dir.join("repomon-panic.log");
         std::panic::set_hook(Box::new(move |info| {
             let loc = info
                 .location()
@@ -4773,7 +4777,7 @@ pub async fn run(client: DaemonClient, theme: Theme) -> Result<Option<PathBuf>> 
                 .unwrap_or_default();
             let bt = std::backtrace::Backtrace::force_capture();
             let _ = std::fs::write(
-                "/tmp/repomon-panic.log",
+                &panic_log,
                 format!("repomon panic at {loc}\n{info}\n\nbacktrace:\n{bt}\n"),
             );
             prev(info);
@@ -5821,14 +5825,15 @@ mod tests {
     /// `apply_orchestrator_status` doesn't touch the network — it just needs *a* connected
     /// `DaemonClient` to build an `App` around (`App::new` has no other constructor). A listener
     /// that accepts once and goes quiet is enough; no daemon RPC is exercised.
-    /// Unix-only until the client is generic over the IPC transport (next PR in this track).
-    #[cfg(unix)]
     async fn app_with_dummy_client() -> App {
+        use repomon_core::transport::{self, Endpoint};
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("d.sock");
-        let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+        let mut listener = transport::listen(&Endpoint::from_path(&sock))
+            .await
+            .unwrap();
         tokio::spawn(async move {
-            let _ = listener.accept().await;
+            let _stream = listener.accept().await;
             // Keep the accepted stream alive for the test's duration instead of dropping it
             // immediately, so the client doesn't see an instant EOF/reconnect churn.
             std::future::pending::<()>().await;
@@ -5837,7 +5842,6 @@ mod tests {
         App::new(client)
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn apply_orchestrator_status_parses_attention_and_headline() {
         let mut app = app_with_dummy_client().await;
@@ -5886,7 +5890,6 @@ mod tests {
         assert_eq!(app.orch_attention, None);
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn orchestrator_attention_edge_is_suppressed_by_view_and_settings() {
         // Deliberately never flips both `notify_enabled` and `notify_needs_you` on together here:
@@ -5929,7 +5932,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn orchestrator_popup_is_seeded_not_fired_on_first_application() {
         // Cold start: repomind is already awaiting attention (e.g. it raised a permission dialog
@@ -5971,8 +5973,6 @@ mod tests {
 
     /// A hand-built lane for cursor/routing tests — deserialized so the `oid_hex` head field
     /// doesn't need a `gix` literal. No daemon involved; tests mutate `agent_sessions` directly.
-    /// Unix-only with its only consumer (`app_on_lane_7`) until the transport PR lands.
-    #[cfg(unix)]
     fn test_lane(id: i64) -> Lane {
         serde_json::from_value(json!({
             "id": id,
@@ -5994,8 +5994,6 @@ mod tests {
 
     /// An app looking at one lane whose first agent runs in `lane-7` — the state right before
     /// a second agent is spawned. Row 0 is the pinned repomind row, so `selected = 1`.
-    /// Unix-only until the client is generic over the IPC transport (next PR in this track).
-    #[cfg(unix)]
     async fn app_on_lane_7() -> App {
         let mut app = app_with_dummy_client().await;
         let mut lane = test_lane(7);
@@ -6006,7 +6004,6 @@ mod tests {
         app
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn typing_right_after_spawn_targets_the_new_window() {
         let mut app = app_on_lane_7().await;
@@ -6026,7 +6023,6 @@ mod tests {
         assert_eq!(app.selected_window().as_deref(), Some("lane-7"));
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn spawn_focus_intent_survives_a_typing_burst_then_lands_on_the_new_agent() {
         let mut app = app_on_lane_7().await;
@@ -6052,7 +6048,6 @@ mod tests {
         assert_eq!(app.selected_window().as_deref(), Some("lane-7-2"));
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn spawn_focus_intent_expires_only_after_sustained_refreshes() {
         let mut app = app_on_lane_7().await;
@@ -6075,7 +6070,6 @@ mod tests {
         assert_eq!(app.selected_window().as_deref(), Some("lane-7"));
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn tab_during_the_spawn_gap_cancels_the_focus_intent() {
         let mut app = app_on_lane_7().await;

--- a/crates/repomon-tui/src/lib.rs
+++ b/crates/repomon-tui/src/lib.rs
@@ -131,6 +131,15 @@ fn spawn_daemon(socket: &Path) -> Result<()> {
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
     }
+    // Windows twin: detach from the console and its Ctrl-C group so closing the terminal
+    // (or Ctrl-C in it) doesn't take the daemon down with it.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
     cmd.spawn()
         .with_context(|| format!("starting daemon `{}`", program.display()))?;
     Ok(())
@@ -186,7 +195,10 @@ async fn start_embedded(config: &Config) -> Result<(PathBuf, EmbeddedGuard)> {
     let db = config::db_path();
     let store = Store::open(&db).with_context(|| format!("opening store at {}", db.display()))?;
     let ctx = Ctx::new(store, config.clone(), Some(db));
+    #[cfg(unix)]
     let socket = std::env::temp_dir().join(format!("repomon-embedded-{}.sock", std::process::id()));
+    #[cfg(windows)]
+    let socket = PathBuf::from(format!(r"\\.\pipe\repomon-embedded-{}", std::process::id()));
 
     let mut watcher = Watcher::new().ok();
     if let Some(w) = watcher.as_mut() {

--- a/crates/repomon-tui/tests/tui.rs
+++ b/crates/repomon-tui/tests/tui.rs
@@ -1,16 +1,11 @@
-//! Unix-only until the daemon/client speak the portable IPC transport (next PR in this track).
-#![cfg(unix)]
-
 //! End-to-end TUI test: embedded daemon -> client -> App -> rendered Fleet frame.
 
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
 
 use repomon_core::{Config, Store};
 use repomon_daemon::{Ctx, serve};
 use repomon_tui::app::App;
-use repomon_tui::client::DaemonClient;
 use repomon_tui::render_to_string;
 use serde_json::json;
 
@@ -80,13 +75,9 @@ async fn waiting_badges_distinguish_attention() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let client = DaemonClient::connect(&sock).await.expect("connect");
+    let client = repomon_tui::connect_with_retry(&sock, 100)
+        .await
+        .expect("connect");
 
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
@@ -255,13 +246,9 @@ async fn peek_popup_shows_the_dialog_and_queue() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let client = DaemonClient::connect(&sock).await.expect("connect");
+    let client = repomon_tui::connect_with_retry(&sock, 100)
+        .await
+        .expect("connect");
 
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
@@ -351,13 +338,9 @@ async fn grid_tiles_plain_shell_terminals() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let client = DaemonClient::connect(&sock).await.expect("connect");
+    let client = repomon_tui::connect_with_retry(&sock, 100)
+        .await
+        .expect("connect");
 
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
@@ -428,13 +411,9 @@ async fn focus_renders_the_embedded_emulator() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let client = DaemonClient::connect(&sock).await.expect("connect");
+    let client = repomon_tui::connect_with_retry(&sock, 100)
+        .await
+        .expect("connect");
 
     let repo_dir = tempfile::tempdir().unwrap();
     git(repo_dir.path(), &["init", "-b", "main"]);
@@ -496,14 +475,9 @@ async fn renders_fleet_with_a_registered_repo() {
         let sock = sock.clone();
         tokio::spawn(async move { serve(ctx, &sock).await })
     };
-    for _ in 0..100 {
-        if sock.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-
-    let client = DaemonClient::connect(&sock).await.expect("connect");
+    let client = repomon_tui::connect_with_retry(&sock, 100)
+        .await
+        .expect("connect");
 
     // Register a repo through the daemon.
     let repo_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Second (and final) PR of Track A. **Stacked on #67 (`ci/windows-ci-leg`) and merges second** - after #67 lands, retarget/rebase this onto main.

### IPC transport abstraction
- New `repomon_core::transport`: `Endpoint`, `listen`/`connect`, `IpcListener`, `IpcStream` (AsyncRead+AsyncWrite+Unpin+Send). Unix domain sockets on unix; `tokio::net::windows::named_pipe` on Windows at `\\.\pipe\repomon-<user>` (`first_pipe_instance` + `reject_remote_clients`, next instance pre-created before handing out an accepted one, ERROR_PIPE_BUSY connect retry). Round-trip framed-protocol unit tests run per-platform (the named-pipe test exercises real pipes on the windows-latest leg), plus an in-memory `IpcStream::pair()` (tokio duplex) replacing `UnixStream::pair()` in tests.
- `socket.rs::serve`/`handle_conn`, `DaemonClient` connect/reconnect, and the embedded daemon (`\\.\pipe\repomon-embedded-<pid>`) all ride the transport; the Windows stubs from #67 are removed. MCP needed no change (it uses `DaemonClient`).
- All socket-based integration tests (daemon integration/orchestrator*/mcp_stdio, core client tests, tui e2e) are ported to the transport and un-gated - they now run on all three CI legs (tmux-dependent ones keep self-skipping via `TmuxRuntime::available()`).

### Portability fixes
- `config.rs`: `#[cfg(windows)] default_socket_path()` pipe name; `current_user()` falls back `USER` -> `LOGNAME` -> `USERNAME` (pure fn + tests); `config::home()` is now pub.
- `rpc.rs`: three direct `$HOME` reads -> `config::home()`; ps/lsof probe cfg tightened to `all(unix, not(linux))` with a `#[cfg(windows)]` `None` stub (Track I wires the real backend-based liveness).
- TUI: panic log -> `<data_dir>/logs/repomon-panic.log`; `spawn_daemon` detaches with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows.
- `exec.rs`: PATHEXT-aware lookup on Windows (finds `claude.cmd`, `git.exe`, `wt.exe`); candidate ordering is pure and unit-tested on every OS.

Zero behavior change on macOS/Linux; the JSON-RPC wire protocol is untouched (transport only).

## Merge notes (integrator)
- Merge #67 first, then this. `Cargo.lock` conflicts with parallel Wave-1 PRs are expected; resolve at integration.
- Deferred (flagged for Track C/I security pass): explicit per-user DACL on the daemon pipe. `reject_remote_clients` is set; the default pipe DACL denies write to other users, but an explicit `SECURITY_ATTRIBUTES` DACL should land with the host-pipe security work where it can be tested on a real Windows box.
- `tui/src/lib.rs` + `tui/src/cli.rs` diffs kept minimal (Track B/D4 conflict hotspots): lib.rs gains only the creation-flags block + the cfg'd embedded pipe path; cli.rs is untouched by this PR (its getrandom change landed in #67).

## Test plan
- macOS gate: fmt --check, clippy -D warnings, `cargo test --workspace --locked` all green (369 tests across the workspace).
- Windows: `cargo xwin clippy --workspace --all-targets --target x86_64-pc-windows-msvc -- -D warnings` clean locally; windows-latest leg on this PR runs the ported integration tests over real named pipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
