### PR TITLE
docs: native Windows support (Track G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **Run a fleet of AI coding agents across all your repos, from one terminal.**
 
-Many repos × many worktrees × many agents on one screen. Durable in tmux, the ones waiting
-on you float to the top, and you can approve a prompt from your phone.
+Many repos × many worktrees × many agents on one screen. Durable across restarts, the ones
+waiting on you float to the top, and you can approve a prompt from your phone.
 
 <p>
   <a href="https://github.com/AliHamzaAzam/repomon/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/AliHamzaAzam/repomon?color=00b3b3&label=release"></a>
   <img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue">
-  <img alt="Platforms: macOS · Linux" src="https://img.shields.io/badge/macOS%20%C2%B7%20Linux-555">
+  <img alt="Platforms: macOS · Linux · Windows" src="https://img.shields.io/badge/macOS%20%C2%B7%20Linux%20%C2%B7%20Windows-555">
   <img alt="Built with Rust" src="https://img.shields.io/badge/built%20with-Rust-orange">
   <img alt="For Claude Code · Codex · Aider" src="https://img.shields.io/badge/for-Claude%20Code%20%C2%B7%20Codex%20%C2%B7%20Aider-8A2BE2">
 </p>
@@ -49,8 +49,9 @@ repomon is one tool with four **zoom levels**, one selection that follows you th
 - **Focus**: one agent full-screen with full live terminal, input, and controls.
 
 Arrow keys drive everything (`↵`/`→` zoom in, `esc`/`←` zoom out, `space` the grid). Agents
-run in durable tmux sessions, so they survive closing the UI and reattach (`a`) with full
-scrollback. `⏸` flags an agent that needs you; `g` jumps to the next one.
+run in durable sessions (tmux on macOS/Linux, detached host processes on Windows), so they
+survive closing the UI and reattach (`a`) with full scrollback. `⏸` flags an agent that needs
+you; `g` jumps to the next one.
 
 Beyond the live views, three Phase-3 dashboards (keys `2`/`3`/`4`): a per-repo **timeline**
 of commit density with cross-repo correlations, detected **work sessions** (focused vs
@@ -83,14 +84,16 @@ repomon earns its keep once you're running agents across **several** projects at
 
 ## Architecture
 
-A background daemon (`repomond`) owns SQLite, file watchers, the git layer, and the
-tmux-backed agent runtime, exposing a JSON-RPC API over a Unix socket. The TUI (`repomon`)
-is a thin client. Four crates:
+A background daemon (`repomond`) owns SQLite, file watchers, the git layer, and the agent
+runtime, exposing a JSON-RPC API over a local transport (Unix socket on macOS/Linux, named
+pipe on Windows). The agent runtime sits behind a `SessionBackend` trait: tmux on macOS/Linux,
+and per-agent host processes on Windows. The TUI (`repomon`) is a thin client. Five crates:
 
-- `repomon-core`: data model, gix git layer, SQLite store, watchers, agent runtime.
-- `repomon-daemon`: the `repomond` socket server and background services.
+- `repomon-core`: data model, gix git layer, SQLite store, watchers, agent runtime (`SessionBackend`).
+- `repomon-daemon`: the `repomond` socket/pipe server and background services.
 - `repomon-tui`: the `repomon` terminal UI.
 - `repomon-mcp`: repomind's MCP server (`repomond mcp`), exposing the fleet to an orchestrator agent over stdio.
+- `repomon-host`: `repomon-agent-host.exe`, the per-agent ConPTY host that gives Windows tmux-style durability (Windows only).
 
 ## Install
 
@@ -117,10 +120,42 @@ on your `PATH`.
 cargo install --git https://github.com/AliHamzaAzam/repomon repomon-tui repomon-daemon
 ```
 
-repomon needs `tmux` (agents run in tmux) and `git` at runtime. Windows isn't supported natively
-yet; use **WSL2** (the Linux build runs there).
-
+On macOS and Linux repomon needs `tmux` (agents run in tmux) and `git` at runtime.
 Don't have `tmux`? Install it: `brew install tmux` (macOS), `sudo apt install tmux` (Debian / Ubuntu / WSL2), `sudo dnf install tmux` (Fedora), `sudo pacman -S tmux` (Arch).
+
+**Windows** (native, no WSL, no tmux):
+
+Native Windows support has landed. There is currently a **preview build on the
+`release/windows-preview` branch** and **no published GitHub release yet**, so the
+`irm | iex` one-liner below will only work once a Windows release is tagged.
+
+Until then, build from source with the Rust toolchain (edition 2024, toolchain 1.95.0) and
+a Git for Windows install:
+
+```powershell
+git clone https://github.com/AliHamzaAzam/repomon
+cd repomon
+git switch release/windows-preview
+cargo build --release
+# repomon.exe, repomond.exe and repomon-agent-host.exe land in target\release\.
+# Copy all three into one directory on your PATH (they must live together).
+```
+
+Once a release is tagged, the installer downloads prebuilt binaries (no Rust toolchain
+needed) and puts the three exes in `%LOCALAPPDATA%\Programs\repomon` on your user PATH:
+
+```powershell
+irm https://github.com/AliHamzaAzam/repomon/releases/latest/download/install.ps1 | iex
+```
+
+Env overrides mirror `install.sh`: `REPOMON_INSTALL_DIR` (install location) and
+`REPOMON_VERSION` (a tag to pin instead of latest).
+
+Then enable cd-on-exit by adding to your PowerShell profile (`$PROFILE`):
+
+```powershell
+repomon shell-init powershell | Out-String | Invoke-Expression
+```
 
 Then enable cd-on-exit by adding to your `~/.zshrc` (or `~/.bashrc`):
 
@@ -147,6 +182,26 @@ On Linux this writes `~/.config/systemd/user/repomon.service`; run
 - Clipboard copy uses `wl-copy` (Wayland) or `xclip` (X11); inside tmux, drag-select falls
   back to OSC52 when neither is installed. Image paste needs `wl-paste` or `xclip`.
 - Click-to-focus notifications are macOS-only (`terminal-notifier`).
+
+### Windows platform notes
+
+- **No tmux, no WSL.** On Windows repomon runs natively. Each agent runs in its own detached
+  host process (`repomon-agent-host.exe`, a ConPTY + server-side terminal emulator) that plays
+  exactly the durability role tmux plays on Unix: agents survive daemon restarts and re-adopt
+  with full scrollback. The daemon talks to the TUI and to the hosts over named pipes instead
+  of Unix sockets.
+- **Windows Terminal recommended.** repomon runs in any modern console, but Windows Terminal
+  gives the best rendering and is where the pop-out attach opens a new tab.
+- **ConPTY floor: Windows 10 1809.** The host relies on ConPTY, which requires Windows 10
+  version 1809 or newer (Windows 11 fully supported). Claude Code on native Windows needs Git
+  for Windows.
+- **Keep the three exes together.** `repomon.exe`, `repomond.exe`, and `repomon-agent-host.exe`
+  must live in the **same directory**; the daemon spawns the host by looking next to itself.
+  `install.ps1` and the release zip already place all three together.
+- **Unsigned binaries → SmartScreen.** The release binaries are not yet code-signed, so
+  Windows SmartScreen may warn on first run ("Windows protected your PC"). Choose *More info →
+  Run anyway*, or unblock the zip before extracting (`Unblock-File`). Signing is on the
+  roadmap.
 
 ## Usage
 
@@ -213,6 +268,13 @@ writes the path to the file descriptor in `$REPOMON_CD_FD`; add the wrapper to y
 eval "$(repomon shell-init zsh)"   # bash: repomon shell-init bash · fish: repomon shell-init fish
 ```
 
+On **Windows / PowerShell** the wrapper reads the path from a temp file (`$REPOMON_CD_FILE`)
+instead of an inherited file descriptor; add it to your `$PROFILE`:
+
+```powershell
+repomon shell-init powershell | Out-String | Invoke-Expression
+```
+
 ## Remote access (open bridge over Tailscale)
 
 The daemon serves the same JSON-RPC API over a token-gated WebSocket bridge, so you can drive
@@ -243,6 +305,8 @@ Manage it with `repomon remote status` (shows the bind and a masked token),
 - [docs/architecture.md](docs/architecture.md): how the daemon, TUI, and core fit together.
 - [docs/protocol.md](docs/protocol.md): the JSON-RPC socket reference.
 - [docs/agents.md](docs/agents.md): how agents run and how status is detected.
+- [docs/windows-validation.md](docs/windows-validation.md): the manual Windows 11 end-to-end validation gate.
+- [crates/repomon-host/PROTOCOL.md](crates/repomon-host/PROTOCOL.md): the frozen Windows agent-host control protocol.
 
 ## Status
 
@@ -251,10 +315,15 @@ babysit grid, multi-agent lanes), the history dashboard (timeline/sessions/searc
 per-session notifications (pane-sniffed permission-dialog detection, fired as desktop popups
 even when the TUI is closed or parked full-screen in an agent), the remote access layer
 (WebSocket bridge + APNs + pairing), and repomind (the MCP-driven fleet orchestrator —
-`repomon orchestrate` and the TUI command-center) are all in, on macOS and Linux (systemd
-service, notifications, clipboard, and process probing all have native Linux paths). The iOS
-companion app is built and ships once an Apple Developer account is in place. Deferred: an
-embedded PTY renderer (vs the tmux pivot), a web dashboard, and Windows support.
+`repomon orchestrate` and the TUI command-center) are all in, on macOS, Linux, and Windows.
+Each platform has native paths for the service, notifications, clipboard, and process/agent
+liveness. **Native Windows support has landed** (code-complete and CI-green on
+`x86_64-pc-windows-msvc`): a `SessionBackend` trait with a tmux backend on Unix and a
+host-process backend on Windows, named-pipe IPC, and `repomon-agent-host.exe` for
+durability parity. It still awaits a physical Windows 11 end-to-end pass and binary signing
+before a Windows release is tagged (see [docs/windows-validation.md](docs/windows-validation.md)).
+The iOS companion app is built and ships once an Apple Developer account is in place.
+Deferred: a web dashboard.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,8 +3,21 @@
 _Snapshot: 2026-07-06 · branch `main` · 248 commits · github.com/AliHamzaAzam/repomon (public)_
 
 repomon is a Rust TUI for running a fleet of AI coding agents across many repos,
-branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned milestones
-(M0–M13) are complete and the quality/perf gates pass — ready for hands-on testing.**
+branches, and worktrees, backed by a session-owning daemon (tmux on macOS/Linux, per-agent
+host processes on Windows). **Verdict: all planned milestones (M0–M13) are complete and the
+quality/perf gates pass — ready for hands-on testing.**
+
+**Native Windows support has landed** (branch `release/windows-preview`, size-M port across
+Tracks A–I). It is **code-complete and CI-green** on `x86_64-pc-windows-msvc`: the workspace
+builds, `cargo fmt`/clippy are clean, and the test suite passes on the `windows-latest` CI leg
+(tmux-only tests self-skip; the new host and backend integration tests run). The design keeps
+the JSON-RPC wire protocol frozen (iOS-safe) and full durability parity: a `SessionBackend`
+trait with a tmux backend on Unix and a host-process backend on Windows, named-pipe IPC, and
+`repomon-agent-host.exe` (ConPTY + server-side vt100) whose detached hosts survive daemon
+restarts and are re-adopted on start. **Two gates remain before a Windows release is tagged:**
+a physical Windows 11 end-to-end pass ([docs/windows-validation.md](docs/windows-validation.md))
+and binary signing (unsigned binaries trip SmartScreen). There is a preview build on
+`release/windows-preview` and **no published Windows GitHub release yet**.
 
 ## Plan completion (M0–M13) ✅
 
@@ -64,9 +77,53 @@ branches, and worktrees, backed by a tmux-owning daemon. **Verdict: all planned 
   wl-paste/xclip, and a /proc-based liveness probe. CI runs the suite on macOS + Ubuntu;
   releases ship x86_64 and aarch64 Linux binaries.
 
+## Native Windows port (branch `release/windows-preview`)
+
+Code-complete, CI-green, awaiting a physical E2E pass and signing. What landed:
+
+- **Track A, IPC transport + portability.** A `transport` abstraction (Unix socket ⇄ named
+  pipe); pipe-name socket default, `USERNAME`/`getrandom`/`$HOME` and PATHEXT-aware lookup,
+  detached daemon spawn, and a `windows-latest` CI leg.
+- **Track B, `SessionBackend` extraction.** The ~25-method trait lifted from `TmuxRuntime`
+  (the single tmux choke point); `Ctx.backend: Arc<dyn SessionBackend>`; `SpawnSpec` replaces
+  shell strings; the FIFO byte stream folded into `open_byte_stream`. Zero behavior change on
+  Unix.
+- **Track C, `repomon-host` crate.** `repomon-agent-host.exe`: ConPTY + server-side `vt100`
+  with 50k scrollback + a named-pipe control server, against a frozen
+  [PROTOCOL.md](crates/repomon-host/PROTOCOL.md).
+- **Track I, `WindowsBackend`.** Host spawning, registry scan + `hello` verification + stale
+  GC, **re-adoption on daemon start** (durability parity), and a Windows liveness arm that asks
+  the hosts instead of `ps`/`lsof`.
+- **Tracks D1–D4, platform services.** `Set-Clipboard`/`Get-Clipboard` + image paste, WinRT
+  toasts, a Task Scheduler service arm, and PowerShell `shell-init` with a `REPOMON_CD_FILE`
+  temp-file cd-on-exit.
+- **Track E + follow-up, packaging.** `install.ps1` and a `windows-latest` release job; the
+  `x86_64-pc-windows-msvc` leg is now **required**, aarch64 stays best-effort.
+- **Track F, attach.** `repomon attach-host` raw byte proxy + the embedded focus view, popped
+  out into a Windows Terminal tab.
+
+## Cutting a Windows release
+
+The Windows binaries are built and packaged by `.github/workflows/release.yml`:
+
+- **Trigger.** A `v*` tag runs the whole release (macOS, Linux, Windows). A
+  `workflow_dispatch` on any branch runs **only** `build-windows`, so the Windows packaging can
+  be validated before a real tag (it stamps a `0.0.0-<sha>` dev version).
+- **Artifacts.** `build-windows` produces `repomon-<version>-<target>.zip` (containing
+  `repomon.exe` + `repomond.exe` + `repomon-agent-host.exe`) and a matching `.zip.sha256`,
+  uploaded per target.
+- **Targets.** `x86_64-pc-windows-msvc` is **required** (the port has landed); the
+  `aarch64-pc-windows-msvc` leg is **best-effort** (`experimental: true`, `continue-on-error`),
+  and the release step uses `nullglob` so a release without the ARM64 zip still succeeds.
+- **Publish.** The tag-gated `release` job attaches every `*.zip`/`*.zip.sha256` (alongside the
+  macOS/Linux tarballs) plus `install.sh` and `install.ps1` to the GitHub release.
+- **TODO before shipping.** Binary **code-signing** is not wired yet; unsigned binaries trip
+  SmartScreen on first run. Sign the three exes before or as part of the first Windows release.
+  (Do not edit `release.yml` for docs work; this note only describes the existing flow.)
+
 ## Deferred (explicitly out of scope in the plan)
 
-SwiftUI menu-bar app · native repomon-owned PTY mode · web dashboard · Windows. None blocking.
+SwiftUI menu-bar app · native repomon-owned PTY mode · web dashboard. None blocking.
 
 ## Known limitations to keep in mind while testing
 
@@ -76,8 +133,8 @@ SwiftUI menu-bar app · native repomon-owned PTY mode · web dashboard · Window
 - **cd-on-exit (`c`)** only acts when the `repomon` shell function is installed (it sets
   `$REPOMON_CD_FD`); otherwise it shows a hint instead of quitting.
 - In agent views (Focus/Split/Grid) the daemon refreshes ~1 s and runs a cached liveness
-  probe (`ps`+`lsof` on macOS, `/proc` on Linux) — light, but slightly more active than the
-  0% Fleet idle.
+  probe (`ps`+`lsof` on macOS, `/proc` on Linux; on Windows the hosts report child liveness
+  directly, no scan); light, but slightly more active than the 0% Fleet idle.
 
 ## Suggested next steps
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,20 +1,26 @@
 # Agents
 
-repomon runs every agent the same way — each in its own durable tmux window — but it learns
+repomon runs every agent the same way (each in its own durable session window), but it learns
 each agent's *status* differently, because each CLI stores its session state differently.
 
 ## How agents run
 
 When you spawn an agent (New Lane, the `e` key, or `agent.spawn`), the daemon launches its
-CLI in a tmux window named `lane-<id>` inside the configured session (default `repomon`):
+CLI in a window named `lane-<id>` inside the configured session (default `repomon`). On
+macOS/Linux that window is a tmux window:
 
 ```
 tmux new-window -t repomon -n lane-7 -c <worktree> '<agent-binary> [task]'
 ```
 
-The daemon reads output with `capture-pane`, sends input with `send-keys`, and `attach`
-gives you the raw session. Because tmux owns the process, the agent survives the daemon and
-the TUI. The spawned kind is recorded on the lane so repomon can identify it later.
+On **Windows** there is no tmux: the daemon spawns a detached host process,
+`repomon-agent-host.exe`, per window (`\\.\pipe\repomon-<session>-<window>`). The host owns a
+ConPTY child and a server-side terminal emulator with scrollback, and it plays the exact
+durability role tmux plays on Unix. Either way the daemon reads output with `capture_named`
+(`capture-pane` / host `capture`), sends input with `send_*` (`send-keys` / host `send_text`),
+and attach hands you the raw session. Because the session backend owns the process (a tmux
+server or a detached host), the agent survives the daemon and the TUI. The spawned kind is
+recorded on the lane so repomon can identify it later.
 
 Several agents can run in the **same** worktree at once: a second spawn (or adopting an
 external session into an occupied lane) takes the next slot — `lane-<id>-2`, `lane-<id>-3`,
@@ -92,6 +98,19 @@ exactly as it would standalone.
 > Why attach rather than emulate? The in-app view is a `capture-pane` *picture* plus
 > `send-keys`; it can't carry a nested terminal's scroll wheel or real clipboard-image paste.
 > Attaching hands you the actual PTY, so the focused agent is indistinguishable from native.
+
+#### On Windows
+
+There is no tmux to hand off, so attach works in two layers. The **embedded focus view**
+renders the agent from the host's server-side terminal (`capture` + `cursor` + `alternate_on`)
+and forwards input the same way it does on Unix. For a genuine terminal, `↵`/`→`/`a` **pops
+out** the agent into a new Windows Terminal tab running `repomon attach-host <window>`, a raw
+byte proxy that subscribes to the host's byte stream (`subscribe_bytes`), pipes your keystrokes
+back, and tracks console resizes. Because a subscribed connection ignores client frames, the
+attach client opens a second control connection for input and resize while the first streams
+the pane. **Press `F12` to detach** (tmux-parity); detaching leaves the agent running in its
+host process. If Windows Terminal (`wt.exe`) is not available the client falls back to a new
+console window.
 
 ### Quick mediated type — `i`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,14 @@
 # Architecture
 
 repomon is a background **daemon** plus a thin **TUI** client, sharing a **core** library.
-The daemon owns all state and all git/tmux work; the TUI only renders cached state and
+The daemon owns all state and all git/session work; the TUI only renders cached state and
 forwards input. That split is what keeps the UI instant and lets agents outlive the UI.
+
+The agent runtime is abstracted behind a `SessionBackend` trait: a tmux backend on
+macOS/Linux and a host-process backend on Windows (see
+[Session backends](#session-backends-tmux-on-unix-host-processes-on-windows) below). Local
+IPC runs over a Unix socket on macOS/Linux and a named pipe on Windows; the JSON-RPC wire
+protocol is identical on both.
 
 ```
       ┌───────────────────────── repomon-core ────────────────────────┐
@@ -25,18 +31,25 @@ forwards input. That split is what keeps the UI instant and lets agents outlive 
 
 ## Crates
 
-- **repomon-core** — the engine. No UI, no socket server. Holds the data model, the SQLite
+- **repomon-core**: the engine. No UI, no socket server. Holds the data model, the SQLite
   store (a dedicated writer thread; never blocks the runtime), the gix-backed git reader and
-  `git worktree` shellout, the notify watcher, the repo registry and lane manager, the
-  tmux-backed agent runtime and the agent monitors, the Phase-3 analytics/sessions/indexer,
-  service management (launchd on macOS, systemd user units on Linux), and the shared
-  JSON-RPC protocol + framing.
-- **repomon-daemon** (`repomond`) — hosts core behind a length-prefixed JSON-RPC Unix socket.
-  Owns the `Ctx` (store, registry, lanes, tmux runtime, event bus, viewport + focus, and the
-  overlay/status caches), the per-connection socket handling, RPC dispatch, the output streamer,
-  the desktop/remote notification watcher, and the background indexer.
-- **repomon-tui** (`repomon`) — the terminal client and headless CLI. A `DaemonClient` over
-  the socket, an async app loop, the four-zoom views, and the `repomon …` subcommands.
+  `git worktree` shellout, the notify watcher, the repo registry and lane manager, the agent
+  runtime behind the `SessionBackend` trait (tmux on Unix, host processes on Windows) and the
+  agent monitors, the local transport abstraction (Unix socket ⇄ named pipe), the Phase-3
+  analytics/sessions/indexer, service management (launchd on macOS, systemd user units on
+  Linux, Task Scheduler on Windows), and the shared JSON-RPC protocol + framing.
+- **repomon-daemon** (`repomond`): hosts core behind a length-prefixed JSON-RPC endpoint (a
+  Unix socket on macOS/Linux, a named pipe on Windows). Owns the `Ctx` (store, registry, lanes,
+  the `SessionBackend`, event bus, viewport + focus, and the overlay/status caches), the
+  per-connection handling, RPC dispatch, the output streamer, the desktop/remote notification
+  watcher, and the background indexer.
+- **repomon-tui** (`repomon`): the terminal client and headless CLI. A `DaemonClient` over
+  the transport, an async app loop, the four-zoom views, the `repomon attach-host` pop-out
+  attach client (Windows), and the `repomon …` subcommands.
+- **repomon-host** (`repomon-agent-host.exe`, Windows only) is a small per-agent host process:
+  one ConPTY child, a server-side `vt100` screen with scrollback, and a named-pipe control
+  server. It is the Windows equivalent of a tmux window and survives daemon restarts. Its
+  control protocol is frozen in [../crates/repomon-host/PROTOCOL.md](../crates/repomon-host/PROTOCOL.md).
 
 ## Key flows
 
@@ -45,13 +58,16 @@ computes live state with gix off the runtime, overlays agent sessions (Claude tr
 Aider history → tmux-alive fallback), and returns lanes. The TUI renders cached state
 immediately on every keystroke; git never runs on the UI thread.
 
-**Live agents.** The daemon spawns each agent in its own tmux window — the first at
+**Live agents.** The daemon spawns each agent in its own session backend window: the first at
 `lane-<id>`, additional agents sharing a worktree at `lane-<id>-2`, `lane-<id>-3`, … so
-several run side by side. The TUI tells the daemon which lanes are visible (and which agent
-window the focused lane should stream) via `viewport.set`; a streamer fast-polls only those
-panes (`capture-pane`) and pushes `event.agent.output`. Input goes back via `agent.send_input`
-(`send-keys`), routed to a specific window in a multi-agent lane; `agent.target` + a raw
-`tmux attach` gives the unmediated session.
+several run side by side. (On Unix a "window" is a tmux window; on Windows it is a host
+process; see [Session backends](#session-backends-tmux-on-unix-host-processes-on-windows).)
+The TUI tells the daemon which lanes are visible (and which agent window the focused lane
+should stream) via `viewport.set`; a streamer fast-polls only those panes (`capture_named` /
+`capture-pane`) and pushes `event.agent.output`. Input goes back via `agent.send_input`
+(`send-keys` on Unix, a host `send_*` op on Windows), routed to a specific window in a
+multi-agent lane; `agent.target` + a raw attach (`tmux attach`, or `repomon attach-host` on
+Windows) gives the unmediated session.
 
 **Change propagation.** A debounced notify watcher (250 ms; `.git/objects` and build/dependency
 churn like `target` and `node_modules` excluded) plus the Claude projects directory feed
@@ -86,6 +102,71 @@ confirm tokens for destructive actions — is the *sole* gate on what repomind c
 daemon's `notify_watch` tick, the same one that fires desktop alerts for lane agents, also
 classifies repomind's own attention (a pending dialog, or — Claude only — an idle end-of-turn)
 each pass and broadcasts it as `event.orchestrator.status`.
+
+## Session backends (tmux on Unix, host processes on Windows)
+
+Every place the runtime spawns, captures, sends input to, resizes, streams, or kills an agent
+goes through one trait, `SessionBackend` (`crates/repomon-core/src/agent/backend.rs`). There
+are two implementations and nothing else in the daemon knows which is live:
+
+- **Unix, `TmuxRuntime`.** Unchanged behavior. tmux owns the durable, out-of-process agent
+  runtime; the trait methods render to `tmux` subcommands (`new-window`, `capture-pane`,
+  `send-keys`, `resize-window`, `pipe-pane`, `attach`, `kill-window`).
+- **Windows, `WindowsBackend`.** No tmux. Each agent runs in its own detached host process,
+  `repomon-agent-host.exe`, which owns a ConPTY child plus a server-side `vt100` screen with
+  50 000 lines of scrollback (parity with tmux `history-limit 50000`). The backend is a
+  named-pipe client of those hosts.
+
+Commands are assembled structurally as a `SpawnSpec { program, args, cwd, env }` rather than a
+shell string: the tmux backend renders it through its existing shell-quoting, and the Windows
+host feeds it straight to ConPTY, so there is no `sh -c` or `cmd /c` quoting on Windows.
+
+### tmux-parity mapping
+
+| Concept | Unix (tmux) | Windows (host processes) |
+|---|---|---|
+| process registry | tmux window names on a dedicated tmux server | host registry dir + named pipes: `<data_dir>\hosts\<session>\<window>.json` |
+| agent process owner | tmux server (out-of-process, durable) | one `repomon-agent-host.exe` per window, detached, survives daemon restarts |
+| PTY | tmux-owned pty | ConPTY (`portable-pty`) inside the host |
+| capture-pane | `tmux capture-pane -e -p` | server-side `vt100` screen render (the source of truth; ConPTY quirks do not leak) |
+| byte stream | `pipe-pane` + `mkfifo` FIFO | host byte subscription over its pipe (`subscribe_bytes`) |
+| send input | `tmux send-keys` | host writes translated VT sequences to the ConPTY |
+| resize | `tmux resize-window` | host resizes the ConPTY + vt100 screen (last-client-wins) |
+| attach | `tmux attach` (PTY handoff) | `repomon attach-host <window>` raw byte proxy in a new Windows Terminal tab |
+| owner guard | `@repomon-owner` tmux server option | owner token in the registry file + `hello` handshake |
+| kill-window | `tmux kill-window` | host kills the child, removes its registry entry, exits |
+
+### Durability and re-adoption (Windows)
+
+Hosts are spawned with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` and keep running when the
+daemon dies, the same durability tmux gives on Unix. On startup `WindowsBackend` scans the
+registry directory, connects to each pipe, verifies the `hello` (owner token + liveness), GCs
+stale entries whose pipe will not connect, and **re-adopts** the surviving hosts with scrollback
+intact. This is the Windows equivalent of the daemon rediscovering an existing tmux server.
+Liveness on Windows skips the Unix `ps`/`lsof`//proc probe entirely: a host authoritatively
+knows whether its child is alive, so the backend asks it directly.
+
+### Named-pipe control protocol
+
+Each host serves one pipe, `\\.\pipe\repomon-<session>-<window>`, secured with a per-user DACL.
+The wire format is length-prefixed JSON with request/response ops (`hello`, `capture`, `cursor`,
+`size`, `alternate_on`, `resize`, `send_literal`, `send_text`, `send_key`, `scroll_wheel`,
+`subscribe_bytes`, `kill`). The full, frozen contract is
+[../crates/repomon-host/PROTOCOL.md](../crates/repomon-host/PROTOCOL.md). Three points worth
+calling out because clients (the daemon backend and the attach client) depend on them:
+
+- **The byte stream is a raw byte channel.** `subscribe_bytes` switches the connection to
+  stream mode; its **first** frame is a full current-screen replay (a client that starts a
+  fresh emulator, applies frame 1, then applies subsequent frames verbatim converges exactly),
+  and every later frame is a raw PTY output chunk.
+- **A client derives the pipe name from config.** The `<window>` half of the pipe name is the
+  tmux/host window id; the `<session>` half is `config.tmux_session` (default `repomon`), the
+  same session name the tmux backend uses. A client that knows the window and the configured
+  session name can compute the pipe without a lookup.
+- **An interactive attach uses two connections.** Once a connection has issued
+  `subscribe_bytes` the host ignores any further client frames on it (disconnect is the only
+  unsubscribe), so an attach client opens a **second** control connection for `resize` /
+  `send_*` while the first streams bytes to the terminal.
 
 ## Performance posture
 

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -1,0 +1,57 @@
+# Windows end-to-end validation
+
+The native Windows port is code-complete and CI-green on `x86_64-pc-windows-msvc` (build,
+`cargo fmt`, clippy, and the workspace test suite, with the tmux-only tests self-skipping and
+the Windows host/backend integration tests running). CI runs on a fresh GitHub `windows-latest`
+runner, which cannot exercise the interactive, durable, multi-process behavior that defines
+repomon.
+
+**This checklist is the remaining manual gate. It requires a physical (or full-VM) Windows 11
+machine** with Windows Terminal, Git for Windows, and native Claude Code installed. Until it
+passes end to end, no Windows release should be tagged, and the binaries stay unsigned (so
+SmartScreen will warn; see the README's Windows platform notes).
+
+Run it against a build from `release/windows-preview` (`cargo build --release`, or `install.ps1`
+once a preview zip exists). Keep `repomon.exe`, `repomond.exe`, and `repomon-agent-host.exe` in
+the same directory.
+
+## Checklist
+
+- [ ] **Install / boot.** `install.ps1` (or a from-source build on PATH) → `repomon` launches,
+      the daemon auto-spawns over the named pipe, the Fleet view renders. Repo/lane CRUD works
+      with no agents yet.
+- [ ] **Service install.** `repomon daemon install` registers a **logon task** via Task
+      Scheduler; the daemon comes back after a sign-out/sign-in. `repomon daemon status` reports
+      it; `repomon daemon uninstall` removes it.
+- [ ] **Spawn a Claude agent + needs-you cycle.** Add a repo → create a lane (worktree under
+      `C:\Users\<u>\code\...`) → spawn a Claude Code agent. It reaches Running, then a
+      permission/end-of-turn prompt floats it to the top as **needs you**; answering it clears
+      the flag.
+- [ ] **Durability / re-adoption.** Kill `repomond.exe` while the agent is mid-work. Relaunch
+      the TUI (or let it auto-start the daemon) → the agent is **re-adopted, still alive, with
+      scrollback intact**. Confirm a hand-killed host's registry entry is GC'd on the next scan.
+- [ ] **Focus view + input.** The embedded focus view renders the live agent from the host's
+      server-side terminal; typing (`i`) reaches the agent.
+- [ ] **Pop-out attach + detach.** `↵`/`→`/`a` opens the agent in a new Windows Terminal tab
+      (`repomon attach-host`). Typing in the tab and the embedded view stay consistent; an
+      alternate-screen TUI (Claude Code) renders correctly. **`F12` detaches** and leaves the
+      agent running.
+- [ ] **Clipboard + image paste.** Copy from a pane lands on the Windows clipboard
+      (`Set-Clipboard`); `Get-Clipboard` paste works; image paste (`v`) saves the clipboard
+      image to a temp PNG and inserts its path.
+- [ ] **Toast on needs-you.** A `needs-you` transition fires a Windows toast notification when
+      the TUI is not already looking at that agent (including with the TUI closed).
+- [ ] **Shell-init cd-on-exit.** `repomon shell-init powershell | iex` in `$PROFILE`; pressing
+      `c` on a lane exits repomon and `cd`s the PowerShell session into that worktree (via the
+      `REPOMON_CD_FILE` temp file).
+- [ ] **iOS pairing against the Windows daemon.** Enable the remote bridge, pair the iOS
+      companion app against the Windows daemon's tailnet address. The JSON-RPC protocol is
+      unchanged across the transport swap, so fleet view, live conversations, and the Approve
+      button should just work.
+
+## After it passes
+
+1. Tag a Windows release (see "Cutting a Windows release" in [../STATUS.md](../STATUS.md)) and
+   test the `install.ps1` one-liner on a clean VM.
+2. Code-sign the three binaries so SmartScreen stops warning; drop the unsigned-binary note from
+   the README once signing ships.


### PR DESCRIPTION
Track G of the native-Windows effort: DOCS ONLY. No `.rs`, `Cargo.*`, `ci.yml`, or `release.yml` touched.

Documents the landed Windows port (code-complete + CI-green on `x86_64-pc-windows-msvc`); the physical Windows 11 E2E pass and binary signing are still pending, and there is no published Windows GitHub release yet (preview build lives on `release/windows-preview`).

## Files
- **README.md** - platform badge -> `macOS · Linux · Windows`; new Windows install section (from-source `cargo build --release` + `install.ps1`, with the preview-branch / no-release caveat on the `irm | iex` one-liner) and a "Windows platform notes" subsection (Windows Terminal, no tmux / no WSL, ConPTY floor Win10 1809, three-exes-together, unsigned SmartScreen note); `SessionBackend` + `repomon-host` in the architecture blurb, the durability line, and the Status section; PowerShell shell-init note.
- **STATUS.md** - native Windows port summary (Tracks A-I), the remaining E2E + signing gates, and a "Cutting a Windows release" note describing the existing `release.yml` flow (workflow_dispatch/tag, zip + `.sha256` of the three exes, required x86_64 leg / best-effort aarch64, signing TODO).
- **docs/architecture.md** - a `SessionBackend` + Windows host-process section: the tmux-parity mapping table, durability via detached hosts + re-adoption on daemon start, and the named-pipe control-protocol pointer to `crates/repomon-host/PROTOCOL.md`, folding in Track F's three clarifications (byte-mode stream with full-screen-replay first frame, `<session>` derived from `config.tmux_session`, two-connection interactive attach).
- **docs/agents.md** - Windows attach notes: embedded focus view + pop-out `repomon attach-host` in a Windows Terminal tab, F12 detach.
- **docs/windows-validation.md** (new) - the manual Windows 11 end-to-end validation checklist from the master plan, labeled as requiring a physical machine.

## Verification
- `cargo fmt --check`: clean.
- `cargo test --workspace --locked`: all suites green (docs-only change).
- No em-dashes introduced in authored prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)