### PR TITLE
fix: make spawned agents immediately talkable

### DIFF
--- a/crates/repomon-core/src/agent/mod.rs
+++ b/crates/repomon-core/src/agent/mod.rs
@@ -24,7 +24,7 @@ use crate::model::{AgentKind, AgentStatus};
 
 pub use claude::TranscriptSummary;
 pub use limit::{LimitMenu, UsageLimit, detect_usage_limit, menu_select_keys};
-pub use tmux::{TmuxRuntime, shell_quote};
+pub use tmux::{TmuxRuntime, WindowMeta, shell_quote};
 pub use usage::{AccountUsage, UsageReport, UsageWindow, parse_codex_status, parse_usage};
 
 /// How recently a file must have changed for its agent to count as "running".

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -366,7 +366,7 @@ impl TmuxRuntime {
 
     /// Launch `command` for `lane` in `cwd` in the lane's first *free* agent slot — a running
     /// agent is never killed, so spawning again runs a second agent side by side. Returns the
-    /// new window's exact target.
+    /// bare window name accepted by the named-window operations.
     pub fn spawn(&self, lane: LaneId, cwd: &Path, command: &str) -> Result<String> {
         let taken = self.windows_for(lane).unwrap_or_default();
         let window = (1..)
@@ -410,7 +410,7 @@ impl TmuxRuntime {
             ])?;
         }
         self.configure();
-        Ok(self.exact_target(&window))
+        Ok(window)
     }
 
     /// Capture the pane's text, including ANSI color escapes (`-e`).

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -18,6 +18,20 @@ pub struct TmuxRuntime {
     session: String,
 }
 
+/// One window as the overlay probes it ([`TmuxRuntime::list_windows_meta`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowMeta {
+    pub name: String,
+    /// Parsed from `#{window_id}` (`@12` → 12). tmux never reuses window ids within a server,
+    /// so ordering by id is true creation order even when slot NAMES are recycled after an
+    /// exit (`spawn` fills the first free slot). `u64::MAX` when unparsable (sorts last).
+    pub wid: u64,
+    /// The transcript session id bound to this window via the `@repomon_session` window
+    /// option ([`TmuxRuntime::set_window_session`]), if any. tmux destroys window options
+    /// with the window, so a binding can never outlive its agent.
+    pub session: Option<String>,
+}
+
 impl TmuxRuntime {
     pub fn new(session: impl Into<String>) -> Self {
         Self {
@@ -256,6 +270,70 @@ impl TmuxRuntime {
                 Some((name, path, activity))
             })
             .collect())
+    }
+
+    /// One window as the overlay probes it: name, tmux's window id, and the transcript
+    /// session id stuck to it via the `@repomon_session` window option, if bound.
+    pub fn list_windows_meta(&self) -> Result<Vec<WindowMeta>> {
+        // Same single fork the overlay already pays for `list_windows`, richer format string.
+        let out = self.run_allow_absent(&[
+            "list-windows",
+            "-t",
+            &self.session,
+            "-F",
+            "#{window_name}\t#{window_id}\t#{@repomon_session}",
+        ])?;
+        Ok(Self::parse_windows_meta(&out))
+    }
+
+    /// Parse `list_windows_meta` probe lines (`name\t@id\tsession?`).
+    fn parse_windows_meta(out: &str) -> Vec<WindowMeta> {
+        out.lines()
+            .filter_map(|l| {
+                let mut it = l.splitn(3, '\t');
+                let name = it.next()?.to_string();
+                let wid = it
+                    .next()
+                    .and_then(|w| w.strip_prefix('@'))
+                    .and_then(|n| n.parse().ok())
+                    .unwrap_or(u64::MAX);
+                let session = it
+                    .next()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(String::from);
+                Some(WindowMeta { name, wid, session })
+            })
+            .collect()
+    }
+
+    /// Stamp `@repomon_session` on `window` — the overlay binder's write-back, done once per
+    /// agent lifetime. tmux destroys window options with the window, so the binding can never
+    /// outlive its agent (slot-name recycling included). A vanished window is a benign no-op.
+    pub fn set_window_session(&self, window: &str, session_id: &str) -> Result<()> {
+        let target = self.exact_target(window);
+        self.run_allow_absent(&[
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "@repomon_session",
+            session_id,
+        ])?;
+        Ok(())
+    }
+
+    /// [`lane_windows_in`] for metas: `lane`'s agent windows, in slot order.
+    pub fn lane_windows_meta(metas: &[WindowMeta], lane: LaneId) -> Vec<WindowMeta> {
+        let mut slots: Vec<(usize, WindowMeta)> = metas
+            .iter()
+            .filter_map(|m| {
+                let (id, slot) = Self::parse_lane_window(&m.name)?;
+                (id == lane).then(|| (slot, m.clone()))
+            })
+            .collect();
+        slots.sort_by_key(|(s, _)| *s);
+        slots.into_iter().map(|(_, m)| m).collect()
     }
 
     pub fn has_window(&self, lane: LaneId) -> bool {
@@ -685,6 +763,68 @@ mod tests {
         );
         assert_eq!(TmuxRuntime::lane_windows_in(&names, 12), vec!["lane-12"]);
         assert!(TmuxRuntime::lane_windows_in(&names, 3).is_empty());
+    }
+
+    #[test]
+    fn parses_windows_meta_lines() {
+        // `name\t@id\tsession?` — the third field is empty when `@repomon_session` is unset.
+        let out = "lane-1\t@3\tabc-123\nlane-1-2\t@7\t\norchestrator\t@1\t\n";
+        assert_eq!(
+            TmuxRuntime::parse_windows_meta(out),
+            vec![
+                WindowMeta {
+                    name: "lane-1".into(),
+                    wid: 3,
+                    session: Some("abc-123".into()),
+                },
+                WindowMeta {
+                    name: "lane-1-2".into(),
+                    wid: 7,
+                    session: None,
+                },
+                WindowMeta {
+                    name: "orchestrator".into(),
+                    wid: 1,
+                    session: None,
+                },
+            ]
+        );
+        // A malformed window id sorts last (u64::MAX), never panics.
+        assert_eq!(
+            TmuxRuntime::parse_windows_meta("w\tbogus\t\n")[0].wid,
+            u64::MAX
+        );
+        // Empty probe (no server) → no windows.
+        assert!(TmuxRuntime::parse_windows_meta("").is_empty());
+    }
+
+    #[test]
+    fn lane_windows_meta_filters_and_slot_orders() {
+        let wm = |name: &str, wid: u64| WindowMeta {
+            name: name.into(),
+            wid,
+            session: None,
+        };
+        // Exact lane matching (`lane-1` never claims `lane-12`), slot order regardless of
+        // probe order or window id.
+        let metas = vec![
+            wm("lane-1-2", 9),
+            wm("lane-12", 4),
+            wm("lane-1", 2),
+            wm("term-1-1", 5),
+            wm("orchestrator", 1),
+        ];
+        let lane1 = TmuxRuntime::lane_windows_meta(&metas, 1);
+        let names: Vec<&str> = lane1.iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, vec!["lane-1", "lane-1-2"]);
+        assert_eq!(
+            TmuxRuntime::lane_windows_meta(&metas, 12)
+                .iter()
+                .map(|w| w.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["lane-12"]
+        );
+        assert!(TmuxRuntime::lane_windows_meta(&metas, 3).is_empty());
     }
 
     #[test]

--- a/crates/repomon-core/src/agent/tmux.rs
+++ b/crates/repomon-core/src/agent/tmux.rs
@@ -178,10 +178,14 @@ impl TmuxRuntime {
         }
         let stderr = String::from_utf8_lossy(&out.stderr);
         // tmux: "can't find window/session/pane: …", "no server running on …",
-        // "error connecting to …" — the target simply isn't there.
+        // "error connecting to …" — the target simply isn't there. `set-option` phrases the
+        // same absence as "no such window/session: …" (tmux ≥ 3.x), unlike the capture/list
+        // commands.
         let absent = stderr.contains("can't find ")
             || stderr.contains("no server running")
