### PR TITLE
feat(tui): Windows attach pop-out wiring (Track F, wiring half)

### DIFF
--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -34,6 +34,12 @@ use crate::notify::{self, NotifEvent, NotifKind};
 use crate::theme::Theme;
 use crate::view;
 
+// The Windows attach pop-out (Track F). Declared here — like `cli::attach_client` — so `lib.rs`
+// stays untouched; the pure-logic argv/launcher helpers are reachable (and dead-code-free) on
+// every OS because `app` is a public module.
+#[path = "popout.rs"]
+pub mod popout;
+
 /// How long an in-app notification banner stays up before reverting to the footer hints.
 pub const NOTIF_BANNER_TTL: Duration = Duration::from_secs(6);
 /// Don't re-fire the same session's notification within this window (suppresses status flapping).
@@ -5184,7 +5190,10 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
     // skips the event-loop's post-burst flush.
     app.flush_pending_input().await;
     // Stop the embedded byte stream while attached: the real terminal shows the pane, and the
-    // sync block re-establishes the emulator on return.
+    // sync block re-establishes the emulator on return. On Windows the attach pops out into a
+    // separate window (below) instead of taking over this terminal, so the embedded render stays
+    // up and the stream keeps running.
+    #[cfg(not(windows))]
     app.stop_emu().await;
     let window = app.selected_window();
     let resp = app
@@ -5215,6 +5224,15 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
         return;
     }
     let spec = AttachSpec::from_parts(target, v.get("attach"));
+    // Windows: pop the agent out into a WT tab / new console and return — the TUI never suspends.
+    // A no-op on Unix, where the tmux-style suspend/attach path below runs unchanged.
+    let title = app
+        .selected_lane()
+        .map(lane_popout_title)
+        .unwrap_or_else(|| popout_title(&spec));
+    if attach_via_popout(app, &spec, &title) {
+        return;
+    }
     app.input_suspended.store(true, Ordering::Relaxed);
     // Tell the daemon we're parking now so it takes over desktop popups on its next tick rather
     // than waiting out LOCAL_TTL for our heartbeat to go stale — closes the handoff gap.
@@ -5263,6 +5281,11 @@ async fn do_attach(terminal: &mut DefaultTerminal, app: &mut App, lane: LaneId) 
 /// Suspend the TUI, attach to an arbitrary target (e.g. a plain terminal), then re-enter.
 async fn do_attach_target(terminal: &mut DefaultTerminal, app: &mut App, spec: &AttachSpec) {
     if spec.target.is_empty() {
+        return;
+    }
+    // Windows: pop out into a separate terminal and return (no-op on Unix — the tmux path runs).
+    let title = popout_title(spec);
+    if attach_via_popout(app, spec, &title) {
         return;
     }
     app.input_suspended.store(true, Ordering::Relaxed);
@@ -5383,6 +5406,50 @@ fn parse_attach_field(a: &serde_json::Value) -> Option<(String, Vec<String>)> {
         .map(|s| Some(s.as_str()?.to_string()))
         .collect::<Option<Vec<_>>>()?;
     Some((program, args))
+}
+
+/// Windows: pop the agent out into a *separate* terminal (a Windows Terminal tab, or a new
+/// console when `wt.exe` isn't on PATH) rather than handing over the TUI's terminal, and return
+/// `true` so the caller skips the whole tmux-style suspend/attach/reinit dance. The FleetView
+/// keeps running — including the embedded focus-view render — beside the popped-out window
+/// (plan decision #2: embedded + external window). `title` labels the new tab.
+///
+/// On macOS/Linux this is a no-op returning `false`, so the existing in-terminal attach path
+/// runs unchanged.
+#[cfg(windows)]
+fn attach_via_popout(app: &mut App, spec: &AttachSpec, title: &str) -> bool {
+    match popout::launch(title, &spec.program, &spec.args) {
+        Ok(()) => {
+            app.status = format!("popped {title} out into a new terminal; it's still running")
+        }
+        Err(e) => app.status = format!("couldn't pop out the attach: {e}"),
+    }
+    true
+}
+
+/// macOS/Linux: never pop out — attach in the current terminal (the tmux path below).
+#[cfg(not(windows))]
+fn attach_via_popout(_app: &mut App, _spec: &AttachSpec, _title: &str) -> bool {
+    false
+}
+
+/// A pop-out tab title for a lane agent: the lane's worktree name (`main` for the primary).
+fn lane_popout_title(lane: &Lane) -> String {
+    if lane.worktree.is_main {
+        "main".to_string()
+    } else {
+        lane.worktree.name.clone()
+    }
+}
+
+/// A concise tab title for a popped-out attach: the window name the client attaches to
+/// (`attach-host <window>` → `<window>`), falling back to the raw target.
+fn popout_title(spec: &AttachSpec) -> String {
+    spec.args
+        .last()
+        .cloned()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| spec.target.clone())
 }
 
 /// Run the attach command in the real terminal. `$TMUX` is dropped so a tmux-backed attach

