### PR TITLE
feat(core): WindowsBackend — host-process session backend (Track I)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "directories",
  "getrandom 0.3.4",
@@ -2604,6 +2605,7 @@ dependencies = [
  "globset",
  "notify",
  "notify-debouncer-full",
+ "repomon-host",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2612,6 +2614,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/repomon-core/Cargo.toml
+++ b/crates/repomon-core/Cargo.toml
@@ -26,5 +26,16 @@ notify = { workspace = true }
 notify-debouncer-full = { workspace = true }
 globset = { workspace = true }
 
+# The Windows session backend talks to per-agent host processes; the host crate carries the
+# frozen wire types (protocol/codec/registry) and the per-user pipe DACL the daemon's own
+# IPC pipe reuses. windows-sys is for CancelSynchronousIo (byte-stream reader shutdown).
+[target.'cfg(windows)'.dependencies]
+repomon-host = { path = "../repomon-host" }
+base64 = { workspace = true }
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_IO",
+] }
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/repomon-core/src/agent/backend.rs
+++ b/crates/repomon-core/src/agent/backend.rs
@@ -220,6 +220,15 @@ pub trait SessionBackend: Send + Sync {
     /// whole server — is already gone.
     fn close_byte_stream(&self, window: &str) -> Result<()>;
 
+    /// How many live Claude CLI processes have each working directory, when the backend has
+    /// an authoritative view of its agent processes (the Windows hosts *own* their children).
+    /// `None` means "no view here — use the platform process probe instead", which is what
+    /// tmux answers: on unix the daemon scans ps/lsof//proc itself, catching external
+    /// sessions too. Used by the daemon's liveness probe (`rpc::live_cwds_cached`).
+    fn live_agent_cwds(&self) -> Option<std::collections::HashMap<PathBuf, usize>> {
+        None
+    }
+
     // ---- provided helpers (backend-agnostic, built on `list_windows` + the shared lane/window
     // naming convention, which is identical across backends) ----
 
@@ -259,5 +268,13 @@ mod tests {
         assert_eq!(CaptureOpts::visible().last_lines, None);
         assert_eq!(CaptureOpts::last(45).last_lines, Some(45));
         assert_eq!(CaptureOpts::default(), CaptureOpts::visible());
+    }
+
+    #[test]
+    fn live_agent_cwds_defaults_to_probe_unavailable() {
+        // Backends without an authoritative process view (tmux) answer `None`, which the
+        // daemon's liveness probe already treats as "don't filter" — the safe degradation.
+        let rt = TmuxRuntime::new("repomon-live-cwds-test");
+        assert!(rt.live_agent_cwds().is_none());
     }
 }

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -31,9 +31,9 @@ pub use backend::{
 pub use claude::TranscriptSummary;
 pub use limit::{LimitMenu, UsageLimit, detect_usage_limit, menu_select_keys};
 pub use tmux::{TmuxRuntime, shell_quote};
+pub use usage::{AccountUsage, UsageReport, UsageWindow, parse_codex_status, parse_usage};
 #[cfg(windows)]
 pub use windows::WindowsBackend;
-pub use usage::{AccountUsage, UsageReport, UsageWindow, parse_codex_status, parse_usage};
 
 /// How recently a file must have changed for its agent to count as "running".
 const ACTIVE_WINDOW: Duration = Duration::from_secs(120);

--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -15,6 +15,7 @@ pub mod prompt;
 pub mod text;
 pub mod tmux;
 pub mod usage;
+pub mod windows;
 
 use std::path::Path;
 use std::time::Duration;
@@ -30,6 +31,8 @@ pub use backend::{
 pub use claude::TranscriptSummary;
 pub use limit::{LimitMenu, UsageLimit, detect_usage_limit, menu_select_keys};
 pub use tmux::{TmuxRuntime, shell_quote};
+#[cfg(windows)]
+pub use windows::WindowsBackend;
 pub use usage::{AccountUsage, UsageReport, UsageWindow, parse_codex_status, parse_usage};
 
 /// How recently a file must have changed for its agent to count as "running".

--- a/crates/repomon-core/src/agent/windows.rs
+++ b/crates/repomon-core/src/agent/windows.rs
@@ -489,7 +489,7 @@ mod host_backend {
                     }
                 }
             }
-            live.sort_by(|a, b| a.hello.started_at.cmp(&b.hello.started_at));
+            live.sort_by_key(|a| a.hello.started_at);
             live
         }
 