-            || stderr.contains("error connecting");
+            || stderr.contains("error connecting")
+            || stderr.contains("no such window")
+            || stderr.contains("no such session");
         if absent {
             Ok(String::new())
         } else {
@@ -307,11 +311,29 @@ impl TmuxRuntime {
             .collect()
     }
 
-    /// Stamp `@repomon_session` on `window` — the overlay binder's write-back, done once per
-    /// agent lifetime. tmux destroys window options with the window, so the binding can never
-    /// outlive its agent (slot-name recycling included). A vanished window is a benign no-op.
+    /// Stamp `@repomon_session` on `window` by NAME — for callers that just created the
+    /// window and know exactly which transcript runs in it (`agent.adopt`). tmux destroys
+    /// window options with the window, so the binding can never outlive its agent (slot-name
+    /// recycling included). A vanished window is a benign no-op.
     pub fn set_window_session(&self, window: &str, session_id: &str) -> Result<()> {
         let target = self.exact_target(window);
+        self.run_allow_absent(&[
+            "set-option",
+            "-w",
+            "-t",
+            &target,
+            "@repomon_session",
+            session_id,
+        ])?;
+        Ok(())
+    }
+
+    /// Stamp `@repomon_session` by window ID (`@N`) — the overlay binder's write-back. The id
+    /// pins the exact window the pairing was computed against: ids are never reused within a
+    /// server, so a slot NAME recycled between the probe and the stamp can't inherit the old
+    /// transcript's binding. A vanished window is a benign no-op.
+    pub fn set_window_session_by_id(&self, wid: u64, session_id: &str) -> Result<()> {
+        let target = format!("@{wid}");
         self.run_allow_absent(&[
             "set-option",
             "-w",

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -47,6 +47,45 @@ pub struct OverlaySession {
     pub worktree: PathBuf,
 }
 
+/// Generation-guarded `lane.list` overlay cache. A fresh scan captures [`Self::generation`]
+/// before doing slow transcript/tmux work and may publish only if no structural invalidation
+/// happened meanwhile. This prevents an older notify-watcher scan from republishing a pre-spawn
+/// snapshot after `agent.spawn` cleared the cache.
+pub struct OverlayCache {
+    generation: u64,
+    entry: Option<(Instant, Vec<Lane>)>,
+}
+
+impl OverlayCache {
+    fn new() -> Self {
+        Self {
+            generation: 0,
+            entry: None,
+        }
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn entry(&self) -> Option<&(Instant, Vec<Lane>)> {
+        self.entry.as_ref()
+    }
+
+    fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.entry = None;
+    }
+
+    pub(crate) fn publish(&mut self, generation: u64, lanes: Vec<Lane>) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.entry = Some((Instant::now(), lanes));
+        true
+    }
+}
+
 /// The dedicated tmux window the repomind orchestrator runs in. Deliberately NOT a `lane-*` name,
 /// so it stays invisible to the lane overlay/reaper and never shows in `lane.list`. Shared by
 /// `rpc` (the RPC dispatch), `notify_watch` (the attention/pane watcher), and this module's own
@@ -156,7 +195,7 @@ pub struct Ctx {
     /// The composite `lane.list` overlay (lanes + live agent sessions), cached for a short TTL so
     /// many clients polling every ~1s don't each re-run the tmux/lsof/transcript scan. Invalidated
     /// on structural changes (spawn/adopt/stop/lane create/delete) so user actions show at once.
-    pub overlay_cache: Mutex<Option<(Instant, Vec<Lane>)>>,
+    pub overlay_cache: Mutex<OverlayCache>,
     /// Cache of the pending-prompt pane sniff per tmux window — a `capture-pane` per Running/Waiting
     /// session is the bulk of the overlay's subprocess cost. Short TTL: a dialog appearing is seen
     /// within it; until then the session reads as it last did. Keyed by window name. Any input sent
@@ -290,7 +329,7 @@ impl Ctx {
             next_conn: AtomicU64::new(0),
             live_cwds: Mutex::new(None),
             cwds_sticky: Mutex::new(HashMap::new()),
-            overlay_cache: Mutex::new(None),
+            overlay_cache: Mutex::new(OverlayCache::new()),
             prompt_cache: Mutex::new(HashMap::new()),
             pane_seen: Mutex::new(HashMap::new()),
             gate_cache: Mutex::new(HashMap::new()),
@@ -320,7 +359,7 @@ impl Ctx {
     /// change (spawn / adopt / stop / lane create / delete) so the action shows up immediately
     /// instead of waiting out the cache TTL.
     pub async fn invalidate_overlay(&self) {
-        *self.overlay_cache.lock().await = None;
+        self.overlay_cache.lock().await.invalidate();
     }
 
     /// Register a new client connection's session and return it. Each transport calls this once on
@@ -727,6 +766,26 @@ mod stream_tests {
             stream_window_for(7, &Some((7, "term-7-1".into()))),
             "lane-7"
         );
+    }
+
+    #[test]
+    fn invalidation_rejects_an_in_flight_overlay_publish() {
+        let mut cache = OverlayCache::new();
+        let stale_generation = cache.generation();
+        assert!(cache.publish(stale_generation, Vec::new()));
+
+        // `agent.spawn` invalidates while a notify-watcher scan that captured the old
+        // generation is still running. That scan must not republish its pre-spawn snapshot.
+        cache.invalidate();
+        assert!(!cache.publish(stale_generation, Vec::new()));
+        assert!(
+            cache.entry().is_none(),
+            "a scan started before invalidation must leave the cache empty"
+        );
+
+        let current_generation = cache.generation();
+        assert!(cache.publish(current_generation, Vec::new()));
+        assert!(cache.entry().is_some());
     }
 
     async fn test_ctx() -> Arc<Ctx> {

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -202,10 +202,11 @@ pub struct Ctx {
     /// count immediately so the vanished agent drops from the `×N` count without waiting out the
     /// `live_cwds` cache TTL.
     pub last_managed_windows: Mutex<HashSet<String>>,
-    /// Last tmux window list a probe returned successfully. Reused for one overlay tick when
-    /// `list_windows` fails transiently (fork/connection fault under load), so a single bad
-    /// snapshot doesn't drop every managed agent — see `rpc::resolve_windows`.
-    pub last_good_windows: Mutex<Vec<String>>,
+    /// Last tmux window list a probe returned successfully (names + window ids +
+    /// `@repomon_session` bindings). Reused for one overlay tick when `list_windows_meta`
+    /// fails transiently (fork/connection fault under load), so a single bad snapshot doesn't
+    /// drop every managed agent — see `rpc::resolve_windows`.
+    pub last_good_windows: Mutex<Vec<repomon_core::agent::WindowMeta>>,
     /// Consecutive empty `list_windows` results. A sudden total-empty is usually a tmux server
     /// bounce, not every agent exiting at once — `resolve_windows` reuses last-good until this
     /// reaches the confirm threshold, so a server restart doesn't mass-fire Idle.

--- a/crates/repomon-daemon/src/reap.rs
+++ b/crates/repomon-daemon/src/reap.rs
@@ -93,7 +93,10 @@ pub(crate) async fn kill_and_forget(ctx: &Ctx, window: &str) {
     let tmux = ctx.tmux.clone();
     let w = window.to_string();
     let _ = tokio::task::spawn_blocking(move || tmux.kill_named(&w)).await;
-    ctx.last_good_windows.lock().await.retain(|w| w != window);
+    ctx.last_good_windows
+        .lock()
+        .await
+        .retain(|w| w.name != window);
     ctx.prompt_cache.lock().await.remove(window);
     ctx.invalidate_overlay().await;
 }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2786,16 +2786,26 @@ fn pair_transcripts_to_windows(
     for (&si, &wi) in chosen.iter().rev().zip(&used) {
         assignment[si] = Some(windows[wi].name.clone());
         taken[wi] = true;
-        // Nominate only transcripts we could ever be confident in: an actively-writing one
-        // IS some window's agent. A quiet one is a stand-in guess (e.g. a fresh spawn whose
-        // .jsonl hasn't appeared yet, with an old transcript filling the display) — show
-        // it, but never nominate it for a binding.
-        if is_fresh(&summaries[si]) {
-            if let Some(sid) = &summaries[si].session_id {
-                if windows[wi].session.as_deref() != Some(sid.as_str()) {
+        // Nominate a transcript for a durable stamp when PANE EVIDENCE could confirm it.
+        // Two routes qualify:
+        //  - it is actively writing (`is_fresh`): it IS some window's agent right now, so
+        //    the evidence pass will find its turn on screen.
+        //  - it is quiet but its window carries NO binding yet AND it has a distinctive
+        //    last-message fingerprint: this recovers an idle agent whose `@repomon_session`
+        //    was lost (a daemon restart of a quiet fleet leaves the window unstamped and no
+        //    transcript fresh, so pass 1 can't reclaim it and this pass never used to try).
+        //    Its pane still shows that last message, so `confirmed_stamps` can reclaim the
+        //    window by evidence. A quiet transcript with no fingerprint stays a display-only
+        //    stand-in — there is nothing to confirm — and a released stale binding
+        //    (`session.is_some()`) is left for a fresh claimant, never re-stamped from a guess.
+        if let Some(sid) = &summaries[si].session_id {
+            if windows[wi].session.as_deref() != Some(sid.as_str()) {
+                let needle = message_fingerprint(summaries[si].last_message.as_deref());
+                if is_fresh(&summaries[si]) || (windows[wi].session.is_none() && needle.is_some())
+                {
                     new_bindings.push(BindingCandidate {
                         sid: sid.clone(),
-                        needle: message_fingerprint(summaries[si].last_message.as_deref()),
+                        needle,
                     });
                 }
             }
@@ -4201,6 +4211,18 @@ mod tests {
         }
     }
 
+    /// A `tsum` that also carries a last message, so it has a pane-evidence fingerprint.
+    fn tsum_msg(
+        sid: &str,
+        last_activity: chrono::DateTime<chrono::Utc>,
+        last_message: &str,
+    ) -> agent::TranscriptSummary {
+        agent::TranscriptSummary {
+            last_message: Some(last_message.to_string()),
+            ..tsum(sid, last_activity)
+        }
+    }
+
     fn candidate_sids(p: &Pairing) -> Vec<&str> {
         p.new_bindings.iter().map(|b| b.sid.as_str()).collect()
     }
@@ -4357,6 +4379,92 @@ mod tests {
         let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
         assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
         assert_eq!(candidate_sids(&p), vec!["x"]);
+    }
+
+    #[test]
+    fn idle_agent_recovers_its_unstamped_window_by_pane_evidence() {
+        // Daemon restarted a quiet fleet: the agent's `@repomon_session` is gone (unstamped
+        // window) and it went idle far longer than RECENTLY_ACTIVE_SECS ago. Its pane still
+        // shows its last message, so it MUST be nominated for a pane-evidence stamp — before
+        // this fix a quiet transcript was never nominated and the window stayed unrecoverable,
+        // so the positional guess wedged and reopening attached the wrong conversation.
+        let msg = "recovered idle agent distinctive last message tail marker";
+        let windows = vec![wm("lane-7", 1, None)];
+        let p = pair_transcripts_to_windows(&[tsum_msg("a", t(0), msg)], &windows, t(100));
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(candidate_sids(&p), vec!["a"]);
+        assert_eq!(p.new_bindings[0].needle, message_fingerprint(Some(msg)));
+    }
+
+    #[test]
+    fn restart_recovers_two_idle_agents_to_their_own_windows() {
+        // Two idle agents, both windows unstamped after a restart. The positional hint may
+        // pair them either way, but the evidence pass pins each to the window whose pane
+        // shows ITS OWN last message — never crosswise.
+        let ma = "idle alpha last message evidence tail one two three";
+        let mb = "idle bravo last message evidence tail four five six";
+        let windows = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
+        let p = pair_transcripts_to_windows(
+            &[tsum_msg("b", t(1), mb), tsum_msg("a", t(0), ma)],
+            &windows,
+            t(100),
+        );
+        let mut sids = candidate_sids(&p);
+        sids.sort();
+        assert_eq!(sids, vec!["a", "b"]);
+        // Each agent's message sits on its own pane; evidence must resolve each to its window.
+        let panes = vec![
+            (
+                1,
+                "lane-7".to_string(),
+                normalize_fingerprint(&format!("✻ {ma}\n❯")),
+            ),
+            (
+                2,
+                "lane-7-2".to_string(),
+                normalize_fingerprint(&format!("✻ {mb}\n❯")),
+            ),
+        ];
+        let mut got = confirmed_stamps(&p.new_bindings, &panes);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                (1, "lane-7".to_string(), "a".to_string()),
+                (2, "lane-7-2".to_string(), "b".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn idle_recovery_without_matching_pane_stamps_nothing() {
+        // A nominated idle agent (unstamped window + fingerprint) whose message is NOT on the
+        // captured pane — scrolled off, or the window is a fresh-spawn stand-in showing a
+        // different agent — gets no 1:1 evidence, so nothing is stamped and no guess wedges.
+        let msg = "idle agent whose tail is not on the captured pane at all";
+        let windows = vec![wm("lane-7", 1, None)];
+        let p = pair_transcripts_to_windows(&[tsum_msg("a", t(0), msg)], &windows, t(100));
+        assert_eq!(candidate_sids(&p), vec!["a"]);
+        let panes = vec![(
+            1,
+            "lane-7".to_string(),
+            normalize_fingerprint("a completely different agent booting up on this pane"),
+        )];
+        assert!(confirmed_stamps(&p.new_bindings, &panes).is_empty());
+    }
+
+    #[test]
+    fn idle_transcript_without_fingerprint_is_not_nominated() {
+        // A quiet stand-in with no distinctive last message (too short to fingerprint, or
+        // None) stays a DISPLAY guess: no evidence to confirm, so it must not be nominated —
+        // preserving the spawn-race invariant that a guess is never stamped.
+        let windows = vec![wm("lane-7", 1, None)];
+        // Too short to fingerprint (< FINGERPRINT_MIN normalized chars).
+        let p = pair_transcripts_to_windows(&[tsum_msg("a", t(0), "ok")], &windows, t(100));
+        assert!(p.new_bindings.is_empty());
+        // A None last message (the plain `tsum`) likewise.
+        let p = pair_transcripts_to_windows(&[tsum("a", t(0))], &windows, t(100));
+        assert!(p.new_bindings.is_empty());
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2096,7 +2096,7 @@ const OVERLAY_TTL: std::time::Duration = std::time::Duration::from_millis(750);
 pub(crate) async fn lanes_with_agents(ctx: &Ctx) -> Result<Vec<Lane>, RpcError> {
     {
         let cache = ctx.overlay_cache.lock().await;
-        if let Some((t, lanes)) = &*cache {
+        if let Some((t, lanes)) = cache.entry() {
             if t.elapsed() < OVERLAY_TTL {
                 return Ok(lanes.clone());
             }
@@ -2109,9 +2109,13 @@ pub(crate) async fn lanes_with_agents(ctx: &Ctx) -> Result<Vec<Lane>, RpcError> 
 /// stale snapshot — notably `notify_watch`, whose edge detection would miss a transition if two
 /// ticks reused the same cached list.
 pub(crate) async fn lanes_with_agents_fresh(ctx: &Ctx) -> Result<Vec<Lane>, RpcError> {
+    let generation = ctx.overlay_cache.lock().await.generation();
     let mut lanes = ctx.lanes.list().await.map_err(internal)?;
     overlay_agents(ctx, &mut lanes).await;
-    *ctx.overlay_cache.lock().await = Some((std::time::Instant::now(), lanes.clone()));
+    ctx.overlay_cache
+        .lock()
+        .await
+        .publish(generation, lanes.clone());
     Ok(lanes)
 }
 
@@ -2801,8 +2805,7 @@ fn pair_transcripts_to_windows(
         if let Some(sid) = &summaries[si].session_id {
             if windows[wi].session.as_deref() != Some(sid.as_str()) {
                 let needle = message_fingerprint(summaries[si].last_message.as_deref());
-                if is_fresh(&summaries[si]) || (windows[wi].session.is_none() && needle.is_some())
-                {
+                if is_fresh(&summaries[si]) || (windows[wi].session.is_none() && needle.is_some()) {
                     new_bindings.push(BindingCandidate {
                         sid: sid.clone(),
                         needle,

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1081,6 +1081,21 @@ pub async fn dispatch(
                 .await
                 .map_err(internal)?
                 .map_err(internal)?;
+            // The one moment the daemon KNOWS which transcript runs in this window: stamp
+            // the sticky binding deterministically instead of leaving it to first-contact
+            // guessing — `--resume` doesn't touch the resumed .jsonl until the first
+            // exchange, so the binder could otherwise pair a newer external transcript onto
+            // the adopted window and the stamp would wedge it there.
+            if let Some(sid) = p.session_id.clone() {
+                let tmux = ctx.tmux.clone();
+                let w = window.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Err(e) = tmux.set_window_session(&w, &sid) {
+                        tracing::warn!("failed to stamp adopted session on {w}: {e}");
+                    }
+                })
+                .await;
+            }
             let _ = ctx
                 .store
                 .set_lane_tmux_window(p.lane_id, Some(window.clone()))
@@ -2154,6 +2169,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     if let Err(ref e) = fresh {
         tracing::warn!("tmux list-windows failed; reusing last-good window set this overlay: {e}");
     }
+    // A tick that ran on the last-good snapshot pairs against binding info that lags any
+    // stamps by a generation — good enough to display, but never persist first-contact
+    // bindings computed from it (they could overwrite fresh stamps with crossed pairs).
+    let probe_ok = fresh.is_ok();
     let windows = {
         let mut last_good = ctx.last_good_windows.lock().await;
         let mut empty_misses = ctx.window_empty_misses.lock().await;
@@ -2191,7 +2210,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let global_auto = ctx.config.read().await.auto_continue;
 
     // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
-    let mut new_bindings: Vec<(String, String)> = Vec::new();
+    let mut new_bindings: Vec<(u64, String, String)> = Vec::new();
     for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
         // The lane's managed agent windows, in slot order. A window only exists while its
         // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
@@ -2225,14 +2244,14 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             .iter()
             .filter_map(|w| w.session.clone())
             .collect();
-        let summaries = select_kept_summaries(summaries, &bound, keep);
+        let summaries = select_kept_summaries(summaries, &bound, keep, now);
         if !summaries.is_empty() {
             // Pair transcripts with windows by sticky identity (`@repomon_session`), falling
             // back to the oldest-with-oldest heuristic only on first contact — see
             // `pair_transcripts_to_windows`. The old purely positional zip re-bound windows
             // whenever two agents swapped activity rank, which moved names, panes, and usage
             // accounts between rows.
-            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows);
+            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows, now);
             new_bindings.extend(pairing.new_bindings);
             for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
@@ -2347,13 +2366,17 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
 
     // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
     // window so the pairing survives daemon restarts and activity-order flips. Rare — once
-    // per agent lifetime — so this adds no forks to a steady-state overlay.
-    if !new_bindings.is_empty() {
+    // per agent lifetime — so this adds no forks to a steady-state overlay. Stamped by
+    // window ID (never reused), and only on fresh-probe ticks (see `probe_ok`). Concurrent
+    // overlay ticks can still cross-stamp in a sub-second window; a wrong winner is caught
+    // by the supersession rule in `pair_transcripts_to_windows` once the real transcript
+    // starts writing.
+    if probe_ok && !new_bindings.is_empty() {
         let tmux = ctx.tmux.clone();
         let _ = tokio::task::spawn_blocking(move || {
-            for (w, sid) in new_bindings {
-                if let Err(e) = tmux.set_window_session(&w, &sid) {
-                    tracing::warn!("failed to stamp @repomon_session on {w}: {e}");
+            for (wid, name, sid) in new_bindings {
+                if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
+                    tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
                 }
             }
         })
@@ -2563,9 +2586,11 @@ pub(crate) const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::fro
 struct Pairing {
     /// Per input summary (order preserved): the managed window it runs in; `None` = external.
     assignment: Vec<Option<String>>,
-    /// Sticky bindings established this tick — `(window_name, session_id)` to stamp as
-    /// `@repomon_session` so they survive daemon restarts and activity-order flips.
-    new_bindings: Vec<(String, String)>,
+    /// Sticky bindings established this tick — `(window_id, window_name, session_id)` to
+    /// stamp as `@repomon_session` so they survive daemon restarts and activity-order flips.
+    /// Stamped by window ID: a slot NAME recycled between the probe and the stamp must not
+    /// inherit the old transcript's binding.
+    new_bindings: Vec<(u64, String, String)>,
     /// Live managed windows no transcript claimed, newest (highest window id) first. The
     /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
     /// appeared yet (at most one, per the `SessKey::Fallback` model).
@@ -2589,38 +2614,88 @@ struct Pairing {
 fn pair_transcripts_to_windows(
     summaries: &[agent::TranscriptSummary],
     windows: &[agent::WindowMeta],
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Pairing {
-    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
-    let mut taken = vec![false; windows.len()];
-    // Pass 1 — sticky identity.
+    let is_fresh =
+        |s: &agent::TranscriptSummary| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS;
+    // Pass 1 — sticky identity, tentatively: each window claims the kept transcript its
+    // `@repomon_session` names.
+    let mut claim: Vec<Option<usize>> = vec![None; windows.len()];
+    let mut claimed = vec![false; summaries.len()];
     for (wi, w) in windows.iter().enumerate() {
         let Some(sid) = &w.session else { continue };
         if let Some(si) = summaries
             .iter()
             .position(|s| s.session_id.as_deref() == Some(sid.as_str()))
         {
-            if assignment[si].is_none() {
-                assignment[si] = Some(w.name.clone());
-                taken[wi] = true;
+            if !claimed[si] {
+                claim[wi] = Some(si);
+                claimed[si] = true;
             }
         }
     }
-    // Pass 2 — first contact. Never-bound windows are offered before stale-bound ones, both
-    // oldest (lowest window id) first.
+    // Supersession: a claude process rotates its transcript id in place (`/clear`, a
+    // fork-on-resume), leaving its window bound to a dead transcript while the live
+    // continuation has no window. When more FRESH unclaimed transcripts exist than free
+    // windows to receive them, release claims whose transcript has gone quiet — coldest
+    // first — so pass 2 can re-bind those windows to the transcripts actually writing. A
+    // claim on a fresh transcript is never released, so an idle fleet can't be shuffled.
+    let fresh_unclaimed = summaries
+        .iter()
+        .enumerate()
+        .filter(|(i, s)| !claimed[*i] && is_fresh(s))
+        .count();
+    let mut free_n = claim.iter().filter(|c| c.is_none()).count();
+    if fresh_unclaimed > free_n {
+        let mut stale_wis: Vec<usize> = (0..windows.len())
+            .filter(|&wi| claim[wi].is_some_and(|si| !is_fresh(&summaries[si])))
+            .collect();
+        stale_wis.sort_by_key(|&wi| summaries[claim[wi].unwrap()].last_activity);
+        for wi in stale_wis {
+            if fresh_unclaimed <= free_n {
+                break;
+            }
+            claimed[claim[wi].unwrap()] = false;
+            claim[wi] = None;
+            free_n += 1;
+        }
+    }
+    // Honor the surviving claims.
+    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
+    let mut taken = vec![false; windows.len()];
+    for (wi, c) in claim.iter().enumerate() {
+        if let Some(si) = c {
+            assignment[*si] = Some(windows[wi].name.clone());
+            taken[wi] = true;
+        }
+    }
+    // Pass 2 — first contact. Never-bound windows are offered before stale/released-bound
+    // ones; among the windows actually used, oldest (lowest window id) pairs with the oldest
+    // chosen transcript, like the legacy positional zip.
     let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
     free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
-    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest;
-    // pair that subset oldest-with-oldest (hence `.rev()`), like the legacy positional zip.
+    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest.
     let chosen: Vec<usize> = (0..summaries.len())
         .filter(|&i| assignment[i].is_none())
         .take(free.len())
         .collect();
+    let mut used: Vec<usize> = free.into_iter().take(chosen.len()).collect();
+    used.sort_by_key(|&i| windows[i].wid);
     let mut new_bindings = Vec::new();
-    for (&si, &wi) in chosen.iter().rev().zip(&free) {
+    for (&si, &wi) in chosen.iter().rev().zip(&used) {
         assignment[si] = Some(windows[wi].name.clone());
         taken[wi] = true;
-        if let Some(sid) = &summaries[si].session_id {
-            new_bindings.push((windows[wi].name.clone(), sid.clone()));
+        // Persist only pairs we're confident in: an actively-writing transcript IS the agent
+        // in this window. A quiet one is a stand-in guess (e.g. a fresh spawn whose .jsonl
+        // hasn't appeared yet, with an old transcript filling the display) — show it, but
+        // leave the window unbound so first contact re-runs once the real transcript starts
+        // writing, instead of wedging the guess for hours.
+        if is_fresh(&summaries[si]) {
+            if let Some(sid) = &summaries[si].session_id {
+                if windows[wi].session.as_deref() != Some(sid.as_str()) {
+                    new_bindings.push((windows[wi].wid, windows[wi].name.clone(), sid.clone()));
+                }
+            }
         }
     }
     let mut unpaired: Vec<&agent::WindowMeta> = windows
@@ -2647,15 +2722,21 @@ fn select_kept_summaries(
     summaries: Vec<agent::TranscriptSummary>,
     bound: &std::collections::HashSet<String>,
     keep: usize,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<agent::TranscriptSummary> {
     if summaries.len() <= keep {
         return summaries;
     }
-    let (bound_s, rest): (Vec<_>, Vec<_>) = summaries
+    let is_fresh =
+        |s: &agent::TranscriptSummary| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS;
+    // Protected: bound to a live window (the window proves its agent alive) OR actively
+    // writing right now — `sessions_to_keep`'s "never drop a session that is working"
+    // contract must survive bound-protection, or a stale binding could make the one live
+    // transcript invisible.
+    let (mut out, rest): (Vec<_>, Vec<_>) = summaries
         .into_iter()
-        .partition(|s| s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
-    let take_rest = keep.saturating_sub(bound_s.len());
-    let mut out = bound_s;
+        .partition(|s| is_fresh(s) || s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
+    let take_rest = keep.saturating_sub(out.len());
     out.extend(rest.into_iter().take(take_rest));
     out.sort_by_key(|s| std::cmp::Reverse(s.last_activity));
     out
@@ -4024,9 +4105,10 @@ mod tests {
         }
     }
 
-    /// Activity times t(0) < t(1) < …, so `t(2)` is newer than `t(1)`.
+    /// Activity times t(0) < t(1) < … in 10s steps, so several consecutive stamps all count
+    /// as "fresh" (within `RECENTLY_ACTIVE_SECS`) relative to a nearby `now`.
     fn t(n: i64) -> chrono::DateTime<chrono::Utc> {
-        chrono::DateTime::from_timestamp(1_700_000_000 + n * 60, 0).unwrap()
+        chrono::DateTime::from_timestamp(1_700_000_000 + n * 10, 0).unwrap()
     }
 
     #[test]
@@ -4035,19 +4117,19 @@ mod tests {
         // slot 1, the overflow transcript external — exactly what the positional zip did.
         let summaries = vec![tsum("c", t(3)), tsum("b", t(2)), tsum("a", t(1))];
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
-        let p = pair_transcripts_to_windows(&summaries, &windows);
+        let p = pair_transcripts_to_windows(&summaries, &windows, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
         );
-        // Both pairs become sticky bindings.
+        // Both paired transcripts are actively fresh → both pairs become sticky bindings.
         let mut nb = p.new_bindings.clone();
         nb.sort();
         assert_eq!(
             nb,
             vec![
-                ("lane-5".to_string(), "b".to_string()),
-                ("lane-5-2".to_string(), "c".to_string())
+                (1, "lane-5".to_string(), "b".to_string()),
+                (2, "lane-5-2".to_string(), "c".to_string())
             ]
         );
         assert!(p.unpaired.is_empty());
@@ -4058,14 +4140,14 @@ mod tests {
         // The reported bug: two bound agents swap activity rank; the pairing must not move.
         let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
         // b most recently active…
-        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows, t(2));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
         assert!(p.new_bindings.is_empty());
         // …then a takes a turn and the order flips: same windows per session id.
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
@@ -4080,13 +4162,13 @@ mod tests {
         // its result is emitted as bindings; re-running with those bindings and flipped
         // activity keeps the original assignment.
         let unbound = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
-        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound);
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound, t(2));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
         let bound = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound, t(3));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
@@ -4100,14 +4182,14 @@ mod tests {
         // The surviving agent b keeps its bound `lane-7-2`; the newcomer c gets the recycled
         // window — even though slot-name order would have handed c the older agent's window.
         let windows = vec![wm("lane-7", 7, None), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows, t(9));
         assert_eq!(
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
         );
         assert_eq!(
             p.new_bindings,
-            vec![("lane-7".to_string(), "c".to_string())]
+            vec![(7, "lane-7".to_string(), "c".to_string())]
         );
     }
 
@@ -4116,7 +4198,7 @@ mod tests {
         // b's transcript flaps out for one tick: its window merely goes unpaired (placeholder
         // target); it is NOT rebound to the surviving transcript and no binding is written.
         let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows, t(3));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
         assert!(p.new_bindings.is_empty());
         assert_eq!(p.unpaired, vec!["lane-7-2".to_string()]);
@@ -4124,14 +4206,14 @@ mod tests {
 
     #[test]
     fn stale_binding_released_to_a_genuinely_new_transcript() {
-        // The bound transcript is gone AND a new one needs a window: the stale binding is
-        // released and rewritten to the newcomer.
+        // The bound transcript is gone AND a new (actively writing) one needs a window: the
+        // stale binding is released and rewritten to the newcomer.
         let windows = vec![wm("lane-7", 1, Some("x"))];
-        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows, t(5));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
         assert_eq!(
             p.new_bindings,
-            vec![("lane-7".to_string(), "y".to_string())]
+            vec![(1, "lane-7".to_string(), "y".to_string())]
         );
         assert!(p.unpaired.is_empty());
     }
@@ -4141,26 +4223,104 @@ mod tests {
         // One transcript, two windows (second freshly spawned, no `.jsonl` yet): the leftover
         // is the NEWEST window (highest id) so the placeholder lands on the fresh spawn.
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
-        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows);
+        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows, t(1));
         assert_eq!(p.assignment, vec![Some("lane-5".into())]);
         assert_eq!(p.unpaired, vec!["lane-5-2".to_string()]);
         // All windows transcript-backed → nothing unpaired.
         let p = pair_transcripts_to_windows(
             &[tsum("b", t(2)), tsum("a", t(1))],
             &[wm("lane-5", 1, None), wm("lane-5-2", 2, None)],
+            t(2),
         );
         assert!(p.unpaired.is_empty());
     }
 
     #[test]
+    fn spawn_race_displays_but_does_not_stamp_a_stale_transcript() {
+        // agent.spawn created the window but claude hasn't written its .jsonl yet; the only
+        // transcript around is a stale leftover (an /exited session, or the user's own
+        // external one). It may stand in for DISPLAY, but the binding must not be stamped —
+        // otherwise the guess wedges for hours (pass 1 would re-claim it every tick).
+        let windows = vec![wm("lane-7", 5, None)];
+        let stale = tsum("e", t(0));
+        let p = pair_transcripts_to_windows(std::slice::from_ref(&stale), &windows, t(100));
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert!(
+            p.new_bindings.is_empty(),
+            "a quiet transcript is a guess, not a binding"
+        );
+        // The real transcript appears (actively writing): IT gets the window and the stamp;
+        // the stale one falls back to external.
+        let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
+        assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
+        assert_eq!(
+            p.new_bindings,
+            vec![(5, "lane-7".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn clear_rotation_rebinds_window_to_the_live_transcript() {
+        // `/clear` (or a fork-on-resume) rotates the session id in place: the window stays
+        // bound to the dead transcript e while the live continuation x has no window. The
+        // stale binding must be superseded — released and re-stamped to the transcript that
+        // is actually writing.
+        let windows = vec![wm("lane-7", 1, Some("e"))];
+        let p =
+            pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), None],
+            "the live transcript takes the window; the dead one goes external"
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![(1, "lane-7".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn fresh_external_does_not_steal_a_bound_window_when_a_free_one_exists() {
+        // An idle bound agent e plus a fresh unpaired transcript x: with a free window
+        // available, x takes the free window and e's binding is left alone — supersession
+        // only fires when the fresh transcript would otherwise have no home.
+        let windows = vec![wm("lane-7", 1, Some("e")), wm("lane-7-2", 9, None)];
+        let p =
+            pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![(9, "lane-7-2".to_string(), "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn idle_bound_pairing_holds_without_fresh_claimants() {
+        // Nothing fresh in the lane (everyone idle): stale-bound windows keep their agents —
+        // supersession must never shuffle a merely-idle fleet.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("b", t(1)), tsum("a", t(0))], &windows, t(100));
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+    }
+
+    #[test]
     fn select_kept_summaries_protects_bound_sessions() {
         // A bound-but-quiet agent (its window is alive — that IS liveness) must survive
-        // truncation ahead of newer unbound transcripts; output stays newest-first.
+        // truncation ahead of newer unbound transcripts; output stays newest-first. `now` is
+        // far past every activity time so freshness plays no part here.
         let bound: std::collections::HashSet<String> = ["a".to_string()].into();
         let kept = select_kept_summaries(
             vec![tsum("e1", t(3)), tsum("e2", t(2)), tsum("a", t(1))],
             &bound,
             2,
+            t(1000),
         );
         let ids: Vec<&str> = kept
             .iter()
@@ -4168,12 +4328,29 @@ mod tests {
             .collect();
         assert_eq!(ids, vec!["e1", "a"]);
         // Under the cap nothing is dropped.
-        let kept = select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5);
+        let kept =
+            select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5, t(1000));
         assert_eq!(kept.len(), 2);
         // More bound sessions than `keep` says: the windows win (each proves a live agent).
         let bound: std::collections::HashSet<String> = ["a".to_string(), "b".to_string()].into();
-        let kept = select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1);
+        let kept =
+            select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1, t(1000));
         assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn select_kept_summaries_never_drops_a_fresh_transcript() {
+        // The fresh backstop must survive bound-protection: with keep=1 and the budget
+        // filled by a bound-but-stale transcript, the actively-writing one is kept too —
+        // truncating the only session doing work would make the live agent invisible.
+        let bound: std::collections::HashSet<String> = ["e".to_string()].into();
+        let kept =
+            select_kept_summaries(vec![tsum("x", t(100)), tsum("e", t(0))], &bound, 1, t(100));
+        let ids: Vec<&str> = kept
+            .iter()
+            .filter_map(|s| s.session_id.as_deref())
+            .collect();
+        assert_eq!(ids, vec!["x", "e"]);
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2621,7 +2621,8 @@ type StampBatch = (Vec<BindingCandidate>, Vec<(u64, String)>);
 
 /// A lane's transcript↔window pairing for one overlay tick ([`pair_transcripts_to_windows`]).
 struct Pairing {
-    /// Per input summary (order preserved): the managed window it runs in; `None` = external.
+    /// Per input summary (order preserved): its evidence-backed managed window; `None` means
+    /// external or still awaiting pane evidence.
     assignment: Vec<Option<String>>,
     /// Transcripts to bind this tick, pending pane confirmation ([`confirmed_stamps`]).
     new_bindings: Vec<BindingCandidate>,
@@ -2629,9 +2630,10 @@ struct Pairing {
     /// name)`. Stamps target the window ID: a slot NAME recycled between the probe and the
     /// stamp must not inherit the old transcript's binding.
     probe: Vec<(u64, String)>,
-    /// Live managed windows no transcript claimed, newest (highest window id) first. The
-    /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
-    /// appeared yet (at most one, per the `SessKey::Fallback` model).
+    /// Live managed windows no evidence-backed transcript claimed, newest (highest window id)
+    /// first. The first is the placeholder target while a just-spawned agent's transcript is
+    /// absent or still awaiting pane confirmation (at most one, per the `SessKey::Fallback`
+    /// model).
     unpaired: Vec<String>,
 }
 
@@ -2702,12 +2704,11 @@ fn confirmed_stamps(
 /// their windows every poll, moving names, panes, and usage accounts between rows — and to
 /// daemon restarts (the binding lives in tmux, not daemon memory).
 ///
-/// Pass 2 (first contact only): the newest still-unassigned transcripts meet the still-free
-/// windows, oldest-with-oldest — the same heuristic the overlay always used, but run ONCE
-/// per agent: each pair is emitted in `new_bindings` and pass 1 owns it from the next tick.
-/// Never-bound windows are offered before stale-bound ones (whose transcript vanished this
-/// tick), so a one-tick transcript flap can't hand a live agent's window to a newcomer; and
-/// window age is the window id — slot NAMES are recycled after an exit, ids never are.
+/// Pass 2 (first contact only): the newest still-unassigned transcripts become binding
+/// candidates for the still-free windows. They remain external for this response and those
+/// windows remain placeholders until [`confirmed_stamps`] proves a 1:1 pane match; the next
+/// overlay's pass 1 then exposes the durable pairing. This deliberately avoids even a temporary
+/// stale-transcript/new-window display mismatch during spawn.
 fn pair_transcripts_to_windows(
     summaries: &[agent::TranscriptSummary],
     windows: &[agent::WindowMeta],
@@ -2768,28 +2769,24 @@ fn pair_transcripts_to_windows(
             taken[wi] = true;
         }
     }
-    // Pass 2 — first contact. Never-bound windows are offered before stale/released-bound
-    // ones; among the windows actually used, oldest (lowest window id) pairs with the oldest
-    // chosen transcript, like the legacy positional zip. This ordering is only the DISPLAY
-    // hint — the durable stamp is decided by pane evidence (`confirmed_stamps`), for which
-    // every pass-1-unclaimed window is a legal target.
+    // Pass 2 — first contact. Unclaimed transcripts are candidates for the free-window pool,
+    // but remain external for this response. The free windows stay placeholders until pane
+    // evidence writes a durable stamp; a positional display guess is precisely what showed an
+    // old transcript over a just-spawned pane.
     let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
     free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
     let probe: Vec<(u64, String)> = free
         .iter()
         .map(|&i| (windows[i].wid, windows[i].name.clone()))
         .collect();
-    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest.
+    // `summaries` is newest-first, so nominate at most one transcript per free window.
     let chosen: Vec<usize> = (0..summaries.len())
         .filter(|&i| assignment[i].is_none())
         .take(free.len())
         .collect();
-    let mut used: Vec<usize> = free.into_iter().take(chosen.len()).collect();
-    used.sort_by_key(|&i| windows[i].wid);
+    let has_never_bound_window = free.iter().any(|&i| windows[i].session.is_none());
     let mut new_bindings = Vec::new();
-    for (&si, &wi) in chosen.iter().rev().zip(&used) {
-        assignment[si] = Some(windows[wi].name.clone());
-        taken[wi] = true;
+    for si in chosen {
         // Nominate a transcript for a durable stamp when PANE EVIDENCE could confirm it.
         // Two routes qualify:
         //  - it is actively writing (`is_fresh`): it IS some window's agent right now, so
@@ -2803,14 +2800,12 @@ fn pair_transcripts_to_windows(
         //    stand-in — there is nothing to confirm — and a released stale binding
         //    (`session.is_some()`) is left for a fresh claimant, never re-stamped from a guess.
         if let Some(sid) = &summaries[si].session_id {
-            if windows[wi].session.as_deref() != Some(sid.as_str()) {
-                let needle = message_fingerprint(summaries[si].last_message.as_deref());
-                if is_fresh(&summaries[si]) || (windows[wi].session.is_none() && needle.is_some()) {
-                    new_bindings.push(BindingCandidate {
-                        sid: sid.clone(),
-                        needle,
-                    });
-                }
+            let needle = message_fingerprint(summaries[si].last_message.as_deref());
+            if is_fresh(&summaries[si]) || (has_never_bound_window && needle.is_some()) {
+                new_bindings.push(BindingCandidate {
+                    sid: sid.clone(),
+                    needle,
+                });
             }
         }
     }
@@ -4245,18 +4240,15 @@ mod tests {
     }
 
     #[test]
-    fn pairing_without_bindings_matches_legacy_heuristic() {
-        // First contact (nothing bound yet): newest transcript ↔ newest slot, oldest paired ↔
-        // slot 1, the overflow transcript external — exactly what the positional zip did.
+    fn first_contact_stays_placeholder_until_pane_evidence() {
+        // First contact (nothing bound yet): no transcript is exposed on a window until pane
+        // evidence confirms it. This prevents a stale transcript from appearing over a new pane.
         let summaries = vec![tsum("c", t(3)), tsum("b", t(2)), tsum("a", t(1))];
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
         let p = pair_transcripts_to_windows(&summaries, &windows, t(3));
-        assert_eq!(
-            p.assignment,
-            vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
-        );
-        // Both paired transcripts are actively fresh → both are nominated for bindings,
-        // with every unclaimed window as a legal stamp target for the evidence pass.
+        assert_eq!(p.assignment, vec![None, None, None]);
+        // The two newest transcripts are actively fresh → both are nominated for bindings,
+        // with every window as a legal stamp target for the evidence pass.
         let mut sids = candidate_sids(&p);
         sids.sort();
         assert_eq!(sids, vec!["b", "c"]);
@@ -4264,7 +4256,10 @@ mod tests {
             p.probe,
             vec![(1, "lane-5".to_string()), (2, "lane-5-2".to_string())]
         );
-        assert!(p.unpaired.is_empty());
+        assert_eq!(
+            p.unpaired,
+            vec!["lane-5-2".to_string(), "lane-5".to_string()]
+        );
     }
 
     #[test]
@@ -4290,15 +4285,12 @@ mod tests {
 
     #[test]
     fn first_contact_binds_then_holds_through_flip() {
-        // Unbound windows (daemon restart / pre-upgrade agents): the heuristic runs once and
-        // its result is emitted as bindings; re-running with those bindings and flipped
-        // activity keeps the original assignment.
+        // Unbound windows (daemon restart / pre-upgrade agents) stay placeholders while the
+        // candidates await evidence; re-running with confirmed bindings and flipped activity
+        // keeps the original assignment.
         let unbound = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
         let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound, t(2));
-        assert_eq!(
-            p.assignment,
-            vec![Some("lane-7-2".into()), Some("lane-7".into())]
-        );
+        assert_eq!(p.assignment, vec![None, None]);
         let bound = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
         let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound, t(3));
         assert_eq!(
@@ -4311,16 +4303,14 @@ mod tests {
     #[test]
     fn slot_recycling_pairs_new_transcript_to_new_window() {
         // Slot 1 (`lane-7`) died and was respawned: same NAME, higher window id, no binding.
-        // The surviving agent b keeps its bound `lane-7-2`; the newcomer c gets the recycled
-        // window — even though slot-name order would have handed c the older agent's window.
+        // The surviving agent b keeps its bound `lane-7-2`; newcomer c awaits pane evidence
+        // against the recycled window instead of inheriting it by slot-name order.
         let windows = vec![wm("lane-7", 7, None), wm("lane-7-2", 2, Some("b"))];
         let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows, t(9));
-        assert_eq!(
-            p.assignment,
-            vec![Some("lane-7".into()), Some("lane-7-2".into())]
-        );
+        assert_eq!(p.assignment, vec![None, Some("lane-7-2".into())]);
         assert_eq!(candidate_sids(&p), vec!["c"]);
         assert_eq!(p.probe, vec![(7, "lane-7".to_string())]);
+        assert_eq!(p.unpaired, vec!["lane-7".to_string()]);
     }
 
     #[test]
@@ -4337,13 +4327,13 @@ mod tests {
     #[test]
     fn stale_binding_released_to_a_genuinely_new_transcript() {
         // The bound transcript is gone AND a new (actively writing) one needs a window: the
-        // stale binding is released and rewritten to the newcomer.
+        // stale binding is released, but its replacement remains a candidate until confirmed.
         let windows = vec![wm("lane-7", 1, Some("x"))];
         let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows, t(5));
-        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(p.assignment, vec![None]);
         assert_eq!(candidate_sids(&p), vec!["y"]);
         assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
-        assert!(p.unpaired.is_empty());
+        assert_eq!(p.unpaired, vec!["lane-7".to_string()]);
     }
 
     #[test]
@@ -4352,36 +4342,45 @@ mod tests {
         // is the NEWEST window (highest id) so the placeholder lands on the fresh spawn.
         let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
         let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows, t(1));
-        assert_eq!(p.assignment, vec![Some("lane-5".into())]);
-        assert_eq!(p.unpaired, vec!["lane-5-2".to_string()]);
-        // All windows transcript-backed → nothing unpaired.
+        assert_eq!(p.assignment, vec![None]);
+        assert_eq!(
+            p.unpaired,
+            vec!["lane-5-2".to_string(), "lane-5".to_string()]
+        );
+        // Even with enough candidate transcripts, both windows remain placeholders until evidence.
         let p = pair_transcripts_to_windows(
             &[tsum("b", t(2)), tsum("a", t(1))],
             &[wm("lane-5", 1, None), wm("lane-5-2", 2, None)],
             t(2),
         );
-        assert!(p.unpaired.is_empty());
+        assert_eq!(p.assignment, vec![None, None]);
+        assert_eq!(
+            p.unpaired,
+            vec!["lane-5-2".to_string(), "lane-5".to_string()]
+        );
     }
 
     #[test]
-    fn spawn_race_displays_but_does_not_stamp_a_stale_transcript() {
+    fn spawn_race_keeps_a_stale_transcript_off_the_new_window() {
         // agent.spawn created the window but claude hasn't written its .jsonl yet; the only
         // transcript around is a stale leftover (an /exited session, or the user's own
-        // external one). It may stand in for DISPLAY, but the binding must not be stamped —
-        // otherwise the guess wedges for hours (pass 1 would re-claim it every tick).
+        // external one). It must remain external while the new window stays a placeholder;
+        // displaying it on that window is already a user-visible transcript mismatch.
         let windows = vec![wm("lane-7", 5, None)];
         let stale = tsum("e", t(0));
         let p = pair_transcripts_to_windows(std::slice::from_ref(&stale), &windows, t(100));
-        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(p.assignment, vec![None]);
+        assert_eq!(p.unpaired, vec!["lane-7".to_string()]);
         assert!(
             p.new_bindings.is_empty(),
             "a quiet transcript is a guess, not a binding"
         );
-        // The real transcript appears (actively writing): IT gets the window and the stamp;
-        // the stale one falls back to external.
+        // The real transcript appears (actively writing): it becomes the sole stamp candidate;
+        // both transcripts remain external for this response and the pane stays a placeholder.
         let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
-        assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
+        assert_eq!(p.assignment, vec![None, None]);
         assert_eq!(candidate_sids(&p), vec!["x"]);
+        assert_eq!(p.unpaired, vec!["lane-7".to_string()]);
     }
 
     #[test]
@@ -4394,16 +4393,17 @@ mod tests {
         let msg = "recovered idle agent distinctive last message tail marker";
         let windows = vec![wm("lane-7", 1, None)];
         let p = pair_transcripts_to_windows(&[tsum_msg("a", t(0), msg)], &windows, t(100));
-        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(p.assignment, vec![None]);
         assert_eq!(candidate_sids(&p), vec!["a"]);
         assert_eq!(p.new_bindings[0].needle, message_fingerprint(Some(msg)));
+        assert_eq!(p.unpaired, vec!["lane-7".to_string()]);
     }
 
     #[test]
     fn restart_recovers_two_idle_agents_to_their_own_windows() {
-        // Two idle agents, both windows unstamped after a restart. The positional hint may
-        // pair them either way, but the evidence pass pins each to the window whose pane
-        // shows ITS OWN last message — never crosswise.
+        // Two idle agents, both windows unstamped after a restart. They remain placeholders
+        // while the evidence pass pins each to the window whose pane shows ITS OWN last
+        // message — never crosswise.
         let ma = "idle alpha last message evidence tail one two three";
         let mb = "idle bravo last message evidence tail four five six";
         let windows = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
@@ -4458,9 +4458,9 @@ mod tests {
 
     #[test]
     fn idle_transcript_without_fingerprint_is_not_nominated() {
-        // A quiet stand-in with no distinctive last message (too short to fingerprint, or
-        // None) stays a DISPLAY guess: no evidence to confirm, so it must not be nominated —
-        // preserving the spawn-race invariant that a guess is never stamped.
+        // A quiet transcript with no distinctive last message (too short to fingerprint, or
+        // None) stays external while the pane remains a placeholder: no evidence means no
+        // display guess and no durable binding.
         let windows = vec![wm("lane-7", 1, None)];
         // Too short to fingerprint (< FINGERPRINT_MIN normalized chars).
         let p = pair_transcripts_to_windows(&[tsum_msg("a", t(0), "ok")], &windows, t(100));
@@ -4474,15 +4474,15 @@ mod tests {
     fn clear_rotation_rebinds_window_to_the_live_transcript() {
         // `/clear` (or a fork-on-resume) rotates the session id in place: the window stays
         // bound to the dead transcript e while the live continuation x has no window. The
-        // stale binding must be superseded — released and re-stamped to the transcript that
-        // is actually writing.
+        // stale binding must be superseded — released, then re-stamped only after pane evidence
+        // identifies the transcript that is actually writing.
         let windows = vec![wm("lane-7", 1, Some("e"))];
         let p =
             pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
         assert_eq!(
             p.assignment,
-            vec![Some("lane-7".into()), None],
-            "the live transcript takes the window; the dead one goes external"
+            vec![None, None],
+            "the live transcript awaits evidence; the dead one goes external"
         );
         assert_eq!(candidate_sids(&p), vec!["x"]);
         assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
@@ -4502,8 +4502,8 @@ mod tests {
         );
         assert_eq!(
             p.assignment,
-            vec![Some("lane-7".into()), None, Some("lane-7-2".into())],
-            "c inherits a's window; b keeps its own; dead a goes external"
+            vec![None, None, Some("lane-7-2".into())],
+            "c awaits evidence for a's released window; b keeps its own; dead a goes external"
         );
         assert_eq!(candidate_sids(&p), vec!["c"]);
         assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
@@ -4512,15 +4512,12 @@ mod tests {
     #[test]
     fn fresh_external_does_not_steal_a_bound_window_when_a_free_one_exists() {
         // An idle bound agent e plus a fresh unpaired transcript x: with a free window
-        // available, x takes the free window and e's binding is left alone — supersession
-        // only fires when the fresh transcript would otherwise have no home.
+        // available, x becomes a candidate for that free window and e's binding is left alone —
+        // supersession only fires when the fresh transcript would otherwise have no home.
         let windows = vec![wm("lane-7", 1, Some("e")), wm("lane-7-2", 9, None)];
         let p =
             pair_transcripts_to_windows(&[tsum("x", t(100)), tsum("e", t(0))], &windows, t(100));
-        assert_eq!(
-            p.assignment,
-            vec![Some("lane-7-2".into()), Some("lane-7".into())]
-        );
+        assert_eq!(p.assignment, vec![None, Some("lane-7".into())]);
         assert_eq!(candidate_sids(&p), vec!["x"]);
         assert_eq!(p.probe, vec![(9, "lane-7-2".to_string())]);
     }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -2209,8 +2209,9 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let auto_off = ctx.auto_continue_off.lock().await.clone();
     let global_auto = ctx.config.read().await.auto_continue;
 
-    // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
-    let mut new_bindings: Vec<(u64, String, String)> = Vec::new();
+    // Per-lane binding candidates + their probe-window pools, resolved against pane
+    // evidence and stamped as `@repomon_session` after the loop.
+    let mut stamp_batches: Vec<StampBatch> = Vec::new();
     for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
         // The lane's managed agent windows, in slot order. A window only exists while its
         // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
@@ -2252,7 +2253,9 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             // whenever two agents swapped activity rank, which moved names, panes, and usage
             // accounts between rows.
             let pairing = pair_transcripts_to_windows(&summaries, &lane_windows, now);
-            new_bindings.extend(pairing.new_bindings);
+            if !pairing.new_bindings.is_empty() {
+                stamp_batches.push((pairing.new_bindings, pairing.probe));
+            }
             for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
                     lane.last_activity_at = s.last_activity;
@@ -2364,19 +2367,33 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         }
     }
 
-    // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
-    // window so the pairing survives daemon restarts and activity-order flips. Rare — once
-    // per agent lifetime — so this adds no forks to a steady-state overlay. Stamped by
-    // window ID (never reused), and only on fresh-probe ticks (see `probe_ok`). Concurrent
-    // overlay ticks can still cross-stamp in a sub-second window; a wrong winner is caught
-    // by the supersession rule in `pair_transcripts_to_windows` once the real transcript
-    // starts writing.
-    if probe_ok && !new_bindings.is_empty() {
+    // Persist the sticky bindings established this tick — but only where the pane PROVES
+    // the pairing: each candidate transcript's last-message fingerprint must be visible in
+    // exactly one of its lane's unclaimed panes (`confirmed_stamps`). Activity rank alone
+    // mis-stamped when several transcripts were fresh at once (live incident: two agents'
+    // names swapped and stayed swapped), and a wrong sticky stamp wedges until superseded.
+    // An unconfirmed candidate simply returns next tick — the pairing stamps itself once
+    // the agent's turn is visible on screen. Rare (once per agent lifetime), so the capture
+    // forks don't touch steady-state ticks. Skipped when the window probe failed
+    // (`probe_ok`): a last-good snapshot lags the stamps by a generation.
+    if probe_ok && !stamp_batches.is_empty() {
         let tmux = ctx.tmux.clone();
         let _ = tokio::task::spawn_blocking(move || {
-            for (wid, name, sid) in new_bindings {
-                if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
-                    tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
+            for (cands, probe) in stamp_batches {
+                if cands.iter().all(|c| c.needle.is_none()) {
+                    continue;
+                }
+                let panes: Vec<(u64, String, String)> = probe
+                    .into_iter()
+                    .map(|(wid, name)| {
+                        let text = tmux.capture_named(&name, Some(60)).unwrap_or_default();
+                        (wid, name, normalize_fingerprint(&text))
+                    })
+                    .collect();
+                for (wid, name, sid) in confirmed_stamps(&cands, &panes) {
+                    if let Err(e) = tmux.set_window_session_by_id(wid, &sid) {
+                        tracing::warn!("failed to stamp @repomon_session on {name} (@{wid}): {e}");
+                    }
                 }
             }
         })
@@ -2582,19 +2599,95 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
 /// pane for reflow within seconds. `pub(crate)` so [`crate::Ctx::viewport_snapshot`] shares it.
 pub(crate) const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::from_secs(15);
 
+/// A transcript that should get a sticky binding this tick, pending pane evidence: the
+/// fingerprint of its last message must be visible in exactly one of the lane's unclaimed
+/// panes before anything is stamped. Activity rank proved able to guess wrong when several
+/// transcripts were fresh at once, and a wrong sticky stamp wedges until superseded — so the
+/// pane, not the rank, picks the window.
+struct BindingCandidate {
+    sid: String,
+    /// Normalized fingerprint of the transcript's last message ([`message_fingerprint`]);
+    /// `None` (no message yet / too short) means no evidence — the candidate simply returns
+    /// next tick.
+    needle: Option<String>,
+}
+
+/// One lane's binding candidates plus the probe-window pool they may stamp onto.
+type StampBatch = (Vec<BindingCandidate>, Vec<(u64, String)>);
+
 /// A lane's transcript↔window pairing for one overlay tick ([`pair_transcripts_to_windows`]).
 struct Pairing {
     /// Per input summary (order preserved): the managed window it runs in; `None` = external.
     assignment: Vec<Option<String>>,
-    /// Sticky bindings established this tick — `(window_id, window_name, session_id)` to
-    /// stamp as `@repomon_session` so they survive daemon restarts and activity-order flips.
-    /// Stamped by window ID: a slot NAME recycled between the probe and the stamp must not
-    /// inherit the old transcript's binding.
-    new_bindings: Vec<(u64, String, String)>,
+    /// Transcripts to bind this tick, pending pane confirmation ([`confirmed_stamps`]).
+    new_bindings: Vec<BindingCandidate>,
+    /// The windows a new binding may land on — everything pass 1 didn't claim, `(window_id,
+    /// name)`. Stamps target the window ID: a slot NAME recycled between the probe and the
+    /// stamp must not inherit the old transcript's binding.
+    probe: Vec<(u64, String)>,
     /// Live managed windows no transcript claimed, newest (highest window id) first. The
     /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
     /// appeared yet (at most one, per the `SessKey::Fallback` model).
     unpaired: Vec<String>,
+}
+
+/// Collapse text to lowercase ASCII alphanumerics. Makes fingerprint matching immune to
+/// tmux line wrapping, markdown styling (the pane renderer strips `**`/`_` markers), ANSI
+/// spacing, and case.
+fn normalize_fingerprint(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// Minimum normalized length before a fingerprint is distinctive enough to act on.
+const FINGERPRINT_MIN: usize = 24;
+/// How much of the normalized TAIL to keep — after a long reply scrolls, its tail is what
+/// stays visible above the input box.
+const FINGERPRINT_LEN: usize = 64;
+
+/// The pane fingerprint of a transcript's last message, or `None` when there is no message
+/// or it is too short to be distinctive.
+fn message_fingerprint(last_message: Option<&str>) -> Option<String> {
+    let n = normalize_fingerprint(last_message?);
+    if n.len() < FINGERPRINT_MIN {
+        return None;
+    }
+    // Byte slicing is safe: the normalized form is pure ASCII.
+    Some(n[n.len().saturating_sub(FINGERPRINT_LEN)..].to_string())
+}
+
+/// Which stamps the pane evidence supports: each candidate with a fingerprint is stamped on
+/// the single probe window whose (normalized) pane contains it. No match, several matching
+/// panes, or several candidates matching the same pane → no stamp for those involved; the
+/// candidates return next tick once the screens disambiguate. Returns `(wid, name, sid)`.
+fn confirmed_stamps(
+    cands: &[BindingCandidate],
+    panes: &[(u64, String, String)],
+) -> Vec<(u64, String, String)> {
+    // Every needle↔pane hit, as (candidate index, pane index).
+    let mut hits: Vec<(usize, usize)> = Vec::new();
+    for (ci, c) in cands.iter().enumerate() {
+        let Some(needle) = &c.needle else { continue };
+        for (pi, (_, _, text)) in panes.iter().enumerate() {
+            if text.contains(needle.as_str()) {
+                hits.push((ci, pi));
+            }
+        }
+    }
+    // Keep only 1:1 matches — a candidate seen in several panes, or a pane claimed by
+    // several candidates, proves nothing yet.
+    hits.iter()
+        .filter(|&&(ci, pi)| {
+            hits.iter().filter(|(c, _)| *c == ci).count() == 1
+                && hits.iter().filter(|(_, p)| *p == pi).count() == 1
+        })
+        .map(|&(ci, pi)| {
+            let (wid, name, _) = &panes[pi];
+            (*wid, name.clone(), cands[ci].sid.clone())
+        })
+        .collect()
 }
 
 /// Pair a lane's kept transcripts (newest-first) with its live managed windows by STICKY
@@ -2637,9 +2730,11 @@ fn pair_transcripts_to_windows(
     // Supersession: a claude process rotates its transcript id in place (`/clear`, a
     // fork-on-resume), leaving its window bound to a dead transcript while the live
     // continuation has no window. When more FRESH unclaimed transcripts exist than free
-    // windows to receive them, release claims whose transcript has gone quiet — coldest
-    // first — so pass 2 can re-bind those windows to the transcripts actually writing. A
-    // claim on a fresh transcript is never released, so an idle fleet can't be shuffled.
+    // windows to receive them, release claims whose transcript has gone quiet — WARMEST
+    // first: the transcript that stopped writing most recently is the one that just rotated
+    // into the newcomer, while a long-cold one is simply an idle agent whose window must not
+    // be given away. A claim on a fresh transcript is never released, so an idle fleet
+    // can't be shuffled.
     let fresh_unclaimed = summaries
         .iter()
         .enumerate()
@@ -2650,7 +2745,7 @@ fn pair_transcripts_to_windows(
         let mut stale_wis: Vec<usize> = (0..windows.len())
             .filter(|&wi| claim[wi].is_some_and(|si| !is_fresh(&summaries[si])))
             .collect();
-        stale_wis.sort_by_key(|&wi| summaries[claim[wi].unwrap()].last_activity);
+        stale_wis.sort_by_key(|&wi| std::cmp::Reverse(summaries[claim[wi].unwrap()].last_activity));
         for wi in stale_wis {
             if fresh_unclaimed <= free_n {
                 break;
@@ -2671,9 +2766,15 @@ fn pair_transcripts_to_windows(
     }
     // Pass 2 — first contact. Never-bound windows are offered before stale/released-bound
     // ones; among the windows actually used, oldest (lowest window id) pairs with the oldest
-    // chosen transcript, like the legacy positional zip.
+    // chosen transcript, like the legacy positional zip. This ordering is only the DISPLAY
+    // hint — the durable stamp is decided by pane evidence (`confirmed_stamps`), for which
+    // every pass-1-unclaimed window is a legal target.
     let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
     free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
+    let probe: Vec<(u64, String)> = free
+        .iter()
+        .map(|&i| (windows[i].wid, windows[i].name.clone()))
+        .collect();
     // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest.
     let chosen: Vec<usize> = (0..summaries.len())
         .filter(|&i| assignment[i].is_none())
@@ -2685,15 +2786,17 @@ fn pair_transcripts_to_windows(
     for (&si, &wi) in chosen.iter().rev().zip(&used) {
         assignment[si] = Some(windows[wi].name.clone());
         taken[wi] = true;
-        // Persist only pairs we're confident in: an actively-writing transcript IS the agent
-        // in this window. A quiet one is a stand-in guess (e.g. a fresh spawn whose .jsonl
-        // hasn't appeared yet, with an old transcript filling the display) — show it, but
-        // leave the window unbound so first contact re-runs once the real transcript starts
-        // writing, instead of wedging the guess for hours.
+        // Nominate only transcripts we could ever be confident in: an actively-writing one
+        // IS some window's agent. A quiet one is a stand-in guess (e.g. a fresh spawn whose
+        // .jsonl hasn't appeared yet, with an old transcript filling the display) — show
+        // it, but never nominate it for a binding.
         if is_fresh(&summaries[si]) {
             if let Some(sid) = &summaries[si].session_id {
                 if windows[wi].session.as_deref() != Some(sid.as_str()) {
-                    new_bindings.push((windows[wi].wid, windows[wi].name.clone(), sid.clone()));
+                    new_bindings.push(BindingCandidate {
+                        sid: sid.clone(),
+                        needle: message_fingerprint(summaries[si].last_message.as_deref()),
+                    });
                 }
             }
         }
@@ -2708,6 +2811,7 @@ fn pair_transcripts_to_windows(
     Pairing {
         assignment,
         new_bindings,
+        probe,
         unpaired: unpaired.into_iter().map(|w| w.name.clone()).collect(),
     }
 }
@@ -4097,6 +4201,10 @@ mod tests {
         }
     }
 
+    fn candidate_sids(p: &Pairing) -> Vec<&str> {
+        p.new_bindings.iter().map(|b| b.sid.as_str()).collect()
+    }
+
     fn wm(name: &str, wid: u64, sid: Option<&str>) -> agent::WindowMeta {
         agent::WindowMeta {
             name: name.into(),
@@ -4122,15 +4230,14 @@ mod tests {
             p.assignment,
             vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
         );
-        // Both paired transcripts are actively fresh → both pairs become sticky bindings.
-        let mut nb = p.new_bindings.clone();
-        nb.sort();
+        // Both paired transcripts are actively fresh → both are nominated for bindings,
+        // with every unclaimed window as a legal stamp target for the evidence pass.
+        let mut sids = candidate_sids(&p);
+        sids.sort();
+        assert_eq!(sids, vec!["b", "c"]);
         assert_eq!(
-            nb,
-            vec![
-                (1, "lane-5".to_string(), "b".to_string()),
-                (2, "lane-5-2".to_string(), "c".to_string())
-            ]
+            p.probe,
+            vec![(1, "lane-5".to_string()), (2, "lane-5-2".to_string())]
         );
         assert!(p.unpaired.is_empty());
     }
@@ -4187,10 +4294,8 @@ mod tests {
             p.assignment,
             vec![Some("lane-7".into()), Some("lane-7-2".into())]
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(7, "lane-7".to_string(), "c".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["c"]);
+        assert_eq!(p.probe, vec![(7, "lane-7".to_string())]);
     }
 
     #[test]
@@ -4211,10 +4316,8 @@ mod tests {
         let windows = vec![wm("lane-7", 1, Some("x"))];
         let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows, t(5));
         assert_eq!(p.assignment, vec![Some("lane-7".into())]);
-        assert_eq!(
-            p.new_bindings,
-            vec![(1, "lane-7".to_string(), "y".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["y"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
         assert!(p.unpaired.is_empty());
     }
 
@@ -4253,10 +4356,7 @@ mod tests {
         // the stale one falls back to external.
         let p = pair_transcripts_to_windows(&[tsum("x", t(100)), stale], &windows, t(100));
         assert_eq!(p.assignment, vec![Some("lane-7".into()), None]);
-        assert_eq!(
-            p.new_bindings,
-            vec![(5, "lane-7".to_string(), "x".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["x"]);
     }
 
     #[test]
@@ -4273,10 +4373,29 @@ mod tests {
             vec![Some("lane-7".into()), None],
             "the live transcript takes the window; the dead one goes external"
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(1, "lane-7".to_string(), "x".to_string())]
+        assert_eq!(candidate_sids(&p), vec!["x"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
+    }
+
+    #[test]
+    fn clear_rotation_releases_the_rotated_window_not_the_coldest() {
+        // Two bound agents, both currently quiet: a rotated its session id a moment ago
+        // (`/clear` → continuation c), b has been idle for much longer. The window released
+        // for c must be a's — the transcript that went quiet MOST recently is the one that
+        // just rotated; sacrificing the long-idle b would route c's keys into b's pane.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(
+            &[tsum("c", t(100)), tsum("a", t(50)), tsum("b", t(0))],
+            &windows,
+            t(100),
         );
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), None, Some("lane-7-2".into())],
+            "c inherits a's window; b keeps its own; dead a goes external"
+        );
+        assert_eq!(candidate_sids(&p), vec!["c"]);
+        assert_eq!(p.probe, vec![(1, "lane-7".to_string())]);
     }
 
     #[test]
@@ -4291,10 +4410,8 @@ mod tests {
             p.assignment,
             vec![Some("lane-7-2".into()), Some("lane-7".into())]
         );
-        assert_eq!(
-            p.new_bindings,
-            vec![(9, "lane-7-2".to_string(), "x".to_string())]
-        );
+        assert_eq!(candidate_sids(&p), vec!["x"]);
+        assert_eq!(p.probe, vec![(9, "lane-7-2".to_string())]);
     }
 
     #[test]
@@ -4336,6 +4453,111 @@ mod tests {
         let kept =
             select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1, t(1000));
         assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn message_fingerprint_normalizes_and_gates() {
+        // Markdown styling and line wrapping vanish under normalization.
+        let m = "**Done!** The deploy isn't blocked on the invite anymore.";
+        let f = message_fingerprint(Some(m)).unwrap();
+        assert!(pane_text_contains(
+            "✻ Done! The deploy isn't\nblocked on the invite anymore.\n❯",
+            &f
+        ));
+        // A different conversation's pane does not match.
+        assert!(!pane_text_contains(
+            "recap: building Store Listen landing page",
+            &f
+        ));
+        // Long messages fingerprint their TAIL (what stays visible above the input box).
+        let long = format!(
+            "{} tail marker alpha beta gamma delta epsilon",
+            "x".repeat(500)
+        );
+        let f = message_fingerprint(Some(&long)).unwrap();
+        assert!(f.len() <= FINGERPRINT_LEN);
+        let pane = format!(
+            "{} tail marker alpha beta gamma delta epsilon",
+            "x".repeat(60)
+        );
+        assert!(pane_text_contains(&pane, &f));
+        // Absent or indistinct messages give no fingerprint: no evidence, no stamp.
+        assert_eq!(message_fingerprint(Some("ok")), None);
+        assert_eq!(message_fingerprint(None), None);
+    }
+
+    /// Test-side helper mirroring the stamp task's pane check.
+    fn pane_text_contains(pane: &str, needle: &str) -> bool {
+        normalize_fingerprint(pane).contains(needle)
+    }
+
+    #[test]
+    fn stamps_follow_pane_evidence_not_the_hint() {
+        let cand = |sid: &str, msg: &str| BindingCandidate {
+            sid: sid.into(),
+            needle: message_fingerprint(Some(msg)),
+        };
+        let a = cand("a", "fingerprint marker for agent alpha pane evidence");
+        let b = cand("b", "fingerprint marker for agent bravo pane evidence");
+        // Panes are CROSSED relative to candidate order: evidence must decide, so a lands
+        // on @2 and b on @1 regardless of any heuristic hint.
+        let panes = vec![
+            (
+                1,
+                "lane-7".to_string(),
+                normalize_fingerprint("✻ fingerprint marker for agent bravo pane evidence\n❯"),
+            ),
+            (
+                2,
+                "lane-7-2".to_string(),
+                normalize_fingerprint("✻ fingerprint marker for agent alpha pane evidence\n❯"),
+            ),
+        ];
+        let mut got = confirmed_stamps(&[a, b], &panes);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                (1, "lane-7".to_string(), "b".to_string()),
+                (2, "lane-7-2".to_string(), "a".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn ambiguous_or_absent_pane_evidence_stamps_nothing() {
+        let cand = |sid: &str, msg: Option<&str>| BindingCandidate {
+            sid: sid.into(),
+            needle: message_fingerprint(msg),
+        };
+        let marker = "identical rotation continuation marker text";
+        // Two panes showing the same text: ambiguous for a matching candidate.
+        let twin_panes = vec![
+            (1, "lane-7".to_string(), normalize_fingerprint(marker)),
+            (2, "lane-7-2".to_string(), normalize_fingerprint(marker)),
+        ];
+        assert!(confirmed_stamps(&[cand("a", Some(marker))], &twin_panes).is_empty());
+        // Two candidates whose needles both match one pane: mutual ambiguity, skip both.
+        let one_pane = vec![(1, "lane-7".to_string(), normalize_fingerprint(marker))];
+        assert!(
+            confirmed_stamps(
+                &[cand("a", Some(marker)), cand("b", Some(marker))],
+                &one_pane
+            )
+            .is_empty()
+        );
+        // No fingerprint (agent mid-first-turn) or no matching pane: nothing stamped.
+        assert!(confirmed_stamps(&[cand("a", None)], &one_pane).is_empty());
+        assert!(
+            confirmed_stamps(
+                &[cand(
+                    "a",
+                    Some("completely unrelated conversation text here")
+                )],
+                &one_pane
+            )
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1950,7 +1950,7 @@ pub async fn dispatch(
             ctx.last_good_windows
                 .lock()
                 .await
-                .retain(|w| w != ORCHESTRATOR_WINDOW);
+                .retain(|w| w.name != ORCHESTRATOR_WINDOW);
             *orch = None;
             *ctx.orchestrator_attention.lock().await = ("none".to_string(), None);
             let status = orchestrator_status_value(None, "none", None);
@@ -2145,8 +2145,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // window set for this tick (a transient tmux fork/connection fault must not momentarily drop
     // every managed agent — that flips sessions to `external`, detaches the focused TUI, and fires
     // stale notifications). A real empty result still clears.
-    let fresh: Result<Vec<String>, String> =
-        match tokio::task::spawn_blocking(move || tmux.list_windows()).await {
+    let fresh: Result<Vec<agent::WindowMeta>, String> =
+        match tokio::task::spawn_blocking(move || tmux.list_windows_meta()).await {
             Ok(Ok(w)) => Ok(w),
             Ok(Err(e)) => Err(e.to_string()),
             Err(e) => Err(e.to_string()),
@@ -2165,8 +2165,8 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     // fresh on the very next line, and the gone agent disappears within one refresh.
     let managed_now: std::collections::HashSet<String> = windows
         .iter()
-        .filter(|w| w.starts_with("lane-"))
-        .cloned()
+        .filter(|w| w.name.starts_with("lane-"))
+        .map(|w| w.name.clone())
         .collect();
     {
         let mut prev = ctx.last_managed_windows.lock().await;
@@ -2190,11 +2190,13 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
     let auto_off = ctx.auto_continue_off.lock().await.clone();
     let global_auto = ctx.config.read().await.auto_continue;
 
-    for (lane, mut summaries) in lanes.iter_mut().zip(per_lane) {
-        // The lane's managed agent windows, in slot order (= spawn order). A window only exists
-        // while its agent's process lives (tmux closes it on exit), so it doubles as proof of
-        // liveness and as the routing target for keys/captures.
-        let lane_windows = TmuxRuntime::lane_windows_in(&windows, lane.id);
+    // Sticky bindings established this tick, stamped as `@repomon_session` after the loop.
+    let mut new_bindings: Vec<(String, String)> = Vec::new();
+    for (lane, summaries) in lanes.iter_mut().zip(per_lane) {
+        // The lane's managed agent windows, in slot order. A window only exists while its
+        // agent's process lives (tmux closes it on exit), so it doubles as proof of liveness
+        // and as the routing target for keys/captures.
+        let lane_windows = TmuxRuntime::lane_windows_meta(&windows, lane.id);
         let managed_n = lane_windows.len();
         // Live `claude` processes whose cwd is this worktree bound how many of its sessions are
         // running (a `/exit`ed one leaves a recent transcript but no process). But never drop a
@@ -2217,13 +2219,22 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             .filter(|s| (now - s.last_activity).num_seconds() < RECENTLY_ACTIVE_SECS)
             .count();
         let keep = sessions_to_keep(summaries.len(), alive, managed_n, fresh);
-        summaries.truncate(keep);
+        // A transcript bound to a live window IS a live agent regardless of what the process
+        // count says — never truncate it away in favor of a newer unbound one.
+        let bound: std::collections::HashSet<String> = lane_windows
+            .iter()
+            .filter_map(|w| w.session.clone())
+            .collect();
+        let summaries = select_kept_summaries(summaries, &bound, keep);
         if !summaries.is_empty() {
-            // Pair the newest `k` transcripts with the `k` windows, oldest with oldest (slot order
-            // tracks spawn order, transcripts arrive newest-first). A heuristic, but it routes
-            // keys/captures to the right pane in practice.
-            let paired = summaries.len().min(managed_n);
-            for (idx, s) in summaries.into_iter().enumerate() {
+            // Pair transcripts with windows by sticky identity (`@repomon_session`), falling
+            // back to the oldest-with-oldest heuristic only on first contact — see
+            // `pair_transcripts_to_windows`. The old purely positional zip re-bound windows
+            // whenever two agents swapped activity rank, which moved names, panes, and usage
+            // accounts between rows.
+            let pairing = pair_transcripts_to_windows(&summaries, &lane_windows);
+            new_bindings.extend(pairing.new_bindings);
+            for (s, win) in summaries.into_iter().zip(pairing.assignment) {
                 if s.last_activity > lane.last_activity_at {
                     lane.last_activity_at = s.last_activity;
                 }
@@ -2232,11 +2243,12 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                     .session_id
                     .as_ref()
                     .and_then(|id| labels.get(id).cloned());
-                if idx < paired {
-                    session.external = false;
-                    session.tmux_window = Some(lane_windows[paired - 1 - idx].clone());
-                } else {
-                    session.external = true;
+                match win {
+                    Some(w) => {
+                        session.external = false;
+                        session.tmux_window = Some(w);
+                    }
+                    None => session.external = true,
                 }
                 lane.agent_sessions.push(session);
             }
@@ -2245,13 +2257,10 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             // away as a window-only placeholder so it isn't invisible until then. At most one
             // (the `SessKey::Fallback` model allows a single no-transcript session per lane): the
             // newest unpaired window, which is the slot the latest spawn took.
-            if let Some(w) = placeholder_window_index(paired, managed_n) {
+            if let Some(w) = pairing.unpaired.first() {
                 let kind = lane_meta_kind(&metas, lane.id);
-                lane.agent_sessions.push(window_placeholder_session(
-                    lane,
-                    kind,
-                    lane_windows[w].clone(),
-                ));
+                lane.agent_sessions
+                    .push(window_placeholder_session(lane, kind, w.clone()));
             }
         } else if managed_n > 0 {
             // No parseable transcript: surface a repomon-spawned agent if its window is alive.
@@ -2259,7 +2268,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
             lane.agent_sessions.push(window_placeholder_session(
                 lane,
                 kind,
-                lane_windows[0].clone(),
+                lane_windows[0].name.clone(),
             ));
         } else if let Some(changed) = lane.state.last_change_at {
             // No identified agent, but a *non-main* worktree's files changed very recently — infer
@@ -2334,6 +2343,21 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
                 }
             }
         }
+    }
+
+    // Persist the sticky bindings established this tick: stamp `@repomon_session` on each
+    // window so the pairing survives daemon restarts and activity-order flips. Rare — once
+    // per agent lifetime — so this adds no forks to a steady-state overlay.
+    if !new_bindings.is_empty() {
+        let tmux = ctx.tmux.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            for (w, sid) in new_bindings {
+                if let Err(e) = tmux.set_window_session(&w, &sid) {
+                    tracing::warn!("failed to stamp @repomon_session on {w}: {e}");
+                }
+            }
+        })
+        .await;
     }
 
     // dxkit stop-gate verdicts: worktrees running dxkit's loop pack leave an append-only
@@ -2477,7 +2501,7 @@ async fn overlay_agents(ctx: &Ctx, lanes: &mut [Lane]) {
         // liveness ONLY — its old timestamps are the stall clock.
         {
             let live: std::collections::HashSet<&str> =
-                windows.iter().map(String::as_str).collect();
+                windows.iter().map(|w| w.name.as_str()).collect();
             let mut cache = ctx.prompt_cache.lock().await;
             cache.retain(|w, (t, _)| live.contains(w.as_str()) && t.elapsed() < SNIFF_TTL);
             let mut seen = ctx.pane_seen.lock().await;
@@ -2534,6 +2558,108 @@ fn sessions_to_keep(total: usize, alive: Option<usize>, managed_n: usize, fresh:
 /// heartbeats — generous against a busy tick, short enough that a closed/crashed client frees the
 /// pane for reflow within seconds. `pub(crate)` so [`crate::Ctx::viewport_snapshot`] shares it.
 pub(crate) const FOCUS_OWNED_TTL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// A lane's transcript↔window pairing for one overlay tick ([`pair_transcripts_to_windows`]).
+struct Pairing {
+    /// Per input summary (order preserved): the managed window it runs in; `None` = external.
+    assignment: Vec<Option<String>>,
+    /// Sticky bindings established this tick — `(window_name, session_id)` to stamp as
+    /// `@repomon_session` so they survive daemon restarts and activity-order flips.
+    new_bindings: Vec<(String, String)>,
+    /// Live managed windows no transcript claimed, newest (highest window id) first. The
+    /// first is the placeholder target for a just-spawned agent whose `.jsonl` hasn't
+    /// appeared yet (at most one, per the `SessKey::Fallback` model).
+    unpaired: Vec<String>,
+}
+
+/// Pair a lane's kept transcripts (newest-first) with its live managed windows by STICKY
+/// IDENTITY first, position last.
+///
+/// Pass 1: a window whose `@repomon_session` names a kept transcript keeps it. This is what
+/// makes the pairing immune to two agents swapping activity rank — which used to re-bind
+/// their windows every poll, moving names, panes, and usage accounts between rows — and to
+/// daemon restarts (the binding lives in tmux, not daemon memory).
+///
+/// Pass 2 (first contact only): the newest still-unassigned transcripts meet the still-free
+/// windows, oldest-with-oldest — the same heuristic the overlay always used, but run ONCE
+/// per agent: each pair is emitted in `new_bindings` and pass 1 owns it from the next tick.
+/// Never-bound windows are offered before stale-bound ones (whose transcript vanished this
+/// tick), so a one-tick transcript flap can't hand a live agent's window to a newcomer; and
+/// window age is the window id — slot NAMES are recycled after an exit, ids never are.
+fn pair_transcripts_to_windows(
+    summaries: &[agent::TranscriptSummary],
+    windows: &[agent::WindowMeta],
+) -> Pairing {
+    let mut assignment: Vec<Option<String>> = vec![None; summaries.len()];
+    let mut taken = vec![false; windows.len()];
+    // Pass 1 — sticky identity.
+    for (wi, w) in windows.iter().enumerate() {
+        let Some(sid) = &w.session else { continue };
+        if let Some(si) = summaries
+            .iter()
+            .position(|s| s.session_id.as_deref() == Some(sid.as_str()))
+        {
+            if assignment[si].is_none() {
+                assignment[si] = Some(w.name.clone());
+                taken[wi] = true;
+            }
+        }
+    }
+    // Pass 2 — first contact. Never-bound windows are offered before stale-bound ones, both
+    // oldest (lowest window id) first.
+    let mut free: Vec<usize> = (0..windows.len()).filter(|&i| !taken[i]).collect();
+    free.sort_by_key(|&i| (windows[i].session.is_some(), windows[i].wid));
+    // `summaries` is newest-first, so the first `free.len()` unassigned ones are the newest;
+    // pair that subset oldest-with-oldest (hence `.rev()`), like the legacy positional zip.
+    let chosen: Vec<usize> = (0..summaries.len())
+        .filter(|&i| assignment[i].is_none())
+        .take(free.len())
+        .collect();
+    let mut new_bindings = Vec::new();
+    for (&si, &wi) in chosen.iter().rev().zip(&free) {
+        assignment[si] = Some(windows[wi].name.clone());
+        taken[wi] = true;
+        if let Some(sid) = &summaries[si].session_id {
+            new_bindings.push((windows[wi].name.clone(), sid.clone()));
+        }
+    }
+    let mut unpaired: Vec<&agent::WindowMeta> = windows
+        .iter()
+        .zip(&taken)
+        .filter(|(_, t)| !**t)
+        .map(|(w, _)| w)
+        .collect();
+    unpaired.sort_by_key(|w| std::cmp::Reverse(w.wid));
+    Pairing {
+        assignment,
+        new_bindings,
+        unpaired: unpaired.into_iter().map(|w| w.name.clone()).collect(),
+    }
+}
+
+/// Which of a lane's newest-first transcripts to keep, honoring bindings: every summary bound
+/// to a live managed window is kept regardless of rank (the window only exists while its
+/// agent's process lives, so it outranks the process-count probe), then newest-first from the
+/// rest up to `keep` total. Output is re-sorted newest-first so the wire order is unchanged.
+/// Without this, a bound-but-quiet agent could be truncated in favor of a newer external
+/// transcript, dropping a live agent from the lane.
+fn select_kept_summaries(
+    summaries: Vec<agent::TranscriptSummary>,
+    bound: &std::collections::HashSet<String>,
+    keep: usize,
+) -> Vec<agent::TranscriptSummary> {
+    if summaries.len() <= keep {
+        return summaries;
+    }
+    let (bound_s, rest): (Vec<_>, Vec<_>) = summaries
+        .into_iter()
+        .partition(|s| s.session_id.as_ref().is_some_and(|id| bound.contains(id)));
+    let take_rest = keep.saturating_sub(bound_s.len());
+    let mut out = bound_s;
+    out.extend(rest.into_iter().take(take_rest));
+    out.sort_by_key(|s| std::cmp::Reverse(s.last_activity));
+    out
+}
 
 /// The fit-arbitration-relevant slice of one session, snapshotted so [`fit_allowed`] is a pure
 /// function over plain data (and unit-testable without a live `Ctx`).
@@ -3007,16 +3133,6 @@ fn window_placeholder_session(lane: &Lane, kind: AgentKind, window: String) -> A
     }
 }
 
-/// Whether a lane needs a window-only placeholder for a just-spawned agent whose transcript
-/// hasn't appeared yet, and which managed-window index it maps to. `shown` = transcript-backed
-/// sessions already emitted; `managed_n` = live managed windows. A managed window exists only
-/// while its agent's process lives (tmux closes it on exit), so an unpaired window is a real
-/// agent that simply hasn't written its `.jsonl` yet. Returns the newest unpaired window's index
-/// (at most one, per the `SessKey::Fallback` single-no-transcript-session model), or `None`.
-fn placeholder_window_index(shown: usize, managed_n: usize) -> Option<usize> {
-    (managed_n > shown).then(|| managed_n - 1)
-}
-
 /// A Claude session id is safe to interpolate into a resume command (`claude --resume <id>`).
 /// Transcript ids are UUIDs / `[A-Za-z0-9_-]`; anything else (whitespace, `;`, `$`, quotes, `|`,
 /// backticks…) is rejected so `agent.adopt` can't be turned into shell injection — the command is
@@ -3032,11 +3148,11 @@ fn valid_session_id(s: &str) -> bool {
 /// `tmux` failing to spawn under load — distinct from a genuinely empty server), reuse the
 /// last-good list so a single bad snapshot doesn't momentarily drop every managed agent — which
 /// would flip sessions to `external`, detach the focused TUI, and fire stale notifications.
-fn resolve_windows(
-    fresh: Result<Vec<String>, String>,
-    last_good: &mut Vec<String>,
+fn resolve_windows<T: Clone>(
+    fresh: Result<Vec<T>, String>,
+    last_good: &mut Vec<T>,
     empty_misses: &mut u8,
-) -> Vec<String> {
+) -> Vec<T> {
     match fresh {
         // Transient probe fault (fork/connection): reuse last-good; don't touch the empty counter.
         Err(_) => last_good.clone(),
@@ -3883,19 +3999,181 @@ mod tests {
         assert_eq!(misses, 0);
     }
 
+    /// A minimal transcript summary for pairing tests: `sid` + activity time.
+    fn tsum(sid: &str, last_activity: chrono::DateTime<chrono::Utc>) -> agent::TranscriptSummary {
+        agent::TranscriptSummary {
+            kind: repomon_core::model::AgentKind::ClaudeCode,
+            manifest_path: PathBuf::from(format!("/tmp/{sid}.jsonl")),
+            cwd: None,
+            last_activity,
+            tool_call_count: 0,
+            status: repomon_core::model::AgentStatus::Idle,
+            title: None,
+            last_message: None,
+            config_dir: None,
+            session_id: Some(sid.to_string()),
+            ended_turn: false,
+        }
+    }
+
+    fn wm(name: &str, wid: u64, sid: Option<&str>) -> agent::WindowMeta {
+        agent::WindowMeta {
+            name: name.into(),
+            wid,
+            session: sid.map(str::to_string),
+        }
+    }
+
+    /// Activity times t(0) < t(1) < …, so `t(2)` is newer than `t(1)`.
+    fn t(n: i64) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::from_timestamp(1_700_000_000 + n * 60, 0).unwrap()
+    }
+
     #[test]
-    fn placeholder_for_the_newest_unpaired_window() {
-        // One existing agent (transcript) + a freshly-spawned second window: surface the new
-        // window immediately, mapped to the newest slot, so it isn't invisible until its
-        // transcript lands.
-        assert_eq!(placeholder_window_index(1, 2), Some(1));
-        // Every managed window already transcript-backed → no placeholder.
-        assert_eq!(placeholder_window_index(2, 2), None);
-        assert_eq!(placeholder_window_index(1, 1), None);
-        assert_eq!(placeholder_window_index(0, 0), None);
-        // Three windows, one transcript: still a single placeholder (the Fallback invariant),
-        // mapped to the newest window.
-        assert_eq!(placeholder_window_index(1, 3), Some(2));
+    fn pairing_without_bindings_matches_legacy_heuristic() {
+        // First contact (nothing bound yet): newest transcript ↔ newest slot, oldest paired ↔
+        // slot 1, the overflow transcript external — exactly what the positional zip did.
+        let summaries = vec![tsum("c", t(3)), tsum("b", t(2)), tsum("a", t(1))];
+        let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
+        let p = pair_transcripts_to_windows(&summaries, &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-5-2".into()), Some("lane-5".into()), None]
+        );
+        // Both pairs become sticky bindings.
+        let mut nb = p.new_bindings.clone();
+        nb.sort();
+        assert_eq!(
+            nb,
+            vec![
+                ("lane-5".to_string(), "b".to_string()),
+                ("lane-5-2".to_string(), "c".to_string())
+            ]
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn pairing_sticks_across_activity_flip() {
+        // The reported bug: two bound agents swap activity rank; the pairing must not move.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        // b most recently active…
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+        // …then a takes a turn and the order flips: same windows per session id.
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn first_contact_binds_then_holds_through_flip() {
+        // Unbound windows (daemon restart / pre-upgrade agents): the heuristic runs once and
+        // its result is emitted as bindings; re-running with those bindings and flipped
+        // activity keeps the original assignment.
+        let unbound = vec![wm("lane-7", 1, None), wm("lane-7-2", 2, None)];
+        let p = pair_transcripts_to_windows(&[tsum("b", t(2)), tsum("a", t(1))], &unbound);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7-2".into()), Some("lane-7".into())]
+        );
+        let bound = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3)), tsum("b", t(2))], &bound);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert!(p.new_bindings.is_empty());
+    }
+
+    #[test]
+    fn slot_recycling_pairs_new_transcript_to_new_window() {
+        // Slot 1 (`lane-7`) died and was respawned: same NAME, higher window id, no binding.
+        // The surviving agent b keeps its bound `lane-7-2`; the newcomer c gets the recycled
+        // window — even though slot-name order would have handed c the older agent's window.
+        let windows = vec![wm("lane-7", 7, None), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("c", t(9)), tsum("b", t(2))], &windows);
+        assert_eq!(
+            p.assignment,
+            vec![Some("lane-7".into()), Some("lane-7-2".into())]
+        );
+        assert_eq!(
+            p.new_bindings,
+            vec![("lane-7".to_string(), "c".to_string())]
+        );
+    }
+
+    #[test]
+    fn one_tick_transcript_flap_does_not_rebind() {
+        // b's transcript flaps out for one tick: its window merely goes unpaired (placeholder
+        // target); it is NOT rebound to the surviving transcript and no binding is written.
+        let windows = vec![wm("lane-7", 1, Some("a")), wm("lane-7-2", 2, Some("b"))];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(3))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert!(p.new_bindings.is_empty());
+        assert_eq!(p.unpaired, vec!["lane-7-2".to_string()]);
+    }
+
+    #[test]
+    fn stale_binding_released_to_a_genuinely_new_transcript() {
+        // The bound transcript is gone AND a new one needs a window: the stale binding is
+        // released and rewritten to the newcomer.
+        let windows = vec![wm("lane-7", 1, Some("x"))];
+        let p = pair_transcripts_to_windows(&[tsum("y", t(5))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-7".into())]);
+        assert_eq!(
+            p.new_bindings,
+            vec![("lane-7".to_string(), "y".to_string())]
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn placeholder_target_is_the_newest_unpaired_window() {
+        // One transcript, two windows (second freshly spawned, no `.jsonl` yet): the leftover
+        // is the NEWEST window (highest id) so the placeholder lands on the fresh spawn.
+        let windows = vec![wm("lane-5", 1, None), wm("lane-5-2", 2, None)];
+        let p = pair_transcripts_to_windows(&[tsum("a", t(1))], &windows);
+        assert_eq!(p.assignment, vec![Some("lane-5".into())]);
+        assert_eq!(p.unpaired, vec!["lane-5-2".to_string()]);
+        // All windows transcript-backed → nothing unpaired.
+        let p = pair_transcripts_to_windows(
+            &[tsum("b", t(2)), tsum("a", t(1))],
+            &[wm("lane-5", 1, None), wm("lane-5-2", 2, None)],
+        );
+        assert!(p.unpaired.is_empty());
+    }
+
+    #[test]
+    fn select_kept_summaries_protects_bound_sessions() {
+        // A bound-but-quiet agent (its window is alive — that IS liveness) must survive
+        // truncation ahead of newer unbound transcripts; output stays newest-first.
+        let bound: std::collections::HashSet<String> = ["a".to_string()].into();
+        let kept = select_kept_summaries(
+            vec![tsum("e1", t(3)), tsum("e2", t(2)), tsum("a", t(1))],
+            &bound,
+            2,
+        );
+        let ids: Vec<&str> = kept
+            .iter()
+            .filter_map(|s| s.session_id.as_deref())
+            .collect();
+        assert_eq!(ids, vec!["e1", "a"]);
+        // Under the cap nothing is dropped.
+        let kept = select_kept_summaries(vec![tsum("e1", t(3)), tsum("a", t(1))], &bound, 5);
+        assert_eq!(kept.len(), 2);
+        // More bound sessions than `keep` says: the windows win (each proves a live agent).
+        let bound: std::collections::HashSet<String> = ["a".to_string(), "b".to_string()].into();
+        let kept = select_kept_summaries(vec![tsum("b", t(3)), tsum("a", t(1))], &bound, 1);
+        assert_eq!(kept.len(), 2);
     }
 
     #[test]

--- a/crates/repomon-daemon/tests/integration.rs
+++ b/crates/repomon-daemon/tests/integration.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use repomon_core::protocol::{self, Request, Response};
 use repomon_core::{Config, Store, TmuxRuntime};
 use repomon_daemon::{Ctx, serve};
-use serde_json::json;
+use serde_json::{Value, json};
 use tokio::net::UnixStream;
 
 fn git(dir: &Path, args: &[&str]) {
@@ -187,13 +187,28 @@ async fn daemon_spawns_and_drives_an_agent() {
         "agent.spawn errored: {:?}",
         spawned.error
     );
+    let spawned_window = spawned
+        .result
+        .as_ref()
+        .and_then(|v| v.get("window"))
+        .and_then(Value::as_str)
+        .expect("agent.spawn returns a window");
+    assert_eq!(
+        spawned_window,
+        TmuxRuntime::window_name(lane_id),
+        "agent.spawn must return the bare window name accepted by named-window RPCs"
+    );
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     call(
         &mut stream,
         4,
         "agent.send_input",
-        Some(json!({ "lane_id": lane_id, "text": "echo HELLO_FROM_AGENT_XYZ" })),
+        Some(json!({
+            "lane_id": lane_id,
+            "window": spawned_window,
+            "text": "echo HELLO_FROM_AGENT_XYZ"
+        })),
     )
     .await;
     tokio::time::sleep(Duration::from_millis(600)).await;

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -384,10 +384,8 @@ pub struct App {
     /// shows up in `lane.list` — so a fresh spawn lands you on the *new* agent, not the old one.
     /// Cleared when matched (or after a few refreshes if the window never appears).
     pending_focus_window: Option<(LaneId, String)>,
+    /// Successful data refreshes spent waiting for [`Self::pending_focus_window`] to appear.
     pending_focus_ticks: u8,
-    /// The `refresh_gen` the last pending-focus miss was counted against — the give-up
-    /// clock ticks per data refresh, not per event-loop iteration.
-    pending_focus_gen: u64,
     /// Plain shell terminals open for the selected lane (tmux window names).
     pub terminals: Vec<String>,
     terminals_lane: Option<LaneId>,
@@ -591,7 +589,6 @@ impl App {
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
-            pending_focus_gen: u64::MAX,
             terminals: Vec::new(),
             terminals_lane: None,
             term_windows: Vec::new(),
@@ -4072,8 +4069,8 @@ impl App {
 
     /// Land on a just-spawned agent, typing-ready: select its lane in the fleet, arm the
     /// pending-focus intent (which also routes keys to the window before its session shows up
-    /// in `lane.list` — see [`Self::selected_window`]), and enter Focus with insert mode on —
-    /// creating an agent needs no manual open before talking to it.
+    /// in `lane.list` — see [`Self::selected_window`]), and enter Split with insert mode on —
+    /// creating an agent needs no manual open before talking to it while the sidebar stays visible.
     fn land_on_spawned(&mut self, lane: LaneId, window: Option<String>) {
         self.select_lane_session(lane, None);
         if let Some(w) = window {
@@ -4081,11 +4078,11 @@ impl App {
             self.pending_focus_ticks = 0;
         }
         self.reset_scroll(); // live tail, mirroring what `i` does
-        self.view = View::Focus;
+        self.view = View::Split;
         self.focus_insert = true;
     }
 
-    /// Spawn `agent` into `lane`: on success drop into Focus on the *new* agent with insert on,
+    /// Spawn `agent` into `lane`: on success drop into Split on the *new* agent with insert on,
     /// typing straight to it. The daemon surfaces the new window right away (a window-only
     /// placeholder until its transcript lands), so an immediate refresh plus the pending-focus
     /// intent put the cursor on it instead of leaving you on the lane's existing agent.

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -385,6 +385,9 @@ pub struct App {
     /// Cleared when matched (or after a few refreshes if the window never appears).
     pending_focus_window: Option<(LaneId, String)>,
     pending_focus_ticks: u8,
+    /// The `refresh_gen` the last pending-focus miss was counted against — the give-up
+    /// clock ticks per data refresh, not per event-loop iteration.
+    pending_focus_gen: u64,
     /// Plain shell terminals open for the selected lane (tmux window names).
     pub terminals: Vec<String>,
     terminals_lane: Option<LaneId>,
@@ -588,6 +591,7 @@ impl App {
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
+            pending_focus_gen: u64::MAX,
             terminals: Vec::new(),
             terminals_lane: None,
             term_windows: Vec::new(),
@@ -1763,7 +1767,16 @@ impl App {
             }) = self.selected_row()
             {
                 let lane_id = self.selected_lane().map(|l| l.id);
-                if self.session_idx != s || self.session_lane != lane_id {
+                // Same agent? Compare by identity, not raw index — the daemon re-sorts
+                // `agent_sessions` as agents take turns, so the same agent's row carries a
+                // new index after every re-sort; wiping the scrollback for that would kick
+                // the user out of what they were reading.
+                let same_agent = self.session_lane == lane_id
+                    && self.session_ref.as_ref().and_then(|r| {
+                        self.selected_lane()
+                            .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
+                    }) == Some(s);
+                if !same_agent {
                     self.reset_scroll();
                 }
                 self.session_lane = lane_id;
@@ -4995,10 +5008,11 @@ fn session_rank(
     }
 }
 
-/// A stable identity for one agent session within a lane, used to remember which agent a lane
-/// had selected across a switch away and back. The persistent `id` is `0` for daemon-overlaid
-/// placeholders so it can't be used; the managed tmux window (preferred) and the Claude
-/// transcript id are the durable handles the rest of the app already keys on.
+/// A stable identity for one agent session within a lane — the session cursor's anchor and
+/// the per-lane selection memory. The persistent `id` is `0` for daemon-overlaid
+/// placeholders so it can't be used; the Claude transcript id (preferred — UUIDs are never
+/// reused, while slot names are recycled on respawn) and the managed tmux window (the
+/// placeholder fallback) are the durable handles. See [`agent_session_ref`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SessionRef {
     Window(String),
@@ -5060,11 +5074,14 @@ fn stable_session_order(sessions: &[AgentSession]) -> Vec<usize> {
 }
 
 /// The stable identity of a session, or `None` for an inferred/keyless one (nothing to pin to).
+/// Transcript id first — UUIDs are never reused, while slot names (`lane-7-2`) are recycled on
+/// respawn, so a long-held `Window` ref could resolve to a brand-new different agent. The
+/// window is the fallback for just-spawned placeholders whose `.jsonl` hasn't appeared yet.
 fn agent_session_ref(s: &AgentSession) -> Option<SessionRef> {
-    if let Some(w) = &s.tmux_window {
-        Some(SessionRef::Window(w.clone()))
+    if let Some(id) = &s.session_id {
+        Some(SessionRef::Transcript(id.clone()))
     } else {
-        s.session_id.clone().map(SessionRef::Transcript)
+        s.tmux_window.clone().map(SessionRef::Window)
     }
 }
 
@@ -5717,10 +5734,17 @@ mod tests {
     }
 
     #[test]
-    fn agent_session_ref_prefers_window_then_transcript() {
-        // A managed agent keys on its window even when it also has a transcript id.
+    fn agent_session_ref_prefers_transcript_then_window() {
+        // A transcript-backed agent keys on its transcript id even when it also has a window:
+        // transcript UUIDs are never reused, while slot names like `lane-7-2` are recycled on
+        // respawn — a remembered Window ref could resolve to a brand-new different agent.
         assert_eq!(
             agent_session_ref(&managed("lane-7-2", Some("uuid-1"))),
+            Some(SessionRef::Transcript("uuid-1".into()))
+        );
+        // A just-spawned placeholder (window, no `.jsonl` yet) falls back to its window.
+        assert_eq!(
+            agent_session_ref(&managed("lane-7-2", None)),
             Some(SessionRef::Window("lane-7-2".into()))
         );
         // An external/transcript-only session keys on the transcript id.
@@ -5909,6 +5933,60 @@ mod tests {
         assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
         // A later reorder still can't move the cursor off the spawned agent.
         app.lanes[0].agent_sessions = vec![a, b];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn expanded_row_resort_keeps_scroll_on_same_agent() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = true;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        // Land the fleet cursor on b's sub-row (rows: orchestrator, header, sub, sub).
+        app.select_lane_session(1, Some(SessionRef::Transcript("sid-b".into())));
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        app.scroll = 7;
+        // The daemon re-sorts; refresh_lanes re-anchors the row by identity — same agent,
+        // new raw index. That must not read as a switch and wipe the scrollback position.
+        app.lanes[0].agent_sessions = vec![b.clone(), a.clone()];
+        app.select_lane_session(1, Some(SessionRef::Transcript("sid-b".into())));
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        assert_eq!(
+            app.scroll, 7,
+            "a re-sort of the same agent must keep the scroll"
+        );
+        // A real move to the other agent still resets it.
+        app.cycle_session(true);
+        assert_eq!(app.scroll, 0);
+    }
+
+    #[tokio::test]
+    async fn pending_focus_survives_input_burst() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, _) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // An agent was just spawned; its window hasn't shown up in lane.list yet.
+        app.pending_focus_window = Some((1, "lane-1-2".to_string()));
+        // A burst of input events re-runs the sync many times against the SAME snapshot:
+        // the give-up clock counts data refreshes, not event-loop iterations.
+        for _ in 0..20 {
+            app.sync_session_cursor();
+        }
+        assert!(
+            app.pending_focus_window.is_some(),
+            "spawn-focus intent must survive an input burst"
+        );
+        // The window appears on the next refresh: the cursor lands on it.
+        app.lanes[0].agent_sessions = vec![a, managed("lane-1-2", None)];
+        app.refresh_gen = app.refresh_gen.wrapping_add(1);
         app.sync_session_cursor();
         assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
     }

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -6099,11 +6099,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_lands_in_focus_typing_ready() {
+    async fn spawn_lands_in_split_typing_ready() {
         let mut app = app_on_lane_7().await;
         // `e` on lane 7 spawned a second agent into window lane-7-2.
         app.land_on_spawned(7, Some("lane-7-2".into()));
-        assert_eq!(app.view, View::Focus);
+        assert_eq!(app.view, View::Split);
         assert!(
             app.focus_insert,
             "typing must reach the agent with no `i` press"
@@ -6121,18 +6121,18 @@ mod tests {
         app.lanes.push(test_lane(8));
         app.land_on_spawned(8, Some("lane-8".into()));
         assert_eq!(app.selected_lane().map(|l| l.id), Some(8));
-        assert_eq!(app.view, View::Focus);
+        assert_eq!(app.view, View::Split);
         assert!(app.focus_insert);
         assert_eq!(app.selected_window().as_deref(), Some("lane-8"));
     }
 
     #[tokio::test]
-    async fn landing_without_a_window_still_opens_focus_insert() {
+    async fn landing_without_a_window_still_opens_split_insert() {
         let mut app = app_on_lane_7().await;
         // A malformed spawn response (no window name): no intent to arm, but the user still
         // lands typing-ready on the lane's selected session.
         app.land_on_spawned(7, None);
-        assert_eq!(app.view, View::Focus);
+        assert_eq!(app.view, View::Split);
         assert!(app.focus_insert);
         assert!(app.pending_focus_window.is_none());
         assert_eq!(app.selected_window().as_deref(), Some("lane-7"));

--- a/crates/repomon-tui/src/app.rs
+++ b/crates/repomon-tui/src/app.rs
@@ -356,12 +356,29 @@ pub struct App {
     pub recent_commits: Vec<Commit>,
     recent_commits_lane: Option<LaneId>,
     /// Which of the selected lane's agent sessions is highlighted (for adopt). Several
-    /// concurrent agents can run in one worktree; this cursor picks among them.
+    /// concurrent agents can run in one worktree; this cursor picks among them. Derived: the
+    /// daemon orders `agent_sessions` newest-active-first and re-sorts it as agents take
+    /// turns, so `sync_session_cursor` re-derives this position from `session_ref` on every
+    /// tick — a raw index held across refreshes would silently drift onto a different agent
+    /// (wrong usage account, keys routed to the wrong pane).
     pub session_idx: usize,
     session_lane: Option<LaneId>,
-    /// The agent each lane had selected when you last left it, so returning to a multi-agent
-    /// lane restores your pick instead of snapping back to the first slot. Keyed by a stable
-    /// identity (tmux window / transcript id), so it survives the session list reordering.
+    /// The durable identity of the agent the session cursor is on — the source of truth that
+    /// `session_idx` is re-derived from each tick. `None` until a lane's first pin.
+    session_ref: Option<SessionRef>,
+    /// Consecutive refreshes the anchored agent has been missing from the selected lane (see
+    /// [`SESSION_REF_GRACE`]); counted at most once per `refresh_gen`.
+    session_ref_misses: u8,
+    /// The `refresh_gen` the last anchor miss was counted against, so a burst of input events
+    /// during one bad snapshot (the cursor sync runs per event-loop iteration) can't exhaust
+    /// the grace that is meant to be measured in data refreshes.
+    session_ref_miss_gen: u64,
+    /// Bumped by every successful `refresh_lanes` — the anchor miss counter's clock.
+    refresh_gen: u64,
+    /// The agent each lane had selected when you last left it (saved from `session_ref` on
+    /// lane change), so returning to a multi-agent lane restores your pick instead of
+    /// snapping back to the first slot. Keyed by a stable identity (transcript id / tmux
+    /// window), so it survives the session list reordering.
     session_memory: HashMap<LaneId, SessionRef>,
     /// After spawning an agent, the (lane, tmux window) to move the session cursor onto once it
     /// shows up in `lane.list` — so a fresh spawn lands you on the *new* agent, not the old one.
@@ -563,6 +580,11 @@ impl App {
             recent_commits_lane: None,
             session_idx: 0,
             session_lane: None,
+            session_ref: None,
+            session_ref_misses: 0,
+            // Sentinel ≠ refresh_gen, so the very first snapshot's miss is counted too.
+            session_ref_miss_gen: u64::MAX,
+            refresh_gen: 0,
             session_memory: HashMap::new(),
             pending_focus_window: None,
             pending_focus_ticks: 0,
@@ -730,6 +752,8 @@ impl App {
                 let keep = self.selected_lane().map(|l| l.id);
                 let keep_ref = self.selected_session_ref();
                 self.lanes = l;
+                // New snapshot: advance the anchor miss counter's clock (see `refresh_gen`).
+                self.refresh_gen = self.refresh_gen.wrapping_add(1);
                 // Forget remembered agent selections for lanes that no longer exist.
                 self.session_memory
                     .retain(|id, _| self.lanes.iter().any(|l| l.id == *id));
@@ -1704,16 +1728,14 @@ impl App {
                 });
                 match hit {
                     Some(i) => {
-                        self.session_idx = i;
+                        // Anchor by identity: the ref is the window for now and upgrades to
+                        // the transcript id once the `.jsonl` lands (per-tick re-resolve).
+                        self.pin_session(i);
                         self.pending_focus_window = None;
                         self.pending_focus_ticks = 0;
                         self.reset_scroll();
                         if self.settings.expand_agents {
-                            let sref = self
-                                .selected_lane()
-                                .and_then(|l| l.agent_sessions.get(i))
-                                .and_then(agent_session_ref);
-                            self.select_lane_session(lane, sref);
+                            self.select_lane_session(lane, self.session_ref.clone());
                         }
                         return;
                     }
@@ -1733,7 +1755,8 @@ impl App {
             }
         }
         // In expanded mode an agent sub-row IS the session cursor — drive `session_idx` straight
-        // from the selected row (the memory logic below is for the collapsed lane rows).
+        // from the selected row (the row itself is identity-remapped on refresh, so it's safe);
+        // the anchor mirrors it so collapsing keeps the pick.
         if self.settings.expand_agents {
             if let Some(FleetRow {
                 session: Some(s), ..
@@ -1744,7 +1767,7 @@ impl App {
                     self.reset_scroll();
                 }
                 self.session_lane = lane_id;
-                self.session_idx = s;
+                self.pin_session(s);
                 return;
             }
         }
@@ -1754,34 +1777,80 @@ impl App {
             // your pick instead of snapping to the first slot. Identity-keyed, so it survives
             // the session list reordering; falls back to the first agent when the remembered
             // one is gone (or this lane was never visited).
-            if let Some(old) = self.session_lane {
-                if let Some(r) = self
-                    .lanes
-                    .iter()
-                    .find(|l| l.id == old)
-                    .and_then(|l| l.agent_sessions.get(self.session_idx))
-                    .and_then(agent_session_ref)
-                {
-                    self.session_memory.insert(old, r);
-                }
+            if let (Some(old), Some(r)) = (self.session_lane, self.session_ref.clone()) {
+                self.session_memory.insert(old, r);
             }
             self.session_lane = sel;
-            self.session_idx = sel
+            let idx = sel
                 .and_then(|id| self.session_memory.get(&id))
                 .and_then(|r| {
                     self.selected_lane()
                         .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
                 })
                 .unwrap_or(0);
+            self.pin_session(idx);
             self.reset_scroll(); // scrollback buffer belonged to the previous lane
+            return;
         }
-        let n = self
+        // Same lane, possibly a new snapshot: re-resolve the anchor EVERY tick. The daemon
+        // orders `agent_sessions` newest-active-first and re-sorts it as agents take turns,
+        // so identity is the truth and `session_idx` merely its current position. No scroll
+        // reset on a position change — it is the same agent.
+        let resolved = self.session_ref.as_ref().and_then(|r| {
+            self.selected_lane()
+                .and_then(|l| session_index_for_ref(&l.agent_sessions, r))
+        });
+        match resolved {
+            Some(i) => {
+                self.session_idx = i;
+                self.session_ref_misses = 0;
+                // Re-derive the anchor from the resolved session, so a `Window` ref upgrades
+                // to the sturdier `Transcript` ref once a placeholder gains its transcript.
+                self.session_ref = self
+                    .selected_lane()
+                    .and_then(|l| l.agent_sessions.get(i))
+                    .and_then(agent_session_ref);
+            }
+            None => {
+                let n = self
+                    .selected_lane()
+                    .map(|l| l.agent_sessions.len())
+                    .unwrap_or(0);
+                if self.session_idx >= n {
+                    self.session_idx = n.saturating_sub(1);
+                }
+                if n == 0 {
+                    return;
+                }
+                if self.session_ref.is_none() {
+                    // First contact with a populated lane (arrival landed on an empty lane, or
+                    // nothing was ever pinned): pin the current occupant — and hold it, per
+                    // the pin-on-arrival rule, instead of following the daemon's re-sorts.
+                    self.pin_session(self.session_idx);
+                } else if self.session_ref_miss_gen != self.refresh_gen {
+                    // The anchored agent is missing from this snapshot. Counted once per data
+                    // refresh: a transient overlay flap must not re-pin the pick, a real exit
+                    // adopts the occupant after the grace.
+                    self.session_ref_miss_gen = self.refresh_gen;
+                    self.session_ref_misses = self.session_ref_misses.saturating_add(1);
+                    if self.session_ref_misses > SESSION_REF_GRACE {
+                        self.pin_session(self.session_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Point the session cursor at `idx` on the selected lane and anchor it by identity —
+    /// every deliberate cursor move funnels through here so `sync_session_cursor`'s per-tick
+    /// re-resolve can never snap the cursor back to a stale pick.
+    fn pin_session(&mut self, idx: usize) {
+        self.session_idx = idx;
+        self.session_ref = self
             .selected_lane()
-            .map(|l| l.agent_sessions.len())
-            .unwrap_or(0);
-        if self.session_idx >= n {
-            self.session_idx = n.saturating_sub(1);
-        }
+            .and_then(|l| l.agent_sessions.get(idx))
+            .and_then(agent_session_ref);
+        self.session_ref_misses = 0;
     }
 
     /// Drop out of Focus once the agent we were driving exits (its managed session is gone —
@@ -1977,11 +2046,12 @@ impl App {
         // appear to move while `selected_window()` kept routing keys at the pending window.
         self.pending_focus_window = None;
         self.pending_focus_ticks = 0;
-        self.session_idx = if forward {
+        let idx = if forward {
             (self.session_idx + 1) % n
         } else {
             (self.session_idx + n - 1) % n
         };
+        self.pin_session(idx);
         // The scrollback snapshot belonged to the previous agent's window — drop it so the new
         // agent shows its own live tail instead of stale lines.
         self.reset_scroll();
@@ -1989,11 +2059,7 @@ impl App {
         // agent's sub-row — otherwise the per-tick cursor sync snaps session_idx straight back.
         if self.settings.expand_agents {
             if let Some(lane_id) = self.selected_lane().map(|l| l.id) {
-                let sref = self
-                    .selected_lane()
-                    .and_then(|l| l.agent_sessions.get(self.session_idx))
-                    .and_then(agent_session_ref);
-                self.select_lane_session(lane_id, sref);
+                self.select_lane_session(lane_id, self.session_ref.clone());
             }
         }
     }
@@ -2980,16 +3046,19 @@ impl App {
         if let Some(i) = idx {
             self.session_lane = Some(lane_id); // keep sync_session_cursor from resetting it
             self.session_idx = i;
+            // Anchor by identity (from the target lane — the fleet cursor may not be on it
+            // yet), or the per-tick re-resolve would snap back to the old pick within a tick.
+            self.session_ref = self
+                .lanes
+                .iter()
+                .find(|l| l.id == lane_id)
+                .and_then(|l| l.agent_sessions.get(i))
+                .and_then(agent_session_ref);
+            self.session_ref_misses = 0;
             // In expanded mode, also land the fleet cursor on that agent's row so the per-tick
             // cursor sync (which keys off the selected row) keeps it there.
             if self.settings.expand_agents {
-                let sref = self
-                    .lanes
-                    .iter()
-                    .find(|l| l.id == lane_id)
-                    .and_then(|l| l.agent_sessions.get(i))
-                    .and_then(agent_session_ref);
-                self.select_lane_session(lane_id, sref);
+                self.select_lane_session(lane_id, self.session_ref.clone());
             }
         }
     }
@@ -4951,6 +5020,12 @@ const VIEWPORT_REASSERT: std::time::Duration = std::time::Duration::from_secs(5)
 /// within ~grace refreshes.
 const FOCUS_DETACH_GRACE: u8 = 3;
 
+/// Consecutive cursor syncs the anchored agent may be missing from the selected lane before
+/// the cursor re-pins to whatever agent it currently rests on. More than one, so a transient
+/// overlay flap (one bad tmux/transcript snapshot) can't permanently retarget the pick; a
+/// real exit stays absent and re-pins within ~grace ticks.
+const SESSION_REF_GRACE: u8 = 3;
+
 /// How many ~1s refreshes to keep trying to land the cursor on a just-spawned agent's window
 /// before giving up (the transcript/window may take a moment to appear).
 const PENDING_FOCUS_GIVE_UP_TICKS: u8 = 5;
@@ -5682,6 +5757,199 @@ mod tests {
             session_index_for_ref(&sessions, &SessionRef::Window("lane-7-3".into())),
             None
         );
+    }
+
+    /// A minimal collapsed-mode fleet: real `Lane` built over the wire shape (the TUI has no
+    /// gix dependency to mint `ObjectId`s directly), sessions swapped in by the caller.
+    fn fake_lane(id: repomon_core::model::LaneId, sessions: Vec<AgentSession>) -> Lane {
+        let zero = "0".repeat(40);
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut lane: Lane = serde_json::from_value(json!({
+            "id": id,
+            "repo": {
+                "id": 1, "path": "/tmp/repo", "name": "repo",
+                "added_at": now, "worktree_root_template": null,
+            },
+            "worktree": {
+                "id": id, "repo_id": 1, "path": format!("/tmp/wt{id}"),
+                "branch": "main", "head": zero, "is_main": true, "name": format!("wt{id}"),
+            },
+            "state": {
+                "worktree_id": id, "head": zero, "branch": "main", "upstream": null,
+                "ahead": 0, "behind": 0,
+                "dirty": {"staged": 0, "unstaged": 0, "untracked": 0},
+                "last_commit_at": null,
+            },
+            "agent_sessions": [],
+            "last_activity_at": now,
+            "pinned": false,
+        }))
+        .expect("fake lane");
+        lane.agent_sessions = sessions;
+        lane
+    }
+
+    /// Two managed agents on distinct accounts for cursor-identity tests: `a` in slot 1 on
+    /// the default account, `b` in slot 2 on a work account.
+    fn two_agents() -> (AgentSession, AgentSession) {
+        let a = managed("lane-1", Some("sid-a"));
+        let mut b = managed("lane-1-2", Some("sid-b"));
+        b.config_dir = Some(PathBuf::from("/Users/x/.claude-work"));
+        (a, b)
+    }
+
+    #[tokio::test]
+    async fn session_cursor_survives_within_lane_reorder() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1; // row 0 is the pinned orchestrator row
+        app.sync_session_cursor();
+        // Tab onto the second agent and note its account.
+        app.cycle_session(true);
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        let key = app.focused_account_key().expect("account key");
+        // The daemon re-sorts `agent_sessions` newest-active-first: b moves to the front.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1-2"),
+            "the cursor must follow the agent, not the slot"
+        );
+        assert_eq!(
+            app.focused_account_key().as_deref(),
+            Some(key.as_str()),
+            "the usage corner must keep the picked agent's account"
+        );
+    }
+
+    #[tokio::test]
+    async fn pin_on_arrival_does_not_follow_newest() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1;
+        // No explicit pick: arriving on the lane pins whatever is front-most at that moment.
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+        // b takes a turn and the daemon reorders — the default pick must not drift with it.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+    }
+
+    #[tokio::test]
+    async fn anchor_rides_out_a_flap_then_adopts_occupant() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        // One "refresh": a new daemon snapshot (refresh_gen advances) then the cursor sync,
+        // mirroring refresh_lanes + the event loop.
+        fn refresh(app: &mut App, sessions: Vec<AgentSession>) {
+            app.lanes[0].agent_sessions = sessions;
+            app.refresh_gen = app.refresh_gen.wrapping_add(1);
+            app.sync_session_cursor();
+        }
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![])];
+        app.selected = 1;
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        app.cycle_session(true); // pick b
+        // b's session flaps out for one snapshot: the cursor falls back without re-pinning…
+        refresh(&mut app, vec![a.clone()]);
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1"));
+        // …even while input events re-run the sync against the same bad snapshot…
+        for _ in 0..10 {
+            app.sync_session_cursor();
+        }
+        // …and re-lands on b the moment it reappears.
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1-2"),
+            "a one-tick flap must not lose the pick"
+        );
+        // A sustained absence is a real exit: the pick re-pins to the current occupant and
+        // stays there even when the old identity's window name is later reused.
+        for _ in 0..=(SESSION_REF_GRACE as usize) {
+            refresh(&mut app, vec![a.clone()]);
+        }
+        refresh(&mut app, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            app.selected_window().as_deref(),
+            Some("lane-1"),
+            "after a sustained absence the pick belongs to the occupant"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_focus_pins_placeholder_then_upgrades_to_transcript() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, _) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // A second agent is spawned; its window appears before its transcript.
+        app.pending_focus_window = Some((1, "lane-1-2".to_string()));
+        let placeholder = managed("lane-1-2", None);
+        app.lanes[0].agent_sessions = vec![a.clone(), placeholder];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // The transcript lands and the daemon lists the new agent first (newest activity).
+        let b = managed("lane-1-2", Some("sid-b"));
+        app.lanes[0].agent_sessions = vec![b.clone(), a.clone()];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // A later reorder still can't move the cursor off the spawned agent.
+        app.lanes[0].agent_sessions = vec![a, b];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn notification_jump_pick_survives_resort() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![fake_lane(1, vec![a.clone(), b.clone()])];
+        app.selected = 1;
+        app.sync_session_cursor();
+        // A notification jump lands on b by transcript id…
+        app.select_session(1, Some("sid-b"));
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+        // …and must hold through the next daemon re-sort.
+        app.lanes[0].agent_sessions = vec![b, a];
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
+    }
+
+    #[tokio::test]
+    async fn return_to_lane_restores_pick() {
+        let mut app = app_with_dummy_client().await;
+        app.settings.notify_enabled = false;
+        app.settings.expand_agents = false;
+        let (a, b) = two_agents();
+        app.lanes = vec![
+            fake_lane(1, vec![a, b]),
+            fake_lane(2, vec![managed("lane-2", Some("sid-c"))]),
+        ];
+        app.selected = 1;
+        app.sync_session_cursor();
+        app.cycle_session(true); // pick b on lane 1
+        // Visit lane 2, then come back: the pick is restored by identity.
+        app.selected = 2;
+        app.sync_session_cursor();
+        app.selected = 1;
+        app.sync_session_cursor();
+        assert_eq!(app.selected_window().as_deref(), Some("lane-1-2"));
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-07-19-auto-open-spawned-agent-design.md
+++ b/docs/superpowers/specs/2026-07-19-auto-open-spawned-agent-design.md
@@ -5,15 +5,11 @@
 
 ## Problem
 
-Creating an agent leaves a manual step before you can talk to it:
+Creating an agent must open it without hiding the fleet context. The earlier implementation
+misread "open" as the full-screen Focus view, which removes the sidebar.
 
-- `e` spawn (Fleet/Split/Focus, with or without the picker) lands in Focus on the
-  new agent but with insert mode off — you must press `i` before typing.
-- New Lane + agent (`submit_new_lane`) spawns the agent, then returns to **Fleet**
-  with no selection change: you must find the lane, open Focus, and press `i`.
-
-The user's intent: after creating an agent, land in the Focus view with `INSERT`
-active — typing goes straight to the new agent, zero extra keypresses.
+The user's intent: after creating an agent, land in the Split view with the fleet sidebar
+visible and `INSERT` active — typing goes straight to the new agent, zero extra keypresses.
 
 ## Design
 
@@ -24,7 +20,7 @@ Extract `do_spawn`'s post-spawn landing into one helper on `App`:
 ```rust
 /// Land on a just-spawned agent, typing-ready: select its lane in the fleet,
 /// arm the pending-focus intent (which also routes keys to the window before
-/// lane.list shows it), and enter Focus with insert mode on.
+/// lane.list shows it), and enter Split with insert mode on.
 fn land_on_spawned(&mut self, lane: LaneId, window: Option<String>)
 ```
 
@@ -37,15 +33,14 @@ Behavior:
    appears in `lane.list`, and `selected_window()` routes keystrokes to it
    immediately (PR #65).
 3. `reset_scroll()` — show the live tail, mirroring what `i` does today.
-4. `view = View::Focus`, `focus_insert = true`.
+4. `view = View::Split`, `focus_insert = true`.
 
 `focus_managed` needs no handling: `check_focus_alive` derives it per tick.
 
 ### Call sites
 
-- **`do_spawn`** (all `e`-spawn paths): replace the current inline landing
-  (`view = Focus; focus_insert = false; pending_focus_window = …`) with the
-  helper. Net behavior change: insert mode starts on.
+- **`do_spawn`** (all `e`-spawn paths): use the shared helper so the new
+  agent opens in Split with insert mode on.
 - **`submit_new_lane`**: capture the `agent.spawn` response instead of
   discarding it (`let _ =`). On spawn success: keep the status line, `refresh()`
   first (so the new lane exists in `self.lanes` for `select_lane_session`),
@@ -66,18 +61,18 @@ Unit tests in `app.rs::tests` using the existing dummy-client harness
 `submit_new_lane` stay thin):
 
 1. **`e`-spawn landing:** `land_on_spawned(7, Some("lane-7-2"))` → view is
-   Focus, `focus_insert` on, `pending_focus_window` armed,
+   Split, `focus_insert` on, `pending_focus_window` armed,
    `selected_window() == "lane-7-2"` before the session appears in `lane.list`.
 2. **New-lane landing:** app with two lanes, selection on the first;
    `land_on_spawned(8, Some("lane-8"))` → fleet selection moves to lane 8,
-   Focus + insert on, keys route to `lane-8`.
-3. **No window (spawn response malformed):** lands in Focus + insert with no
+   Split + insert on, keys route to `lane-8`.
+3. **No window (spawn response malformed):** lands in Split + insert with no
    pending intent, routing falls back to the selected session.
 
 Existing PR #65 tests already cover intent resolution, expiry, and Tab cancel.
 
 ## Out of scope
 
-- Full tmux attach on spawn (rejected: heavier than the Focus view the user
-  chose; attaching mid-boot is janky).
+- Full tmux attach on spawn (rejected: heavier than the mediated Split view;
+  attaching mid-boot is janky and hides the sidebar).
 - Auto-insert when merely *navigating* to an agent (only creation opens it).


### PR DESCRIPTION
## Summary

- Land successful e-spawn and New Lane flows in Split with insert mode already targeting the new agent.
- Return the bare tmux window name expected by the daemon RPC contract, so the very first key burst reaches the spawned pane instead of a doubly-qualified nonexistent target.
- Replace activity-order transcript/window guesses with durable @repomon_session identity bindings confirmed by unique pane evidence; unbound windows remain placeholders until confirmed, so a stale transcript is never displayed over a fresh agent.
- Anchor the TUI session cursor by identity across refresh resorting and close the overlay invalidation race with cache generations.

## Root causes

1. TmuxRuntime::spawn returned session:=window while lane.list and all named-window RPCs use a bare window name. The pending landing intent could never match, and send_input wrapped the exact target again.
2. The daemon zipped recent transcripts to live windows by activity order on every scan. As agents took turns, names, panes, transcripts, and account usage could swap; a spawn could also inherit a stale leftover transcript.
3. A watcher scan started before agent.spawn invalidated the overlay could finish afterward and republish its stale snapshot.
4. The landing helper selected Focus even though the intended workflow requires the fleet sidebar to remain visible.

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- Fully isolated live run with its own config, database, daemon socket, daemon tmux server, and driver tmux server:
  - e-spawn plus an immediate same-burst message reached only the new pane and landed in Split insert mode.
  - A second agent did the same while a controlled stale transcript existed; the stale transcript stayed external and both windows acquired the correct evidence-backed identity.
  - Command-mode BackTab and Tab switched between the two agents, and unique messages landed in the corresponding per-window logs.
  - New Lane plus an immediate message landed on the new lane's agent in Split insert mode.

## Deployment note

Both repomon and repomond changed. Install both binaries. The daemon must then be restarted; that restart briefly pauses live fleet monitoring/control, though the tmux-hosted agent processes remain alive.