--- a/crates/repomon-tui/src/attach_client.rs
+++ b/crates/repomon-tui/src/attach_client.rs
@@ -407,9 +407,10 @@ mod windows_impl {
                 }
                 _ = resize_tick.tick() => {
                     let size = console_size();
-                    if size.is_some() && size != last_size {
+                    if let Some((cols, rows)) = size
+                        && size != last_size
+                    {
                         last_size = size;
-                        let (cols, rows) = size.expect("checked is_some");
                         report(ctrl.request(|id| super::req_resize(id, cols, rows)).await);
                     }
                 }

--- a/crates/repomon-tui/src/popout.rs
+++ b/crates/repomon-tui/src/popout.rs
@@ -1,0 +1,126 @@
+//! Windows attach pop-out: launch the raw byte-proxy attach client (`repomon attach-host
+//! <window>`) in a *separate* terminal so the FleetView TUI keeps running.
+//!
+//! On macOS/Linux "attach" hands the current terminal over to tmux (see [`app::run_attach`] —
+//! it blocks until the user detaches). The TUI has no terminal to give up on Windows, so it
+//! pops the agent out instead: into a titled Windows Terminal tab when `wt.exe` is on PATH, and
+//! otherwise a brand-new console (`CREATE_NEW_CONSOLE`). Both keep the embedded focus-view
+//! renderer live alongside them (decision #2 in the plan: embedded + external window).
+//!
+//! The launcher choice and the `wt.exe` argv are pure logic, unit-tested on every OS; only the
+//! process spawn is `#[cfg(windows)]`.
+//!
+//! [`app::run_attach`]: crate::app
+
+/// `CREATE_NEW_CONSOLE`: the fallback attach client gets its own console window rather than
+/// sharing the TUI's (which its raw-VT takeover would corrupt). The `wt.exe` path needs no such
+/// flag — Windows Terminal hosts the client in its own tab's pseudoconsole.
+#[cfg(windows)]
+const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+
+/// Where to pop the attach client out.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Launcher {
+    /// `wt.exe` is on PATH: open the client in a titled new Windows Terminal tab.
+    WindowsTerminal,
+    /// No Windows Terminal: spawn the client in a brand-new console window.
+    NewConsole,
+}
+
+/// Prefer a Windows Terminal tab when `wt.exe` is available, else a fresh console.
+pub fn choose_launcher(wt_on_path: bool) -> Launcher {
+    if wt_on_path {
+        Launcher::WindowsTerminal
+    } else {
+        Launcher::NewConsole
+    }
+}
+
+/// The `wt.exe` argument vector that opens `program args…` in a titled new tab:
+/// `new-tab --title <title> <program> <args…>`. Windows Terminal treats everything after the
+/// `new-tab` options as the commandline to run, so no `--` terminator is used (nor needed — the
+/// attach client's program and args never start with a dash).
+pub fn wt_argv(title: &str, program: &str, args: &[String]) -> Vec<String> {
+    let mut v = vec![
+        "new-tab".to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        program.to_string(),
+    ];
+    v.extend(args.iter().cloned());
+    v
+}
+
+/// Pop the attach client (`program args…`, i.e. `repomon attach-host <window>`) out into a
+/// separate terminal, titled `title`. Returns once the launcher has been spawned — the TUI
+/// never blocks on the popped-out window (unlike the Unix in-terminal attach).
+#[cfg(windows)]
+pub fn launch(title: &str, program: &str, args: &[String]) -> anyhow::Result<()> {
+    use std::os::windows::process::CommandExt;
+    use std::process::Command;
+
+    match choose_launcher(repomon_core::exec::find_in_path("wt").is_some()) {
+        Launcher::WindowsTerminal => {
+            // `wt.exe` is an app-execution alias; CreateProcess resolves it off PATH. It hands
+            // the tab to the running Windows Terminal and exits, so this spawn is fire-and-forget
+            // (never wait on it — the attach client lives under WindowsTerminal.exe, not us).
+            Command::new("wt.exe")
+                .args(wt_argv(title, program, args))
+                .spawn()
+                .map(drop)
+                .map_err(|e| anyhow::anyhow!("couldn't open a Windows Terminal tab: {e}"))
+        }
+        Launcher::NewConsole => {
+            // No stdio redirection: CREATE_NEW_CONSOLE allocates a fresh console for the child,
+            // and the attach client needs those real console handles for its raw-VT takeover.
+            // The child outlives the TUI (Windows never auto-reaps it), matching a pop-out tab.
+            Command::new(program)
+                .args(args)
+                .creation_flags(CREATE_NEW_CONSOLE)
+                .spawn()
+                .map(drop)
+                .map_err(|e| anyhow::anyhow!("couldn't open a new console: {e}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chooses_windows_terminal_when_wt_is_on_path() {
+        assert_eq!(choose_launcher(true), Launcher::WindowsTerminal);
+        assert_eq!(choose_launcher(false), Launcher::NewConsole);
+    }
+
+    #[test]
+    fn wt_argv_opens_a_titled_new_tab_running_the_client() {
+        // The exact pop-out invocation: `wt.exe new-tab --title lane-3-1 repomon attach-host
+        // lane-3-1`. No `--` terminator (WT reads the trailing tokens as the commandline).
+        let args = wt_argv(
+            "lane-3-1",
+            "repomon",
+            &["attach-host".to_string(), "lane-3-1".to_string()],
+        );
+        assert_eq!(
+            args,
+            vec![
+                "new-tab",
+                "--title",
+                "lane-3-1",
+                "repomon",
+                "attach-host",
+                "lane-3-1",
+            ]
+        );
+    }
+
+    #[test]
+    fn wt_argv_preserves_a_title_with_spaces_as_one_token() {
+        // Rust quotes args with spaces for CreateProcess; WT's own arg parse then reconstructs
+        // the single `--title` token, so a lane label with spaces stays intact.
+        let args = wt_argv("my feature", "repomon", &["attach-host".to_string()]);
+        assert_eq!(args[2], "my feature");
+    }
+}


### PR DESCRIPTION
## Track F, wiring half — Windows attach pop-out

Wires the already-merged Windows attach **client** (`repomon attach-host <window>`) into the FleetView TUI so the attach keys work on Windows. On macOS/Linux the tmux attach path is untouched.

### What this does
On Windows the TUI has no terminal to give up, so "attach" **pops the agent out** into a separate window rather than the Unix-style in-terminal handoff:
- `wt.exe new-tab --title <lane> repomon attach-host <window>` when Windows Terminal is on PATH, or
- a fresh console via `CREATE_NEW_CONSOLE` when `wt.exe` isn't found.

The FleetView keeps running beside the popped-out window, and the embedded focus-view render stays live (plan decision #2: embedded + external window). The plain-terminal (`terminal.open`, user shell via the backend's `open_named`) and orchestrator attach keys route through the same path, so they pop out too.

### How
- New `crates/repomon-tui/src/popout.rs`: `choose_launcher` (wt-vs-console from PATH) and `wt_argv` are **pure logic, unit-tested on every OS**; only `launch` (the spawn) is `#[cfg(windows)]`.
- `do_attach` / `do_attach_target` gain a cfg-split `attach_via_popout` guard: fires on Windows (pop out, return, never suspend) and is a **no-op returning `false` on Unix**, so the tmux suspend/attach/reinit path runs byte-identically. `stop_emu` is skipped on Windows (the embedded stream keeps running under a pop-out).
- Consumes the daemon's existing optional `attach` response field (the Windows backend fills it with `repomon attach-host <window>` via `attach_command()`). **The JSON-RPC wire protocol is unchanged** (iOS-safe); PROTOCOL.md untouched.

### Verification
- macOS gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` (224 + all crate suites pass, incl. 3 new pop-out tests).
- `cfg(windows)` launch type-checked against `x86_64-pc-windows-msvc` via a standalone probe crate (the workspace msvc check fails env-wide on ring/libsqlite3-sys C build scripts; windows-latest CI is authoritative).

### Notes
- No `--` terminator in the `wt.exe` invocation: Microsoft's docs treat everything after `new-tab`'s options as the commandline, and the attach client's program/args never start with a dash. (The plan's illustrative `--` would have been passed through as a bogus program.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)