--- a/crates/repomon-core/src/agent/windows.rs
+++ b/crates/repomon-core/src/agent/windows.rs
@@ -1,0 +1,371 @@
+//! Windows session backend: per-window `repomon-agent-host.exe` processes.
+//!
+//! The Windows counterpart of [`TmuxRuntime`](super::tmux::TmuxRuntime): each agent window is
+//! owned by one detached host process (ConPTY + child + server-side vt100 screen) that serves
+//! the frozen control protocol in `crates/repomon-host/PROTOCOL.md` on
+//! `\\.\pipe\repomon-<session>-<window>` and registers itself under
+//! `<data_dir>\hosts\<session>\<window>.json`. Hosts survive daemon restarts; on startup the
+//! backend re-adopts them by scanning the registry and `hello`-verifying each pipe — the
+//! Windows equivalent of the daemon finding an existing tmux server.
+//!
+//! Everything decision-shaped (spawn-command parsing, host argv assembly, target formats,
+//! scan adopt/skip/GC rules, shell selection) is pure logic tested on every OS; only the pipe
+//! client, host spawning, and the byte-stream pump are `#[cfg(windows)]`.
+
+use crate::error::{Error, Result};
+
+use super::backend::AttachCommand;
+
+// ---------------------------------------------------------------------------
+// Pure logic (all OSes)
+// ---------------------------------------------------------------------------
+
+/// Split a [`SpawnSpec`](super::backend::SpawnSpec) `program` string into environment
+/// assignments and an argv. On Unix the program is a shell fragment run via `sh -c`; there is
+/// no shell on Windows, so the backend parses the common shapes itself: leading `KEY=VALUE`
+/// tokens become environment overrides (`CLAUDE_CONFIG_DIR='…' claude`), and the rest is
+/// whitespace-split with single/double quotes respected (quotes group, backslashes are plain
+/// path characters). An empty program is an error.
+pub fn split_spawn_program(program: &str) -> Result<(Vec<(String, String)>, Vec<String>)> {
+    let tokens = tokenize(program);
+    let mut env: Vec<(String, String)> = Vec::new();
+    let mut argv: Vec<String> = Vec::new();
+    for tok in tokens {
+        if argv.is_empty()
+            && let Some((key, value)) = tok.split_once('=')
+            && is_env_key(key)
+        {
+            env.push((key.to_string(), value.to_string()));
+            continue;
+        }
+        argv.push(tok);
+    }
+    if argv.is_empty() {
+        return Err(Error::Agent(format!(
+            "agent command {program:?} has no program to run"
+        )));
+    }
+    Ok((env, argv))
+}
+
+/// A shell-ish environment-assignment key: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Whitespace-split honoring single/double quotes (quotes group and are stripped; backslash is
+/// a plain character — these are Windows paths, not shell escapes).
+fn tokenize(s: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut in_token = false;
+    let mut quote: Option<char> = None;
+    for c in s.chars() {
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some(_) => cur.push(c),
+            None => match c {
+                '\'' | '"' => {
+                    quote = Some(c);
+                    in_token = true;
+                }
+                c if c.is_whitespace() => {
+                    if in_token {
+                        tokens.push(std::mem::take(&mut cur));
+                        in_token = false;
+                    }
+                }
+                c => {
+                    cur.push(c);
+                    in_token = true;
+                }
+            },
+        }
+    }
+    if in_token {
+        tokens.push(cur);
+    }
+    tokens
+}
+
+/// The full argument vector for `repomon-agent-host.exe`, per the PROTOCOL.md §1 spawn
+/// contract: `--session S --window W --cwd DIR --owner TOK [--env K=V]... -- PROGRAM ARGS...`.
+/// `--cols`/`--rows` are omitted — the host defaults to 220×50 (tmux parity).
+pub fn host_spawn_args(
+    session: &str,
+    window: &str,
+    cwd: &str,
+    owner: &str,
+    env: &[(String, String)],
+    argv: &[String],
+) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "--session".into(),
+        session.into(),
+        "--window".into(),
+        window.into(),
+        "--cwd".into(),
+        cwd.into(),
+        "--owner".into(),
+        owner.into(),
+    ];
+    for (k, v) in env {
+        args.push("--env".into());
+        args.push(format!("{k}={v}"));
+    }
+    args.push("--".into());
+    args.extend(argv.iter().cloned());
+    args
+}
+
+/// `session:window` — same shape as the tmux target so clients treat both opaquely.
+fn target_of(session: &str, window: &str) -> String {
+    format!("{session}:{window}")
+}
+
+/// `session:=window` — the exact-match form (tmux parity; the `=` is inert here but keeps the
+/// format identical across backends).
+fn exact_target_of(session: &str, window: &str) -> String {
+    format!("{session}:={window}")
+}
+
+/// Recover the window name from a target produced by [`target_of`]/[`exact_target_of`]; a
+/// bare window name passes through unchanged.
+pub fn window_from_target(session: &str, target: &str) -> String {
+    let rest = target
+        .strip_prefix(&format!("{session}:"))
+        .unwrap_or(target);
+    rest.strip_prefix('=').unwrap_or(rest).to_string()
+}
+
+/// How a registry-scan connect attempt ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConnectOutcome {
+    /// Pipe connected (hello may or may not have succeeded).
+    Connected,
+    /// Pipe absent: not found / connection refused — the host is gone.
+    Absent,
+    /// Pipe exists but every instance was momentarily busy.
+    Busy,
+}
+
+/// What the scanner does with one registry entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScanAction {
+    /// Live host owned by us: adopt (list it, drive it).
+    Adopt,
+    /// Leave it alone (foreign owner, busy pipe, or hello failed on a live pipe).
+    Skip,
+    /// Stale registry entry: delete the JSON file (PROTOCOL.md §8).
+    Gc,
+}
+
+/// The adopt/skip/GC rule (PROTOCOL.md §6 + §8): a pipe that won't connect marks the entry
+/// stale (GC); a connected host is adopted only when its `hello.owner` matches `me` — on
+/// mismatch the daemon MUST back off (not adopt, not reap, not kill). A busy pipe or a failed
+/// hello on a live pipe is skipped, never GC'd.
+pub fn scan_action(connect: ConnectOutcome, hello_owner: Option<&str>, me: &str) -> ScanAction {
+    match connect {
+        ConnectOutcome::Absent => ScanAction::Gc,
+        ConnectOutcome::Busy => ScanAction::Skip,
+        ConnectOutcome::Connected => match hello_owner {
+            Some(owner) if owner == me => ScanAction::Adopt,
+            _ => ScanAction::Skip,
+        },
+    }
+}
+
+/// Pick the user's interactive shell for plain terminals (`terminal.open`): PowerShell 7
+/// (`pwsh`) when installed, else `%COMSPEC%`, else `cmd.exe`.
+pub fn user_shell_from(pwsh: Option<std::path::PathBuf>, comspec: Option<String>) -> String {
+    if let Some(p) = pwsh {
+        return p.to_string_lossy().into_owned();
+    }
+    comspec
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| "cmd.exe".to_string())
+}
+
+/// The command a client runs in a real terminal to attach to `window`: the raw byte-proxy
+/// attach client (`repomon attach-host <window>`, Track F).
+pub fn attach_command_for(window: &str) -> AttachCommand {
+    AttachCommand {
+        program: "repomon".to_string(),
+        args: vec!["attach-host".to_string(), window.to_string()],
+    }
+}
+
+/// Whether a host's `program` is the Claude Code CLI, for the liveness probe's per-cwd claude
+/// count: basename, extension stripped (`claude`, `claude.cmd`, `C:\…\claude.exe` all match),
+/// case-insensitive (Windows filenames).
+pub fn is_claude_program(program: &str) -> bool {
+    let base = program
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(program)
+        .to_ascii_lowercase();
+    let stem = base
+        .rsplit_once('.')
+        .map(|(stem, _ext)| stem)
+        .unwrap_or(&base);
+    stem == "claude"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_a_bare_program() {
+        let (env, argv) = split_spawn_program("claude").unwrap();
+        assert!(env.is_empty());
+        assert_eq!(argv, vec!["claude"]);
+    }
+
+    #[test]
+    fn splits_program_with_args_and_quotes() {
+        let (env, argv) =
+            split_spawn_program(r#"claude --permission-mode plan --title "my agent""#).unwrap();
+        assert!(env.is_empty());
+        assert_eq!(
+            argv,
+            vec!["claude", "--permission-mode", "plan", "--title", "my agent"]
+        );
+    }
+
+    #[test]
+    fn splits_leading_env_assignments_into_env() {
+        // The autodetected Claude-variant shape: `CLAUDE_CONFIG_DIR='…' claude`.
+        let (env, argv) =
+            split_spawn_program(r"CLAUDE_CONFIG_DIR='C:\Users\me\.claude-work' claude").unwrap();
+        assert_eq!(
+            env,
+            vec![(
+                "CLAUDE_CONFIG_DIR".to_string(),
+                r"C:\Users\me\.claude-work".to_string()
+            )]
+        );
+        assert_eq!(argv, vec!["claude"]);
+    }
+
+    #[test]
+    fn env_assignment_after_the_program_is_an_argument() {
+        let (env, argv) = split_spawn_program("cmd.exe FOO=bar").unwrap();
+        assert!(env.is_empty());
+        assert_eq!(argv, vec!["cmd.exe", "FOO=bar"]);
+    }
+
+    #[test]
+    fn backslashes_are_plain_characters() {
+        // Windows paths must survive: no shell-style backslash escaping.
+        let (_, argv) = split_spawn_program(r"C:\tools\claude.exe --fast").unwrap();
+        assert_eq!(argv, vec![r"C:\tools\claude.exe", "--fast"]);
+    }
+
+    #[test]
+    fn empty_program_is_an_error() {
+        assert!(split_spawn_program("").is_err());
+        assert!(split_spawn_program("   ").is_err());
+        // Only env assignments, nothing to run.
+        assert!(split_spawn_program("FOO=bar").is_err());
+    }
+
+    #[test]
+    fn host_spawn_args_follow_the_protocol_contract() {
+        let args = host_spawn_args(
+            "repomon",
+            "lane-3-1",
+            r"C:\work",
+            "tok",
+            &[("FOO".to_string(), "bar".to_string())],
+            &["claude".to_string(), "--permission-mode".to_string(), "plan".to_string()],
+        );
+        assert_eq!(
+            args,
+            vec![
+                "--session", "repomon", "--window", "lane-3-1", "--cwd", r"C:\work", "--owner",
+                "tok", "--env", "FOO=bar", "--", "claude", "--permission-mode", "plan",
+            ]
+        );
+    }
+
+    #[test]
+    fn targets_match_the_tmux_shapes_and_round_trip() {
+        assert_eq!(target_of("repomon", "lane-7"), "repomon:lane-7");
+        assert_eq!(exact_target_of("repomon", "lane-7"), "repomon:=lane-7");
+        assert_eq!(window_from_target("repomon", "repomon:lane-7"), "lane-7");
+        assert_eq!(window_from_target("repomon", "repomon:=lane-7"), "lane-7");
+        // A bare window name passes through (defensive).
+        assert_eq!(window_from_target("repomon", "lane-7"), "lane-7");
+    }
+
+    #[test]
+    fn scan_adopts_own_live_hosts_only() {
+        assert_eq!(
+            scan_action(ConnectOutcome::Connected, Some("me"), "me"),
+            ScanAction::Adopt
+        );
+        // Foreign owner: back off — never adopt, reap, or kill (PROTOCOL.md §6).
+        assert_eq!(
+            scan_action(ConnectOutcome::Connected, Some("other"), "me"),
+            ScanAction::Skip
+        );
+        // Live pipe but hello failed: leave it alone, never GC a connectable pipe.
+        assert_eq!(
+            scan_action(ConnectOutcome::Connected, None, "me"),
+            ScanAction::Skip
+        );
+    }
+
+    #[test]
+    fn scan_gcs_only_dead_pipes() {
+        assert_eq!(
+            scan_action(ConnectOutcome::Absent, None, "me"),
+            ScanAction::Gc
+        );
+        // Busy = alive: never GC, never adopt this pass.
+        assert_eq!(
+            scan_action(ConnectOutcome::Busy, None, "me"),
+            ScanAction::Skip
+        );
+    }
+
+    #[test]
+    fn shell_prefers_pwsh_then_comspec_then_cmd() {
+        assert_eq!(
+            user_shell_from(
+                Some(std::path::PathBuf::from(r"C:\Program Files\PowerShell\7\pwsh.exe")),
+                Some(r"C:\Windows\system32\cmd.exe".to_string()),
+            ),
+            r"C:\Program Files\PowerShell\7\pwsh.exe"
+        );
+        assert_eq!(
+            user_shell_from(None, Some(r"C:\Windows\system32\cmd.exe".to_string())),
+            r"C:\Windows\system32\cmd.exe"
+        );
+        assert_eq!(user_shell_from(None, None), "cmd.exe");
+    }
+
+    #[test]
+    fn attach_command_runs_the_attach_host_client() {
+        let cmd = attach_command_for("lane-7");
+        assert_eq!(cmd.program, "repomon");
+        assert_eq!(cmd.args, vec!["attach-host", "lane-7"]);
+    }
+
+    #[test]
+    fn claude_program_matching_handles_paths_and_extensions() {
+        assert!(is_claude_program("claude"));
+        assert!(is_claude_program("claude.cmd"));
+        assert!(is_claude_program("CLAUDE.EXE"));
+        assert!(is_claude_program(r"C:\Users\me\AppData\Roaming\npm\claude.cmd"));
+        assert!(!is_claude_program("codex"));
+        assert!(!is_claude_program("claude-helper.exe"));
+        assert!(!is_claude_program(""));
+    }
+}

--- a/crates/repomon-core/src/agent/windows.rs
+++ b/crates/repomon-core/src/agent/windows.rs
@@ -203,6 +203,666 @@ pub fn attach_command_for(window: &str) -> AttachCommand {
 /// Whether a host's `program` is the Claude Code CLI, for the liveness probe's per-cwd claude
 /// count: basename, extension stripped (`claude`, `claude.cmd`, `C:\…\claude.exe` all match),
 /// case-insensitive (Windows filenames).
+#[cfg(windows)]
+pub use host_backend::WindowsBackend;
+
+// ---------------------------------------------------------------------------
+// The backend proper (Windows only)
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+mod host_backend {
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::os::windows::io::AsRawHandle;
+    use std::os::windows::process::CommandExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    use base64::Engine as _;
+    use repomon_host::codec::{FrameDecoder, encode_frame};
+    use repomon_host::protocol::{HelloInfo, Op, Request, StreamFrame};
+    use repomon_host::registry::{self, RegistryEntry};
+
+    use super::super::backend::{
+        AttachCommand, ByteStream, CaptureOpts, Cursor, OwnerState, SessionBackend, SpawnSpec,
+        WindowActivity,
+    };
+    use super::super::tmux::TmuxRuntime;
+    use super::{
+        ConnectOutcome, ScanAction, attach_command_for, exact_target_of, host_spawn_args,
+        is_claude_program, scan_action, split_spawn_program, target_of, user_shell_from,
+        window_from_target,
+    };
+    use crate::error::{Error, Result};
+    use crate::model::LaneId;
+
+    /// `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`: the host has no console and outlives the
+    /// daemon (PROTOCOL.md §1) — durability parity with the out-of-process tmux server.
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+    /// How long a spawn waits for the fresh host's pipe to answer `hello`.
+    const SPAWN_HELLO_TIMEOUT: Duration = Duration::from_secs(10);
+    /// Busy-retry ceiling for ordinary control connects (mirrors `transport::connect`).
+    const BUSY_CEILING: Duration = Duration::from_secs(2);
+    /// Shorter ceiling for registry scans, which touch every host per call.
+    const SCAN_BUSY_CEILING: Duration = Duration::from_millis(250);
+
+    static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+    static NEXT_STREAM_ID: AtomicU64 = AtomicU64::new(0);
+
+    /// The result of trying to reach a host's pipe once (with busy retry).
+    enum Connect {
+        Ok(File),
+        /// `ERROR_FILE_NOT_FOUND`: no live pipe — the host is gone.
+        Absent,
+        /// The pipe exists but couldn't be opened right now (all instances busy, or an
+        /// unexpected open error). Alive as far as we know — never GC'd.
+        Busy,
+    }
+
+    /// Open `\\.\pipe\…` as a synchronous byte-mode duplex file, retrying `ERROR_PIPE_BUSY`
+    /// briefly (the host pre-creates a spare instance, so busy is a tiny race window).
+    fn connect_pipe(name: &str, busy_ceiling: Duration) -> Connect {
+        const ERROR_PIPE_BUSY: i32 = 231;
+        let mut delay = Duration::from_millis(10);
+        let mut waited = Duration::ZERO;
+        loop {
+            match std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(name)
+            {
+                Ok(f) => return Connect::Ok(f),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Connect::Absent,
+                Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) && waited < busy_ceiling => {
+                    std::thread::sleep(delay);
+                    waited += delay;
+                    delay = (delay * 2).min(Duration::from_millis(100));
+                }
+                Err(_) => return Connect::Busy,
+            }
+        }
+    }
+
+    fn write_request(f: &mut File, id: u64, op: Op) -> Result<()> {
+        let payload = serde_json::to_vec(&Request { id, op })
+            .map_err(|e| Error::Agent(format!("encode host request: {e}")))?;
+        f.write_all(&encode_frame(&payload)).map_err(Error::Io)?;
+        Ok(())
+    }
+
+    /// Read frames until one arrives; `Ok(None)` on EOF.
+    fn read_frame(f: &mut File, dec: &mut FrameDecoder) -> Result<Option<Vec<u8>>> {
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            match dec.next_frame() {
+                Ok(Some(p)) => return Ok(Some(p)),
+                Ok(None) => {}
+                Err(e) => return Err(Error::Agent(format!("host frame: {e}"))),
+            }
+            let n = f.read(&mut buf).map_err(Error::Io)?;
+            if n == 0 {
+                return Ok(None);
+            }
+            dec.extend(&buf[..n]);
+        }
+    }
+
+    /// One request/response exchange on an open control connection: returns the `ok` body.
+    fn roundtrip(f: &mut File, dec: &mut FrameDecoder, op: Op) -> Result<serde_json::Value> {
+        let id = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+        write_request(f, id, op)?;
+        let payload = read_frame(f, dec)?
+            .ok_or_else(|| Error::Agent("host closed the pipe mid-request".into()))?;
+        let v: serde_json::Value = serde_json::from_slice(&payload)
+            .map_err(|e| Error::Agent(format!("host response: {e}")))?;
+        if let Some(err) = v.get("err").and_then(|e| e.as_str()) {
+            return Err(Error::Agent(format!("host: {err}")));
+        }
+        Ok(v.get("ok").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    /// One live, adopted host as a registry scan sees it.
+    struct LiveHost {
+        hello: HelloInfo,
+    }
+
+    /// A running byte-stream reader for one window.
+    struct ActiveStream {
+        id: u64,
+        stop: Arc<AtomicBool>,
+        thread: std::thread::JoinHandle<()>,
+    }
+
+    /// Ask a possibly-blocked synchronous reader thread to stop: set its flag, then cancel its
+    /// in-flight pipe read until the thread finishes (a missed cancel while it processes a
+    /// frame just means the next blocking read gets cancelled on the following attempt).
+    fn stop_stream(s: ActiveStream) {
+        s.stop.store(true, Ordering::Relaxed);
+        std::thread::spawn(move || {
+            for _ in 0..40 {
+                if s.thread.is_finished() {
+                    return;
+                }
+                unsafe {
+                    windows_sys::Win32::System::IO::CancelSynchronousIo(
+                        s.thread.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+    }
+
+    /// The Windows [`SessionBackend`]: drives per-window `repomon-agent-host.exe` processes
+    /// over their control pipes. Cheap to construct; all state is on disk (registry) or in the
+    /// hosts themselves, so a new daemon re-adopts everything by scanning.
+    pub struct WindowsBackend {
+        session: String,
+        /// This daemon's owner identity (its db path): stamped on every spawned host
+        /// (`--owner`) and compared against `hello.owner` before adopting (PROTOCOL.md §6).
+        owner: String,
+        /// repomon's data dir; the host registry lives at `<data_dir>\hosts\<session>\`.
+        data_dir: PathBuf,
+        /// Live byte-stream readers, one per window at most (trait contract).
+        streams: Arc<Mutex<HashMap<String, ActiveStream>>>,
+    }
+
+    impl WindowsBackend {
+        pub fn new(
+            session: impl Into<String>,
+            owner: impl Into<String>,
+            data_dir: impl Into<PathBuf>,
+        ) -> Self {
+            Self {
+                session: session.into(),
+                owner: owner.into(),
+                data_dir: data_dir.into(),
+                streams: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn hosts_dir(&self) -> PathBuf {
+            self.data_dir.join("hosts").join(&self.session)
+        }
+
+        fn pipe_name(&self, window: &str) -> String {
+            registry::pipe_name(&self.session, window)
+        }
+
+        /// Locate `repomon-agent-host.exe`: env override, beside the current executable, one
+        /// directory up (`target\debug\deps\…` test binaries), then `PATH`.
+        fn host_binary() -> Option<PathBuf> {
+            if let Ok(p) = std::env::var("REPOMON_HOST_BIN")
+                && !p.is_empty()
+            {
+                return Some(PathBuf::from(p));
+            }
+            const NAME: &str = "repomon-agent-host.exe";
+            if let Ok(exe) = std::env::current_exe()
+                && let Some(dir) = exe.parent()
+            {
+                let beside = dir.join(NAME);
+                if beside.exists() {
+                    return Some(beside);
+                }
+                if let Some(parent) = dir.parent() {
+                    let above = parent.join(NAME);
+                    if above.exists() {
+                        return Some(above);
+                    }
+                }
+            }
+            crate::exec::find_in_path("repomon-agent-host")
+        }
+
+        /// One request/response against a window's host on a fresh control connection.
+        fn request(&self, window: &str, op: Op) -> Result<serde_json::Value> {
+            match connect_pipe(&self.pipe_name(window), BUSY_CEILING) {
+                Connect::Ok(mut f) => roundtrip(&mut f, &mut FrameDecoder::new(), op),
+                Connect::Absent => Err(absent(window)),
+                Connect::Busy => Err(Error::Agent(format!(
+                    "host pipe for window {window} is busy"
+                ))),
+            }
+        }
+
+        /// Like [`request`], but a vanished window is benign (`Ok(None)`) — the analogue of
+        /// the tmux impl's `run_allow_absent`.
+        fn request_allow_absent(&self, window: &str, op: Op) -> Result<Option<serde_json::Value>> {
+            match self.request(window, op) {
+                Ok(v) => Ok(Some(v)),
+                Err(e) if is_absent(&e) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+
+        /// Scan the registry, GC stale entries, and return every live host we own
+        /// (PROTOCOL.md §6 + §8) — re-adoption *is* this scan run on a fresh daemon.
+        fn scan(&self) -> Vec<LiveHost> {
+            let dir = self.hosts_dir();
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                return Vec::new();
+            };
+            let mut live = Vec::new();
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                let Ok(bytes) = std::fs::read(&path) else {
+                    continue;
+                };
+                let Ok(reg) = serde_json::from_slice::<RegistryEntry>(&bytes) else {
+                    continue; // unreadable/foreign file: not ours to judge
+                };
+                if reg.session != self.session {
+                    continue;
+                }
+                let (outcome, hello) = match connect_pipe(&reg.pipe, SCAN_BUSY_CEILING) {
+                    Connect::Ok(mut f) => {
+                        let hello = roundtrip(&mut f, &mut FrameDecoder::new(), Op::Hello)
+                            .ok()
+                            .and_then(|ok| serde_json::from_value::<HelloInfo>(ok).ok());
+                        (ConnectOutcome::Connected, hello)
+                    }
+                    Connect::Absent => (ConnectOutcome::Absent, None),
+                    Connect::Busy => (ConnectOutcome::Busy, None),
+                };
+                let owner = hello.as_ref().map(|h| h.owner.as_str());
+                match scan_action(outcome, owner, &self.owner) {
+                    ScanAction::Adopt => live.push(LiveHost {
+                        hello: hello.expect("adopt implies hello"),
+                    }),
+                    ScanAction::Skip => {}
+                    ScanAction::Gc => {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+            }
+            live.sort_by(|a, b| a.hello.started_at.cmp(&b.hello.started_at));
+            live
+        }
+
+        /// Spawn a detached host per the PROTOCOL.md §1 contract and wait for its pipe to
+        /// answer `hello` (the registry entry is written once the pipe is connectable).
+        fn spawn_host(
+            &self,
+            window: &str,
+            cwd: &Path,
+            env: &[(String, String)],
+            argv: &[String],
+        ) -> Result<()> {
+            let host = Self::host_binary().ok_or_else(|| {
+                Error::Agent("repomon-agent-host.exe not found (beside repomond or on PATH)".into())
+            })?;
+            let args = host_spawn_args(
+                &self.session,
+                window,
+                &cwd.to_string_lossy(),
+                &self.owner,
+                env,
+                argv,
+            );
+            let mut child = std::process::Command::new(&host)
+                .args(&args)
+                .env("REPOMON_DATA_DIR", &self.data_dir)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+                .spawn()
+                .map_err(Error::Io)?;
+            let pipe = self.pipe_name(window);
+            let deadline = Instant::now() + SPAWN_HELLO_TIMEOUT;
+            loop {
+                if let Connect::Ok(mut f) = connect_pipe(&pipe, SCAN_BUSY_CEILING)
+                    && roundtrip(&mut f, &mut FrameDecoder::new(), Op::Hello).is_ok()
+                {
+                    return Ok(());
+                }
+                if let Ok(Some(status)) = child.try_wait() {
+                    return Err(Error::Agent(format!(
+                        "repomon-agent-host for window {window} exited at startup ({status})"
+                    )));
+                }
+                if Instant::now() >= deadline {
+                    return Err(Error::Agent(format!(
+                        "repomon-agent-host for window {window} did not come up in {}s",
+                        SPAWN_HELLO_TIMEOUT.as_secs()
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+
+        /// Spawn from a [`SpawnSpec`]: parse the program string (env prefixes + quoting),
+        /// merge the spec's env, append its args, and launch the host.
+        fn spawn_spec(&self, window: &str, spec: &SpawnSpec) -> Result<()> {
+            let (mut env, mut argv) = split_spawn_program(&spec.program)?;
+            let mut all_env = spec.env.clone();
+            all_env.append(&mut env);
+            argv.extend(spec.args.iter().cloned());
+            self.spawn_host(window, &spec.cwd, &all_env, &argv)
+        }
+    }
+
+    fn absent(window: &str) -> Error {
+        Error::Agent(format!("can't find window {window}"))
+    }
+
+    fn is_absent(e: &Error) -> bool {
+        matches!(e, Error::Agent(msg) if msg.starts_with("can't find window "))
+    }
+
+    impl SessionBackend for WindowsBackend {
+        fn available(&self) -> bool {
+            Self::host_binary().is_some()
+        }
+
+        fn label(&self) -> String {
+            self.session.clone()
+        }
+
+        fn session_exists(&self) -> bool {
+            !self.scan().is_empty()
+        }
+
+        /// Cooperative single-owner guard: an `owner` stamp file in the session's registry
+        /// directory (the durable analogue of the tmux server option `@repomon-owner`).
+        /// First writer wins; later daemons with a different identity must back off.
+        fn claim_or_verify_owner(&self, me: &str) -> OwnerState {
+            let path = self.hosts_dir().join("owner");
+            let verify = |content: String| {
+                if content.trim() == me {
+                    OwnerState::Owned
+                } else {
+                    OwnerState::OwnedByOther
+                }
+            };
+            if let Ok(existing) = std::fs::read_to_string(&path) {
+                return verify(existing);
+            }
+            let _ = std::fs::create_dir_all(self.hosts_dir());
+            // create_new: if a concurrent claimer got there first, re-read and compare.
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                && f.write_all(me.as_bytes()).is_err()
+            {
+                return OwnerState::OwnedByOther;
+            }
+            match std::fs::read_to_string(&path) {
+                Ok(content) => verify(content),
+                Err(_) => OwnerState::OwnedByOther,
+            }
+        }
+
+        fn list_windows(&self) -> Result<Vec<String>> {
+            Ok(self.scan().into_iter().map(|h| h.hello.window).collect())
+        }
+
+        fn list_windows_with_activity(&self) -> Result<Vec<WindowActivity>> {
+            Ok(self
+                .scan()
+                .into_iter()
+                .map(|h| WindowActivity {
+                    name: h.hello.window,
+                    cwd: PathBuf::from(h.hello.cwd),
+                    last_activity: h.hello.last_activity,
+                })
+                .collect())
+        }
+
+        fn live_agent_cwds(&self) -> Option<HashMap<PathBuf, usize>> {
+            let mut counts: HashMap<PathBuf, usize> = HashMap::new();
+            for h in self.scan() {
+                if !is_claude_program(&h.hello.program) {
+                    continue;
+                }
+                let p = PathBuf::from(&h.hello.cwd);
+                let key = p.canonicalize().unwrap_or(p);
+                *counts.entry(key).or_insert(0) += 1;
+            }
+            Some(counts)
+        }
+
+        fn spawn(&self, lane: LaneId, spec: &SpawnSpec) -> Result<String> {
+            let taken = self.windows_for(lane).unwrap_or_default();
+            let window = (1..)
+                .map(|slot| TmuxRuntime::slot_name(lane, slot))
+                .find(|name| !taken.contains(name))
+                .expect("unbounded slot range");
+            self.spawn_spec(&window, spec)?;
+            Ok(exact_target_of(&self.session, &window))
+        }
+
+        fn spawn_named(&self, window: &str, spec: &SpawnSpec) -> Result<String> {
+            self.spawn_spec(window, spec)?;
+            Ok(exact_target_of(&self.session, window))
+        }
+
+        fn open_named(&self, window: &str, cwd: &Path) -> Result<String> {
+            let shell = user_shell_from(
+                crate::exec::find_in_path("pwsh"),
+                std::env::var("COMSPEC").ok(),
+            );
+            self.spawn_host(window, cwd, &[], &[shell])?;
+            Ok(target_of(&self.session, window))
+        }
+
+        fn capture_named(&self, window: &str, opts: CaptureOpts) -> Result<String> {
+            let ok = self.request_allow_absent(
+                window,
+                Op::Capture {
+                    lines: opts.last_lines,
+                },
+            )?;
+            Ok(ok
+                .and_then(|v| v.get("text").and_then(|t| t.as_str()).map(str::to_string))
+                .unwrap_or_default())
+        }
+
+        fn cursor_named(&self, window: &str) -> Option<Cursor> {
+            let v = self.request(window, Op::Cursor).ok()?;
+            let visible = v.get("visible")?.as_bool()?;
+            if !visible {
+                return None;
+            }
+            Some(Cursor {
+                col: v.get("col")?.as_u64()? as u16,
+                row: v.get("row")?.as_u64()? as u16,
+            })
+        }
+
+        fn size_named(&self, window: &str) -> Option<(u16, u16)> {
+            let v = self.request(window, Op::Size).ok()?;
+            Some((
+                v.get("cols")?.as_u64()? as u16,
+                v.get("rows")?.as_u64()? as u16,
+            ))
+        }
+
+        fn resize_named(&self, window: &str, cols: u16, rows: u16) -> Result<()> {
+            self.request_allow_absent(window, Op::Resize { cols, rows })?;
+            Ok(())
+        }
+
+        /// No pinned-size concept: the host's ConPTY is always last-client-wins.
+        fn follow_client_named(&self, _window: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn alternate_on_named(&self, window: &str) -> bool {
+            self.request(window, Op::AlternateOn)
+                .ok()
+                .and_then(|v| v.get("on").and_then(|o| o.as_bool()))
+                .unwrap_or(false)
+        }
+
+        fn scroll_wheel_named(&self, window: &str, up: bool, ticks: u32) -> Result<()> {
+            if ticks == 0 {
+                return Ok(());
+            }
+            self.request_allow_absent(window, Op::ScrollWheel { up, ticks })?;
+            Ok(())
+        }
+
+        fn send_literal_named(&self, window: &str, text: &str) -> Result<()> {
+            self.request(
+                window,
+                Op::SendLiteral {
+                    text: text.to_string(),
+                },
+            )?;
+            Ok(())
+        }
+
+        fn send_text_named(&self, window: &str, text: &str) -> Result<()> {
+            self.request(
+                window,
+                Op::SendText {
+                    text: text.to_string(),
+                },
+            )?;
+            Ok(())
+        }
+
+        fn send_key_named(&self, window: &str, key: &str) -> Result<()> {
+            self.request(
+                window,
+                Op::SendKey {
+                    key: key.to_string(),
+                },
+            )?;
+            Ok(())
+        }
+
+        fn kill_named(&self, window: &str) -> Result<()> {
+            // The host answers `ok` then exits, removing its own registry entry.
+            self.request(window, Op::Kill)?;
+            Ok(())
+        }
+
+        /// Nothing to configure: capture/scrollback/mouse behavior live in the hosts.
+        fn configure(&self) {}
+
+        fn target_named(&self, window: &str) -> String {
+            target_of(&self.session, window)
+        }
+
+        fn exact_target_named(&self, window: &str) -> String {
+            exact_target_of(&self.session, window)
+        }
+
+        fn attach_command(&self, target: &str) -> AttachCommand {
+            attach_command_for(&window_from_target(&self.session, target))
+        }
+
+        /// `subscribe_bytes` on a dedicated second connection (PROTOCOL.md §5: a subscribed
+        /// connection is stream-only). The first pushed frame is a full-screen replay; every
+        /// frame's payload is forwarded raw to the channel. A reader thread pumps the pipe;
+        /// [`close_byte_stream`](Self::close_byte_stream) stops it via a flag +
+        /// `CancelSynchronousIo`.
+        fn open_byte_stream(&self, window: &str) -> Result<ByteStream> {
+            let mut file = match connect_pipe(&self.pipe_name(window), BUSY_CEILING) {
+                Connect::Ok(f) => f,
+                Connect::Absent => return Err(absent(window)),
+                Connect::Busy => {
+                    return Err(Error::Agent(format!(
+                        "host pipe for window {window} is busy"
+                    )));
+                }
+            };
+            let mut dec = FrameDecoder::new();
+            // The subscribe response arrives on the same connection; the same decoder may
+            // already hold the first stream frames behind it — hand both to the pump.
+            roundtrip(&mut file, &mut dec, Op::SubscribeBytes)?;
+
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+            let stop = Arc::new(AtomicBool::new(false));
+            let id = NEXT_STREAM_ID.fetch_add(1, Ordering::Relaxed);
+            let mut map = self.streams.lock().expect("streams lock");
+            // At most one stream per window: a fresh open supersedes a lingering reader.
+            if let Some(old) = map.remove(window) {
+                stop_stream(old);
+            }
+            let thread = {
+                let stop = stop.clone();
+                let streams = self.streams.clone();
+                let window = window.to_string();
+                std::thread::spawn(move || {
+                    pump(file, dec, tx, &stop);
+                    let mut map = streams.lock().expect("streams lock");
+                    if map.get(&window).is_some_and(|e| e.id == id) {
+                        map.remove(&window);
+                    }
+                })
+            };
+            map.insert(window.to_string(), ActiveStream { id, stop, thread });
+            Ok(ByteStream { rx })
+        }
+
+        fn close_byte_stream(&self, window: &str) -> Result<()> {
+            let entry = self.streams.lock().expect("streams lock").remove(window);
+            if let Some(entry) = entry {
+                stop_stream(entry);
+            }
+            Ok(())
+        }
+    }
+
+    /// Drain stream frames from the subscribed connection into the channel until EOF, error,
+    /// stop-flag, or the consumer hanging up. Disconnecting is the protocol's only
+    /// unsubscribe (PROTOCOL.md §7.11) — dropping `file` on return is the unsubscribe.
+    fn pump(
+        mut file: File,
+        mut dec: FrameDecoder,
+        tx: tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
+        stop: &AtomicBool,
+    ) {
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            loop {
+                match dec.next_frame() {
+                    Ok(Some(payload)) => {
+                        let Ok(frame) = serde_json::from_slice::<StreamFrame>(&payload) else {
+                            continue; // not a stream frame (unknown push): ignore
+                        };
+                        if frame.stream != "bytes" {
+                            continue;
+                        }
+                        let Ok(bytes) =
+                            base64::engine::general_purpose::STANDARD.decode(&frame.data)
+                        else {
+                            continue;
+                        };
+                        if tx.send(bytes).is_err() {
+                            return; // consumer gone
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(_) => return, // corrupt peer
+                }
+            }
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            match file.read(&mut buf) {
+                Ok(0) | Err(_) => return, // EOF (host exited) or cancelled
+                Ok(n) => dec.extend(&buf[..n]),
+            }
+        }
+    }
+}
+
 pub fn is_claude_program(program: &str) -> bool {
     let base = program
         .rsplit(['\\', '/'])
@@ -283,13 +943,29 @@ mod tests {
             r"C:\work",
             "tok",
             &[("FOO".to_string(), "bar".to_string())],
-            &["claude".to_string(), "--permission-mode".to_string(), "plan".to_string()],
+            &[
+                "claude".to_string(),
+                "--permission-mode".to_string(),
+                "plan".to_string(),
+            ],
         );
         assert_eq!(
             args,
             vec![
-                "--session", "repomon", "--window", "lane-3-1", "--cwd", r"C:\work", "--owner",
-                "tok", "--env", "FOO=bar", "--", "claude", "--permission-mode", "plan",
+                "--session",
+                "repomon",
+                "--window",
+                "lane-3-1",
+                "--cwd",
+                r"C:\work",
+                "--owner",
+                "tok",
+                "--env",
+                "FOO=bar",
+                "--",
+                "claude",
+                "--permission-mode",
+                "plan",
             ]
         );
     }
@@ -339,7 +1015,9 @@ mod tests {
     fn shell_prefers_pwsh_then_comspec_then_cmd() {
         assert_eq!(
             user_shell_from(
-                Some(std::path::PathBuf::from(r"C:\Program Files\PowerShell\7\pwsh.exe")),
+                Some(std::path::PathBuf::from(
+                    r"C:\Program Files\PowerShell\7\pwsh.exe"
+                )),
                 Some(r"C:\Windows\system32\cmd.exe".to_string()),
             ),
             r"C:\Program Files\PowerShell\7\pwsh.exe"
@@ -363,7 +1041,9 @@ mod tests {
         assert!(is_claude_program("claude"));
         assert!(is_claude_program("claude.cmd"));
         assert!(is_claude_program("CLAUDE.EXE"));
-        assert!(is_claude_program(r"C:\Users\me\AppData\Roaming\npm\claude.cmd"));
+        assert!(is_claude_program(
+            r"C:\Users\me\AppData\Roaming\npm\claude.cmd"
+        ));
         assert!(!is_claude_program("codex"));
         assert!(!is_claude_program("claude-helper.exe"));
         assert!(!is_claude_program(""));

--- a/crates/repomon-core/src/agent/windows.rs
+++ b/crates/repomon-core/src/agent/windows.rs
@@ -20,13 +20,16 @@ use super::backend::AttachCommand;
 // Pure logic (all OSes)
 // ---------------------------------------------------------------------------
 
+/// Environment overrides parsed out of a spawn program string (`KEY=VALUE` prefixes).
+pub type EnvPairs = Vec<(String, String)>;
+
 /// Split a [`SpawnSpec`](super::backend::SpawnSpec) `program` string into environment
 /// assignments and an argv. On Unix the program is a shell fragment run via `sh -c`; there is
 /// no shell on Windows, so the backend parses the common shapes itself: leading `KEY=VALUE`
 /// tokens become environment overrides (`CLAUDE_CONFIG_DIR='…' claude`), and the rest is
 /// whitespace-split with single/double quotes respected (quotes group, backslashes are plain
 /// path characters). An empty program is an error.
-pub fn split_spawn_program(program: &str) -> Result<(Vec<(String, String)>, Vec<String>)> {
+pub fn split_spawn_program(program: &str) -> Result<(EnvPairs, Vec<String>)> {
     let tokens = tokenize(program);
     let mut env: Vec<(String, String)> = Vec::new();
     let mut argv: Vec<String> = Vec::new();
@@ -124,13 +127,13 @@ pub fn host_spawn_args(
 }
 
 /// `session:window` — same shape as the tmux target so clients treat both opaquely.
-fn target_of(session: &str, window: &str) -> String {
+pub fn target_of(session: &str, window: &str) -> String {
     format!("{session}:{window}")
 }
 
 /// `session:=window` — the exact-match form (tmux parity; the `=` is inert here but keeps the
 /// format identical across backends).
-fn exact_target_of(session: &str, window: &str) -> String {
+pub fn exact_target_of(session: &str, window: &str) -> String {
     format!("{session}:={window}")
 }
 

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -27,6 +27,8 @@ pub mod traits;
 pub mod transport;
 pub mod watch;
 
+#[cfg(windows)]
+pub use agent::WindowsBackend;
 pub use agent::{AgentMonitor, ClaudeMonitor, SessionBackend, TmuxRuntime};
 pub use config::Config;
 pub use error::{Error, Result};

--- a/crates/repomon-core/src/transport.rs
+++ b/crates/repomon-core/src/transport.rs
@@ -69,12 +69,39 @@ enum ListenerInner {
     #[cfg(windows)]
     Pipe {
         name: String,
+        /// The per-user security descriptor every instance is created with (see
+        /// [`pipe_instance`]): local IPC must not be reachable by other users.
+        security: repomon_host::dacl::PipeSecurity,
         /// The pre-created pipe instance the next client will hit. Windows named pipes have no
         /// single listening object: each accepted connection consumes one server instance, so
         /// `accept` creates the following instance *before* handing the connected one out —
         /// that way there is never a window with no instance for a client to reach.
         next: Option<tokio::net::windows::named_pipe::NamedPipeServer>,
     },
+}
+
+/// Create one server instance of the daemon pipe with the explicit current-user-only DACL
+/// (same policy as the agent hosts' pipes — PROTOCOL.md §3): owner = current user, DACL
+/// protected, generic-all for that SID only. The default named-pipe DACL is not acceptable
+/// for the daemon's control channel. `first` additionally claims the name exclusively
+/// (`FILE_FLAG_FIRST_PIPE_INSTANCE`), mirroring the unix bind conflict.
+#[cfg(windows)]
+fn pipe_instance(
+    name: &str,
+    security: &repomon_host::dacl::PipeSecurity,
+    first: bool,
+) -> io::Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+    let mut attrs = security.attributes();
+    unsafe {
+        ServerOptions::new()
+            .first_pipe_instance(first)
+            .reject_remote_clients(true)
+            .create_with_security_attributes_raw(
+                name,
+                &mut attrs as *mut _ as *mut std::ffi::c_void,
+            )
+    }
 }
 
 /// A bound local IPC listener. Obtain with [`listen`], then call [`IpcListener::accept`].
@@ -103,14 +130,13 @@ pub async fn listen(endpoint: &Endpoint) -> io::Result<IpcListener> {
         }
         #[cfg(windows)]
         Endpoint::Pipe(name) => {
-            use tokio::net::windows::named_pipe::ServerOptions;
-            let first = ServerOptions::new()
-                .first_pipe_instance(true)
-                .reject_remote_clients(true)
-                .create(name)?;
+            let security =
+                repomon_host::dacl::PipeSecurity::current_user_only().map_err(io::Error::other)?;
+            let first = pipe_instance(name, &security, true)?;
             Ok(IpcListener {
                 inner: ListenerInner::Pipe {
                     name: name.clone(),
+                    security,
                     next: Some(first),
                 },
             })
@@ -128,21 +154,19 @@ impl IpcListener {
                 Ok(IpcStream::Unix(stream))
             }
             #[cfg(windows)]
-            ListenerInner::Pipe { name, next } => {
-                use tokio::net::windows::named_pipe::ServerOptions;
+            ListenerInner::Pipe {
+                name,
+                security,
+                next,
+            } => {
                 let server = match next.take() {
                     Some(server) => server,
                     // The previous accept failed to pre-create an instance (e.g. a transient
                     // resource error); retry here rather than being wedged forever.
-                    None => ServerOptions::new()
-                        .reject_remote_clients(true)
-                        .create(&*name)?,
+                    None => pipe_instance(name, security, false)?,
                 };
                 server.connect().await?;
-                *next = ServerOptions::new()
-                    .reject_remote_clients(true)
-                    .create(&*name)
-                    .ok();
+                *next = pipe_instance(name, security, false).ok();
                 Ok(IpcStream::PipeServer(server))
             }
         }

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -269,10 +269,28 @@ impl Ctx {
     ) -> Arc<Self> {
         let registry = Registry::new(store.clone());
         let lanes = Lanes::new(store.clone(), config.clone());
+        #[cfg(unix)]
         let backend: Arc<dyn SessionBackend> =
             Arc::new(TmuxRuntime::new(config.tmux_session.clone()));
+        #[cfg(windows)]
+        let backend: Arc<dyn SessionBackend> = {
+            // Owner identity mirrors `reap::owner_token`: the db path — stable across
+            // restarts (so this daemon re-adopts its own hosts) and distinct per instance
+            // (so a stray test daemon's hosts are never adopted, reaped, or killed).
+            let me = db_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| format!("pid:{}", std::process::id()));
+            Arc::new(repomon_core::WindowsBackend::new(
+                config.tmux_session.clone(),
+                me,
+                config::data_dir(),
+            ))
+        };
         // Make any already-running session attach-native (mouse, clipboard, deep scrollback);
-        // spawns reapply it, but an existing tmux server outlives a daemon restart.
+        // spawns reapply it, but an existing backend server (a tmux server, or detached
+        // Windows host processes) outlives a daemon restart — on Windows this scan is the
+        // re-adoption pass.
         if backend.session_exists() {
             backend.configure();
         }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -3106,14 +3106,6 @@ fn reuse_per_path_on_failure<T: Clone>(
     }
 }
 
-/// Windows: there is no ps/lsof//proc probe yet — the session-backend track gives hosts an
-/// authoritative child-alive answer. `None` means "probe unavailable, don't filter", the same
-/// safe degradation the unix arms use when `ps` fails.
-#[cfg(windows)]
-fn live_claude_cwds() -> Option<HashMap<PathBuf, usize>> {
-    None
-}
-
 /// How many live `claude` CLI processes have each working directory. claude doesn't hold its
 /// transcript open, but its cwd is the worktree it runs in — so the count per worktree bounds
 /// how many of that worktree's sessions are actually running. `None` if the probe couldn't
@@ -3240,11 +3232,23 @@ async fn live_cwds_cached(ctx: &Ctx) -> Option<HashMap<PathBuf, usize>> {
             }
         }
     }
-    let map = match tokio::task::spawn_blocking(live_claude_cwds)
+    // Windows has no ps/lsof//proc scan: the hosts *own* the agent children, so the backend
+    // answers authoritatively (a live host implies a live child in that cwd). Unix keeps the
+    // platform process probe, which also catches sessions started outside repomon.
+    #[cfg(windows)]
+    let fresh = {
+        let backend = ctx.backend.clone();
+        tokio::task::spawn_blocking(move || backend.live_agent_cwds())
+            .await
+            .ok()
+            .flatten()
+    };
+    #[cfg(not(windows))]
+    let fresh = tokio::task::spawn_blocking(live_claude_cwds)
         .await
         .ok()
-        .flatten()
-    {
+        .flatten();
+    let map = match fresh {
         Some(m) => m,
         None => {
             // The probe couldn't run (ps/lsof spawn failed under load, /proc unreadable).

--- a/crates/repomon-daemon/tests/windows_backend.rs
+++ b/crates/repomon-daemon/tests/windows_backend.rs
@@ -1,0 +1,284 @@
+//! Windows-native agent runtime, end to end — the `tests/integration.rs` flows without tmux.
+//!
+//! Each test gets its own session name and registry data dir (tempdir), spawns real
+//! `repomon-agent-host.exe` processes (built by `cargo test --workspace`; the backend finds
+//! the binary one directory above the test executable in `target\debug`), and drives them
+//! through the `SessionBackend` trait exactly as the daemon does: spawn (cmd.exe stand-ins
+//! for agents), capture, input, kill, stale-entry GC, owner back-off, byte streaming, and —
+//! the point of the host architecture — re-adoption of live hosts by a fresh backend, which
+//! is what a daemon restart does.
+
+#![cfg(windows)]
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use repomon_core::WindowsBackend;
+use repomon_core::agent::backend::{CaptureOpts, OwnerState, SessionBackend, SpawnSpec};
+use repomon_core::agent::detect_usage_limit;
+
+/// A per-test session name: unique per process AND per test tag, so parallel tests never
+/// share pipes or registry directories.
+fn unique_session(tag: &str) -> String {
+    format!("rmwtest-{tag}-{}", std::process::id())
+}
+
+/// Poll until `f` is true or fail loudly. Host spawn + ConPTY output are asynchronous; every
+/// assertion about window content goes through this (mirrors the sleeps in integration.rs,
+/// but bounded and self-describing).
+fn wait_for(what: &str, mut f: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if f() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+fn capture(b: &WindowsBackend, window: &str) -> String {
+    b.capture_named(window, CaptureOpts::visible())
+        .unwrap_or_default()
+}
+
+/// A cmd.exe stand-in for an agent: prints `marker`, then sits at an interactive prompt
+/// (`/K`), alive until killed — the Windows analogue of `sh -c 'echo X; sleep 30'`.
+fn echo_agent(marker: &str, cwd: &Path) -> SpawnSpec {
+    SpawnSpec::new(format!("cmd.exe /Q /K echo {marker}"), cwd)
+}
+
+#[test]
+fn spawn_capture_input_kill_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let b = WindowsBackend::new(unique_session("roundtrip"), "me", dir.path());
+    assert!(b.available(), "repomon-agent-host.exe must be findable");
+
+    let target = b
+        .spawn(1, &echo_agent("HELLO_REPOMON", dir.path()))
+        .unwrap();
+    assert_eq!(target, format!("{}:=lane-1", b.label()));
+    assert!(b.has_window(1));
+    wait_for("initial output", || {
+        capture(&b, "lane-1").contains("HELLO_REPOMON")
+    });
+
+    // Typed input lands in the window (send_text = literal + Enter).
+    b.send_text_named("lane-1", "echo SECOND_LINE").unwrap();
+    wait_for("typed output", || {
+        capture(&b, "lane-1").contains("SECOND_LINE")
+    });
+
+    // The pane answers geometry questions like tmux does (220x50 spawn default).
+    assert_eq!(b.size_named("lane-1"), Some((220, 50)));
+    b.resize_named("lane-1", 190, 45).unwrap();
+    wait_for("resize", || b.size_named("lane-1") == Some((190, 45)));
+    assert!(!b.alternate_on_named("lane-1"), "cmd.exe is not a TUI");
+
+    // A second spawn runs side by side in the next slot; the first agent survives.
+    b.spawn(1, &echo_agent("SLOT_TWO", dir.path())).unwrap();
+    assert_eq!(b.windows_for(1).unwrap(), vec!["lane-1", "lane-1-2"]);
+    wait_for("slot two output", || {
+        b.capture_named("lane-1-2", CaptureOpts::visible())
+            .unwrap_or_default()
+            .contains("SLOT_TWO")
+    });
+
+    // Kill is exact: lane-1 dies, lane-1-2 survives, and the dead window reads as empty
+    // output (benign absence — capture parity with the tmux impl).
+    b.kill_named("lane-1").unwrap();
+    wait_for("lane-1 gone", || {
+        b.windows_for(1).unwrap() == vec!["lane-1-2"]
+    });
+    wait_for(
+        "dead window reads empty",
+        || matches!(b.capture_named("lane-1", CaptureOpts::visible()), Ok(s) if s.is_empty()),
+    );
+
+    b.kill_named("lane-1-2").unwrap();
+    wait_for("all windows gone", || !b.has_window(1));
+    // Clean exits remove their registry entries: no JSON litter left behind.
+    wait_for("registry empty", || {
+        let hosts = dir.path().join("hosts").join(b.label());
+        !std::fs::read_dir(&hosts).is_ok_and(|d| {
+            d.flatten()
+                .any(|e| e.path().extension().is_some_and(|x| x == "json"))
+        })
+    });
+}
+
+/// THE durability test: hosts outlive the backend that spawned them (as they outlive a dying
+/// daemon), and a fresh backend with the same identity re-adopts them from the registry with
+/// scrollback intact.
+#[test]
+fn re_adopts_live_hosts_after_a_daemon_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let session = unique_session("readopt");
+
+    let first = WindowsBackend::new(session.clone(), "daemon-me", dir.path());
+    first.spawn(1, &echo_agent("SURVIVOR", dir.path())).unwrap();
+    wait_for("output before restart", || {
+        capture(&first, "lane-1").contains("SURVIVOR")
+    });
+    drop(first); // the "daemon" dies; the host keeps running detached
+
+    // A restarted daemon: same session, owner identity, and data dir.
+    let second = WindowsBackend::new(session, "daemon-me", dir.path());
+    assert!(second.session_exists(), "host survived and is re-adopted");
+    assert_eq!(second.list_windows().unwrap(), vec!["lane-1"]);
+
+    // Scrollback survived: the marker was printed before the "restart".
+    assert!(capture(&second, "lane-1").contains("SURVIVOR"));
+
+    // The reaper's view carries the original cwd and a sane activity time.
+    let acts = second.list_windows_with_activity().unwrap();
+    assert_eq!(acts.len(), 1);
+    assert_eq!(acts[0].name, "lane-1");
+    assert_eq!(acts[0].cwd, dir.path());
+    assert!(acts[0].last_activity > 0);
+
+    // And the re-adopted window is fully drivable.
+    second
+        .send_text_named("lane-1", "echo AFTER_RESTART")
+        .unwrap();
+    wait_for("input after re-adoption", || {
+        capture(&second, "lane-1").contains("AFTER_RESTART")
+    });
+    second.kill_named("lane-1").unwrap();
+    wait_for("killed after re-adoption", || {
+        second.list_windows().unwrap().is_empty()
+    });
+}
+
+#[test]
+fn stale_registry_entries_are_garbage_collected() {
+    let dir = tempfile::tempdir().unwrap();
+    let session = unique_session("gc");
+    let b = WindowsBackend::new(session.clone(), "me", dir.path());
+
+    // A registry entry whose host is long gone: its pipe does not exist.
+    let hosts = dir.path().join("hosts").join(&session);
+    std::fs::create_dir_all(&hosts).unwrap();
+    let stale = hosts.join("lane-9.json");
+    std::fs::write(
+        &stale,
+        format!(
+            r#"{{"v":1,"session":"{session}","window":"lane-9","pipe":"\\\\.\\pipe\\repomon-{session}-lane-9","host_pid":1,"agent_pid":2,"program":"cmd.exe","args":[],"cwd":"C:\\","owner":"me","started_at":1}}"#
+        ),
+    )
+    .unwrap();
+
+    assert!(b.list_windows().unwrap().is_empty());
+    assert!(!stale.exists(), "dead-pipe entry was GC'd by the scan");
+}
+
+/// PROTOCOL.md §6: another daemon's hosts are invisible and untouchable — never adopted,
+/// reaped, or killed — and the registry-level owner stamp locks the second daemon out of
+/// destructive sweeps.
+#[test]
+fn foreign_owned_hosts_are_backed_off_from() {
+    let dir = tempfile::tempdir().unwrap();
+    let session = unique_session("owner");
+
+    let a = WindowsBackend::new(session.clone(), "daemon-A", dir.path());
+    assert_eq!(a.claim_or_verify_owner("daemon-A"), OwnerState::Owned);
+    a.spawn(1, &echo_agent("MINE", dir.path())).unwrap();
+
+    let b = WindowsBackend::new(session.clone(), "daemon-B", dir.path());
+    // The owner stamp belongs to A; B must back off (and keeps verifying so).
+    assert_eq!(
+        b.claim_or_verify_owner("daemon-B"),
+        OwnerState::OwnedByOther
+    );
+    assert_eq!(a.claim_or_verify_owner("daemon-A"), OwnerState::Owned);
+    // A's host never shows up in B's world: not listed, not adopted...
+    assert!(b.list_windows().unwrap().is_empty());
+    assert!(b.list_windows_with_activity().unwrap().is_empty());
+    // ...and its registry entry is NOT GC'd — the pipe is alive, just not B's.
+    let entry = dir.path().join("hosts").join(&session).join("lane-1.json");
+    assert!(entry.exists());
+
+    // The rightful owner still sees and controls it.
+    assert_eq!(a.list_windows().unwrap(), vec!["lane-1"]);
+    a.kill_named("lane-1").unwrap();
+    wait_for("owner killed its host", || {
+        a.list_windows().unwrap().is_empty()
+    });
+}
+
+/// `subscribe_bytes` on a second connection: the first frame replays the full current screen
+/// (a fresh emulator converges), later frames are live PTY output, and closing the stream
+/// ends the channel (the forwarder's EOF signal).
+#[test]
+fn byte_stream_replays_then_follows_live_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let b = std::sync::Arc::new(WindowsBackend::new(
+        unique_session("bytes"),
+        "me",
+        dir.path(),
+    ));
+    b.spawn(1, &echo_agent("STREAM_START", dir.path())).unwrap();
+    wait_for("pre-stream output", || {
+        capture(&b, "lane-1").contains("STREAM_START")
+    });
+
+    let stream = b.open_byte_stream("lane-1").unwrap();
+    let got = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let pump = {
+        let (got, done) = (got.clone(), done.clone());
+        std::thread::spawn(move || {
+            let mut rx = stream.rx;
+            while let Some(chunk) = rx.blocking_recv() {
+                got.lock().unwrap().extend_from_slice(&chunk);
+            }
+            done.store(true, std::sync::atomic::Ordering::Relaxed);
+        })
+    };
+    let text = |got: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>| {
+        String::from_utf8_lossy(&got.lock().unwrap()).into_owned()
+    };
+
+    // Frame 1 is a full-screen replay: output from BEFORE the subscription is in the stream.
+    wait_for("replay frame", || text(&got).contains("STREAM_START"));
+
+    // Live output follows.
+    b.send_text_named("lane-1", "echo STREAM_LIVE").unwrap();
+    wait_for("live frames", || text(&got).contains("STREAM_LIVE"));
+
+    // Closing the stream ends the channel, which ends the consumer loop.
+    b.close_byte_stream("lane-1").unwrap();
+    wait_for("stream closed", || {
+        done.load(std::sync::atomic::Ordering::Relaxed)
+    });
+    pump.join().unwrap();
+    b.kill_named("lane-1").unwrap();
+}
+
+/// The auto-continue trigger path, minus the daemon loop (whose decision state machine is
+/// unit-tested): a pane showing Claude's usage-limit message is detected from a backend
+/// capture, and the resume message can be typed back through the same backend.
+#[test]
+fn usage_limit_capture_detects_and_resume_types_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let b = WindowsBackend::new(unique_session("limit"), "me", dir.path());
+    let spec = SpawnSpec::new(
+        "cmd.exe /Q /K echo Claude usage limit reached. Your limit will reset at 3:00 PM.",
+        dir.path(),
+    );
+    b.spawn(1, &spec).unwrap();
+
+    wait_for("limit message on screen", || {
+        capture(&b, "lane-1").contains("usage limit reached")
+    });
+    let pane = capture(&b, "lane-1");
+    // A Some return IS the blocking-pause signal auto_continue keys off.
+    let _limit = detect_usage_limit(&pane).expect("usage-limit pause detected from capture");
+
+    // What auto_continue does on resume: type the continue message into the window.
+    b.send_text_named("lane-1", "continue").unwrap();
+    wait_for("resume text landed", || {
+        capture(&b, "lane-1").contains("continue")
+    });
+    b.kill_named("lane-1").unwrap();
+}

--- a/crates/repomon-daemon/tests/windows_backend.rs
+++ b/crates/repomon-daemon/tests/windows_backend.rs
@@ -37,6 +37,32 @@ fn wait_for(what: &str, mut f: impl FnMut() -> bool) {
     panic!("timed out waiting for {what}");
 }
 
+/// TEMP instrumentation: like `wait_for`, but on timeout dumps every `host-debug-*.log` the
+/// host wrote under `dir` so CI shows which ConPTY→screen stage broke.
+fn wait_for_dump(what: &str, dir: &Path, mut f: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if f() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let mut dump = String::new();
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("host-debug-"))
+            {
+                let body = std::fs::read_to_string(&p).unwrap_or_default();
+                dump.push_str(&format!("\n=== {} ===\n{body}", p.display()));
+            }
+        }
+    }
+    panic!("timed out waiting for {what}; host logs:{dump}");
+}
+
 fn capture(b: &WindowsBackend, window: &str) -> String {
     b.capture_named(window, CaptureOpts::visible())
         .unwrap_or_default()
@@ -59,7 +85,7 @@ fn spawn_capture_input_kill_roundtrip() {
         .unwrap();
     assert_eq!(target, format!("{}:=lane-1", b.label()));
     assert!(b.has_window(1));
-    wait_for("initial output", || {
+    wait_for_dump("initial output", dir.path(), || {
         capture(&b, "lane-1").contains("HELLO_REPOMON")
     });
 

--- a/crates/repomon-daemon/tests/windows_backend.rs
+++ b/crates/repomon-daemon/tests/windows_backend.rs
@@ -37,32 +37,6 @@ fn wait_for(what: &str, mut f: impl FnMut() -> bool) {
     panic!("timed out waiting for {what}");
 }
 
-/// TEMP instrumentation: like `wait_for`, but on timeout dumps every `host-debug-*.log` the
-/// host wrote under `dir` so CI shows which ConPTY→screen stage broke.
-fn wait_for_dump(what: &str, dir: &Path, mut f: impl FnMut() -> bool) {
-    let deadline = Instant::now() + Duration::from_secs(20);
-    while Instant::now() < deadline {
-        if f() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    let mut dump = String::new();
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for e in rd.flatten() {
-            let p = e.path();
-            if p.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with("host-debug-"))
-            {
-                let body = std::fs::read_to_string(&p).unwrap_or_default();
-                dump.push_str(&format!("\n=== {} ===\n{body}", p.display()));
-            }
-        }
-    }
-    panic!("timed out waiting for {what}; host logs:{dump}");
-}
-
 fn capture(b: &WindowsBackend, window: &str) -> String {
     b.capture_named(window, CaptureOpts::visible())
         .unwrap_or_default()
@@ -85,7 +59,7 @@ fn spawn_capture_input_kill_roundtrip() {
         .unwrap();
     assert_eq!(target, format!("{}:=lane-1", b.label()));
     assert!(b.has_window(1));
-    wait_for_dump("initial output", dir.path(), || {
+    wait_for("initial output", || {
         capture(&b, "lane-1").contains("HELLO_REPOMON")
     });
 

--- a/crates/repomon-host/src/dispatch.rs
+++ b/crates/repomon-host/src/dispatch.rs
@@ -47,6 +47,9 @@ pub struct Dispatcher {
     screen: Screen,
     pty: Box<dyn PtyIo>,
     last_activity: i64,
+    /// Up to 3 trailing output bytes carried between chunks so a DSR query split across a read
+    /// boundary is still detected (see [`Dispatcher::answer_dsr`]).
+    dsr_tail: Vec<u8>,
 }
 
 impl Dispatcher {
@@ -57,6 +60,7 @@ impl Dispatcher {
             screen,
             pty,
             last_activity,
+            dsr_tail: Vec::new(),
         }
     }
 
@@ -64,6 +68,32 @@ impl Dispatcher {
     pub fn process_output(&mut self, bytes: &[u8], now: i64) {
         self.screen.process(bytes);
         self.last_activity = now;
+        self.answer_dsr(bytes);
+    }
+
+    /// Answer DSR cursor-position reports (`ESC [ 6 n`) in the output stream.
+    ///
+    /// ConPTY emits one at startup as part of its `PSUEDOCONSOLE_INHERIT_CURSOR` handshake (and
+    /// interactive apps query the cursor mid-run) and withholds further output until the
+    /// terminal replies with a CPR (`ESC [ row ; col R`, 1-based) on the PTY input. This host IS
+    /// the terminal, so without this reply ConPTY stalls and no application output ever appears.
+    fn answer_dsr(&mut self, bytes: &[u8]) {
+        const DSR_CPR: &[u8] = b"\x1b[6n";
+        let mut scan = std::mem::take(&mut self.dsr_tail);
+        scan.extend_from_slice(bytes);
+        let hits = scan
+            .windows(DSR_CPR.len())
+            .filter(|w| *w == DSR_CPR)
+            .count();
+        for _ in 0..hits {
+            let (col, row, _) = self.screen.cursor();
+            let reply = format!("\x1b[{};{}R", row + 1, col + 1);
+            let _ = self.pty.write(reply.as_bytes());
+        }
+        // Carry the last few bytes so a sequence straddling the next read is still matched; a
+        // partial (< 4 bytes) tail can never itself complete a match, so nothing double-counts.
+        let keep = scan.len().min(DSR_CPR.len() - 1);
+        self.dsr_tail = scan.split_off(scan.len() - keep);
     }
 
     /// The full current-screen replay for a new byte subscriber's first frame.
@@ -447,6 +477,44 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&huge).unwrap();
         assert_eq!(v["id"], 7);
         assert!(v["err"].as_str().unwrap().contains("frame limit"));
+    }
+
+    #[test]
+    fn dsr_cursor_query_is_answered_with_a_cpr() {
+        // ConPTY's inherit-cursor handshake sends `ESC [ 6 n` and blocks output until the
+        // terminal replies with the cursor position; the host must answer on the PTY input.
+        let (mut d, calls) = dispatcher();
+        d.process_output(b"\x1b[6n", 41);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(b"\x1b[1;1R".to_vec())],
+            "fresh screen cursor at 0,0 replies 1;1 (1-based CPR)"
+        );
+
+        // A query after some output reports the live cursor position.
+        calls.lock().unwrap().clear();
+        d.process_output(b"abc\x1b[6n", 42);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(b"\x1b[1;4R".to_vec())],
+            "cursor after 'abc' is col 3 (0-based) -> 1;4"
+        );
+    }
+
+    #[test]
+    fn dsr_query_split_across_reads_is_still_answered() {
+        let (mut d, calls) = dispatcher();
+        d.process_output(b"hi\x1b[6", 41); // sequence straddles the read boundary
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "no reply until the full sequence arrives"
+        );
+        d.process_output(b"n", 42);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[PtyCall::Write(b"\x1b[1;3R".to_vec())],
+            "boundary-split CPR answered once; cursor after 'hi' is col 2 -> 1;3"
+        );
     }
 
     #[test]

--- a/crates/repomon-host/src/pty.rs
+++ b/crates/repomon-host/src/pty.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use anyhow::Context as _;
-use portable_pty::{Child, ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
 use crate::dispatch::PtyIo;
 
@@ -20,11 +20,32 @@ pub struct SpawnedChild {
     pub child_pid: u32,
 }
 
+/// An owned, inheritable-safe duplicate of the ConPTY child's process handle.
+///
+/// We terminate the child ourselves rather than via `portable_pty`'s `ChildKiller`, whose
+/// Windows `WinChildKiller::kill` has inverted success/error semantics in 0.9: `TerminateProcess`
+/// returns nonzero on success, but the killer returns `Err(last_os_error())` on that success (a
+/// stale `ERROR_IO_INCOMPLETE`/996) and `Ok(())` on the actual failure. Owning a handle and
+/// calling `TerminateProcess` directly gives us correct semantics.
+struct ChildHandle(windows_sys::Win32::Foundation::HANDLE);
+
+// The handle is an OS process handle we own for the controller's lifetime; sending it across
+// threads (the controller lives behind the dispatcher mutex) is sound.
+unsafe impl Send for ChildHandle {}
+
+impl Drop for ChildHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { windows_sys::Win32::Foundation::CloseHandle(self.0) };
+        }
+    }
+}
+
 /// The dispatcher's handle on the ConPTY: input writes, resizes, kills.
 pub struct PtyController {
     master: Box<dyn MasterPty + Send>,
     writer: Box<dyn std::io::Write + Send>,
-    killer: Box<dyn ChildKiller + Send + Sync>,
+    child: ChildHandle,
 }
 
 impl PtyIo for PtyController {
@@ -48,7 +69,23 @@ impl PtyIo for PtyController {
     }
 
     fn kill(&mut self) -> anyhow::Result<()> {
-        self.killer.kill().context("kill agent child")
+        use windows_sys::Win32::Foundation::STILL_ACTIVE;
+        use windows_sys::Win32::System::Threading::{GetExitCodeProcess, TerminateProcess};
+        // `TerminateProcess` returns nonzero on success. A zero return with the child already
+        // gone (`GetExitCodeProcess` != STILL_ACTIVE) is a benign race — the window is dying
+        // either way — so we treat it as success.
+        let ok = unsafe { TerminateProcess(self.child.0, 1) };
+        if ok != 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        let mut code: u32 = 0;
+        let exited = unsafe { GetExitCodeProcess(self.child.0, &mut code) } != 0
+            && code != STILL_ACTIVE as u32;
+        if exited {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!("kill agent child: {err}"))
     }
 }
 
@@ -86,7 +123,9 @@ pub fn spawn_child(
     drop(pair.slave);
 
     let child_pid = child.process_id().unwrap_or(0);
-    let killer = child.clone_killer();
+    // Own an independent duplicate of the child's process handle for `kill` (see `ChildHandle`);
+    // the original handle stays with `child`, which the waiter thread owns.
+    let child_handle = duplicate_child_handle(child.as_ref())?;
     let reader = pair
         .master
         .try_clone_reader()
@@ -97,10 +136,33 @@ pub fn spawn_child(
         controller: PtyController {
             master: pair.master,
             writer,
-            killer,
+            child: child_handle,
         },
         reader,
         child,
         child_pid,
     })
+}
+
+/// Duplicate the ConPTY child's process handle into one this process owns independently, so the
+/// controller can `TerminateProcess` it without racing the waiter thread that owns the original.
+fn duplicate_child_handle(child: &(dyn Child + Send + Sync)) -> anyhow::Result<ChildHandle> {
+    use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let raw = child
+        .as_raw_handle()
+        .context("ConPTY child has no process handle")? as HANDLE;
+    let mut dup: HANDLE = std::ptr::null_mut();
+    let ok = unsafe {
+        let me = GetCurrentProcess();
+        DuplicateHandle(me, raw, me, &mut dup, 0, 0, DUPLICATE_SAME_ACCESS)
+    };
+    if ok == 0 {
+        return Err(anyhow::anyhow!(
+            "duplicate ConPTY child handle: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(ChildHandle(dup))
 }

--- a/crates/repomon-host/src/run.rs
+++ b/crates/repomon-host/src/run.rs
@@ -1,11 +1,35 @@
 //! Host process assembly (Windows only): parse the spawn contract, start the ConPTY child,
 //! register, and serve until the child dies or a `kill` arrives.
 
+use std::io::Write as _;
+use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 
 use clap::Parser as _;
 use tokio::sync::broadcast;
+
+/// TEMP instrumentation: append a line to `<data_dir>\host-debug-<window>.log` when
+/// `REPOMON_HOST_DEBUG` is set. Used to pin which stage of the ConPTY→screen path breaks on CI.
+fn dlog(path: &Option<PathBuf>, msg: &str) {
+    if let Some(p) = path
+        && let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+    {
+        let _ = writeln!(f, "[pid {} @ {}] {msg}", std::process::id(), epoch_now());
+    }
+}
+
+fn debug_log_path(data_dir: &std::path::Path, window: &str) -> Option<PathBuf> {
+    // TEMP: unconditional during CI evidence-gathering (data_dir is a per-test tempdir).
+    let safe: String = window
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    Some(data_dir.join(format!("host-debug-{safe}.log")))
+}
 
 use crate::cli::HostArgs;
 use crate::dacl::PipeSecurity;
@@ -35,14 +59,34 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         .split_first()
         .expect("clap enforces a non-empty command");
 
-    let spawned = pty::spawn_child(
+    let data_dir = registry::data_dir();
+    let dbg = debug_log_path(&data_dir, &args.window);
+    dlog(
+        &dbg,
+        &format!(
+            "run start: program={program:?} args={program_args:?} cwd={:?} cols={} rows={}",
+            args.cwd, args.cols, args.rows
+        ),
+    );
+
+    let spawned = match pty::spawn_child(
         program,
         program_args,
         &args.cwd,
         &args.env,
         args.cols,
         args.rows,
-    )?;
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            dlog(&dbg, &format!("spawn_child FAILED: {e:#}"));
+            return Err(e);
+        }
+    };
+    dlog(
+        &dbg,
+        &format!("spawn_child ok: child_pid={}", spawned.child_pid),
+    );
     let started_at = epoch_now();
 
     let meta = HostMeta {
@@ -56,7 +100,6 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         started_at,
     };
 
-    let data_dir = registry::data_dir();
     let registry_path = registry::registry_path(&data_dir, &args.session, &args.window);
     let pipe = registry::pipe_name(&args.session, &args.window);
 
@@ -85,13 +128,14 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         registry_path: registry_path.clone(),
     });
 
-    spawn_reader_thread(spawned.reader, ctx.clone());
+    spawn_reader_thread(spawned.reader, ctx.clone(), dbg.clone());
     spawn_waiter_thread(spawned.child, registry_path.clone());
 
     let security = PipeSecurity::current_user_only()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
+    dlog(&dbg, &format!("serving pipe={pipe}"));
     runtime.block_on(async move {
         // Listen first, then register: a registry entry implies a connectable pipe
         // (PROTOCOL.md §8).
@@ -105,14 +149,41 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
 /// Drain ConPTY output: feed the vt100 screen (bumping `last_activity`) and fan the raw
 /// chunk out to byte subscribers. EOF means the child is gone — the waiter thread owns the
 /// shutdown.
-fn spawn_reader_thread(mut reader: Box<dyn std::io::Read + Send>, ctx: Arc<ServerCtx>) {
+fn spawn_reader_thread(
+    mut reader: Box<dyn std::io::Read + Send>,
+    ctx: Arc<ServerCtx>,
+    dbg: Option<PathBuf>,
+) {
     std::thread::spawn(move || {
         let mut buf = vec![0u8; 64 * 1024];
+        let mut total: u64 = 0;
+        let mut reads: u64 = 0;
         loop {
             match reader.read(&mut buf) {
-                Ok(0) | Err(_) => return,
+                Ok(0) => {
+                    dlog(
+                        &dbg,
+                        &format!("reader EOF after {reads} reads, {total} bytes"),
+                    );
+                    return;
+                }
+                Err(e) => {
+                    dlog(&dbg, &format!("reader ERR after {total} bytes: {e}"));
+                    return;
+                }
                 Ok(n) => {
                     let chunk = &buf[..n];
+                    total += n as u64;
+                    reads += 1;
+                    if reads <= 5 {
+                        dlog(
+                            &dbg,
+                            &format!(
+                                "reader read #{reads} n={n}: {:?}",
+                                String::from_utf8_lossy(&chunk[..n.min(120)])
+                            ),
+                        );
+                    }
                     {
                         let mut dispatcher = ctx.dispatcher.lock().expect("dispatcher lock");
                         dispatcher.process_output(chunk, epoch_now());

--- a/crates/repomon-host/src/run.rs
+++ b/crates/repomon-host/src/run.rs
@@ -1,35 +1,11 @@
 //! Host process assembly (Windows only): parse the spawn contract, start the ConPTY child,
 //! register, and serve until the child dies or a `kill` arrives.
 
-use std::io::Write as _;
-use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 
 use clap::Parser as _;
 use tokio::sync::broadcast;
-
-/// TEMP instrumentation: append a line to `<data_dir>\host-debug-<window>.log` when
-/// `REPOMON_HOST_DEBUG` is set. Used to pin which stage of the ConPTY→screen path breaks on CI.
-fn dlog(path: &Option<PathBuf>, msg: &str) {
-    if let Some(p) = path
-        && let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(p)
-    {
-        let _ = writeln!(f, "[pid {} @ {}] {msg}", std::process::id(), epoch_now());
-    }
-}
-
-fn debug_log_path(data_dir: &std::path::Path, window: &str) -> Option<PathBuf> {
-    // TEMP: unconditional during CI evidence-gathering (data_dir is a per-test tempdir).
-    let safe: String = window
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    Some(data_dir.join(format!("host-debug-{safe}.log")))
-}
 
 use crate::cli::HostArgs;
 use crate::dacl::PipeSecurity;
@@ -59,34 +35,14 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         .split_first()
         .expect("clap enforces a non-empty command");
 
-    let data_dir = registry::data_dir();
-    let dbg = debug_log_path(&data_dir, &args.window);
-    dlog(
-        &dbg,
-        &format!(
-            "run start: program={program:?} args={program_args:?} cwd={:?} cols={} rows={}",
-            args.cwd, args.cols, args.rows
-        ),
-    );
-
-    let spawned = match pty::spawn_child(
+    let spawned = pty::spawn_child(
         program,
         program_args,
         &args.cwd,
         &args.env,
         args.cols,
         args.rows,
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            dlog(&dbg, &format!("spawn_child FAILED: {e:#}"));
-            return Err(e);
-        }
-    };
-    dlog(
-        &dbg,
-        &format!("spawn_child ok: child_pid={}", spawned.child_pid),
-    );
+    )?;
     let started_at = epoch_now();
 
     let meta = HostMeta {
@@ -100,6 +56,7 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         started_at,
     };
 
+    let data_dir = registry::data_dir();
     let registry_path = registry::registry_path(&data_dir, &args.session, &args.window);
     let pipe = registry::pipe_name(&args.session, &args.window);
 
@@ -128,14 +85,13 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
         registry_path: registry_path.clone(),
     });
 
-    spawn_reader_thread(spawned.reader, ctx.clone(), dbg.clone());
+    spawn_reader_thread(spawned.reader, ctx.clone());
     spawn_waiter_thread(spawned.child, registry_path.clone());
 
     let security = PipeSecurity::current_user_only()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    dlog(&dbg, &format!("serving pipe={pipe}"));
     runtime.block_on(async move {
         // Listen first, then register: a registry entry implies a connectable pipe
         // (PROTOCOL.md §8).
@@ -149,41 +105,14 @@ fn run(args: HostArgs) -> anyhow::Result<ExitCode> {
 /// Drain ConPTY output: feed the vt100 screen (bumping `last_activity`) and fan the raw
 /// chunk out to byte subscribers. EOF means the child is gone — the waiter thread owns the
 /// shutdown.
-fn spawn_reader_thread(
-    mut reader: Box<dyn std::io::Read + Send>,
-    ctx: Arc<ServerCtx>,
-    dbg: Option<PathBuf>,
-) {
+fn spawn_reader_thread(mut reader: Box<dyn std::io::Read + Send>, ctx: Arc<ServerCtx>) {
     std::thread::spawn(move || {
         let mut buf = vec![0u8; 64 * 1024];
-        let mut total: u64 = 0;
-        let mut reads: u64 = 0;
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => {
-                    dlog(
-                        &dbg,
-                        &format!("reader EOF after {reads} reads, {total} bytes"),
-                    );
-                    return;
-                }
-                Err(e) => {
-                    dlog(&dbg, &format!("reader ERR after {total} bytes: {e}"));
-                    return;
-                }
+                Ok(0) | Err(_) => return,
                 Ok(n) => {
                     let chunk = &buf[..n];
-                    total += n as u64;
-                    reads += 1;
-                    if reads <= 5 {
-                        dlog(
-                            &dbg,
-                            &format!(
-                                "reader read #{reads} n={n}: {:?}",
-                                String::from_utf8_lossy(&chunk[..n.min(120)])
-                            ),
-                        );
-                    }
                     {
                         let mut dispatcher = ctx.dispatcher.lock().expect("dispatcher lock");
                         dispatcher.process_output(chunk, epoch_now());


### PR DESCRIPTION
## Track I — WindowsBackend (Wave 2)

Implements `SessionBackend` on Windows against the `repomon-agent-host.exe` per-agent host processes, completing tmux-parity durability (agents survive daemon restarts).

Based on **feat/win-integration** (Tracks A + B + C merged) so the diff shows only Track I. Retarget/rebase onto `main` after the Wave-1 PRs (#67, #73, #70, #62) land.

### What's here
- `crates/repomon-core/src/agent/windows.rs` (new, ~1050 lines): `WindowsBackend` — detached host spawning per PROTOCOL.md spawn contract from `SpawnSpec` (no shell strings); sync length-prefixed JSON pipe client; registry scan + `hello` verification + stale-entry GC; **re-adoption of live hosts on daemon start**; `list_windows_with_activity` from registry + hello; owner-token single-owner guard; `open_byte_stream`/`close_byte_stream` via `subscribe_bytes` on a second connection (first frame = replay); `open_named` runs the user shell (COMSPEC/pwsh); all capture/cursor/size/alternate/resize/send_*/scroll/kill ops mapped per the protocol; `attach_command()` returns the `repomon attach-host` invocation.
- Pure decision logic (registry parsing, hello verification, GC rules, liveness mapping) unit-tested on **all** OSes.
- `crates/repomon-core/src/transport.rs`: per-user DACL on the daemon's own IPC pipe (the piece PR #73 deferred to this track), reusing the host's current-user security descriptor. cfg(windows) only; Unix untouched.
- Backend selection in `repomon-daemon/src/lib.rs` (#[cfg]); real `#[cfg(windows)]` liveness arm at the rpc probe site (replaces Track A's `None` stub).
- Windows CI integration tests mirroring `tests/integration.rs` flows without tmux (spawn/capture/input/kill/reap/re-adoption).

### Verification
macOS gate green: fmt, clippy `-D warnings`, `cargo test --workspace --locked` all suites ok (repomon-core lib 214 passed incl. 14 new decision-logic tests). The windows-latest CI leg is the authoritative Windows check.

Do not merge before the Wave-1 chain.