### PR TITLE
Per-repo fleet memory (repo_notes) — repomind daily-driver Phase 1

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -127,6 +127,7 @@ function App(props: AppProps) {
       case "fleet.addRepo": void actions.addRepo(); break;
       case "fleet.jumpUrgent": fleet.moveSelection(1, true); break;
       case "fleet.hideRepo": if (lane) void actions.setRepoHidden(lane.repo, true); break;
+      case "fleet.repoNotes": if (lane) actions.openRepoNotes(lane.repo); break;
       case "lane.spawn": if (lane) actions.spawn(lane); break;
       case "lane.terminal": void workspace.openShell(actions.reportError); break;
       case "lane.pin": if (lane) void actions.pinLane(lane); break;

--- a/apps/desktop/src/components/ActionModals.tsx
+++ b/apps/desktop/src/components/ActionModals.tsx
@@ -3,6 +3,7 @@ import { Show } from "solid-js";
 import type { ActionsStore } from "../stores/actions";
 import ConfirmDialog from "./ConfirmDialog";
 import NewLaneModal from "./NewLaneModal";
+import RepoNotesModal from "./RepoNotesModal";
 import RenameModal from "./RenameModal";
 import SettingsModal from "./SettingsModal";
 import SpawnModal from "./SpawnModal";
@@ -17,6 +18,9 @@ export default function ActionModals(props: { actions: ActionsStore }) {
       </Show>
       <Show when={actions.spawnLane()}>
         {(lane) => <SpawnModal lane={lane()} onClose={actions.closeSpawn} onDone={() => actions.fleet.refresh()} />}
+      </Show>
+      <Show keyed when={actions.notesRepo()}>
+        {(repo) => <RepoNotesModal repo={repo} onClose={actions.closeRepoNotes} />}
       </Show>
       <Show when={actions.newLaneOpen()}>
         <NewLaneModal

--- a/apps/desktop/src/components/FleetSidebar.tsx
+++ b/apps/desktop/src/components/FleetSidebar.tsx
@@ -225,6 +225,10 @@ export default function FleetSidebar(props: FleetSidebarProps) {
             x={menu.x}
             y={menu.y}
             onOpenExtensions={() => props.onOpenExtensions?.(menu.repoId)}
+            onOpenNotes={() => {
+              const repo = props.fleet.repos().find((r) => r.id === menu.repoId);
+              if (repo) props.actions.openRepoNotes(repo);
+            }}
             onClose={() => setExtMenu(null)}
           />
         )}

--- a/apps/desktop/src/components/RepoExtMenu.tsx
+++ b/apps/desktop/src/components/RepoExtMenu.tsx
@@ -8,6 +8,7 @@ interface RepoExtMenuProps {
   x: number;
   y: number;
   onOpenExtensions: () => void;
+  onOpenNotes: () => void;
   onClose: () => void;
 }
 
@@ -59,6 +60,12 @@ export default function RepoExtMenu(props: RepoExtMenuProps) {
           onClick={() => { props.onOpenExtensions(); props.onClose(); }}
           role="menuitem"
         >Extensions…</button>
+        <button
+          type="button"
+          class="focus-ring block w-full rounded px-2 py-1.5 text-left font-mono text-[0.66rem] text-foreground hover:bg-raised"
+          onClick={() => { props.onOpenNotes(); props.onClose(); }}
+          role="menuitem"
+        >Repo notes…</button>
         <div class="my-1 border-t border-line" />
         <Show when={error()}>{(message) => <p class="px-2 py-1 font-mono text-[0.6rem] text-fault">{message()}</p>}</Show>
         <Show when={snapshot()} fallback={<p class="px-2 py-1 font-mono text-[0.6rem] text-muted">Loading…</p>}>

--- a/apps/desktop/src/components/RepoNotesModal.test.tsx
+++ b/apps/desktop/src/components/RepoNotesModal.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Repo } from "../bindings";
+import RepoNotesModal from "./RepoNotesModal";
+
+const calls = vi.hoisted(() => ({ list: [] as Array<{ method: string; params: unknown }> }));
+const responses = vi.hoisted(() => ({ get: {} as Record<string, unknown>, setFails: null as string | null }));
+
+vi.mock("../ipc/rpc", () => ({
+  daemonCall: (method: string, params: unknown) => {
+    calls.list.push({ method, params });
+    if (method === "repo.notes.get") return Promise.resolve(responses.get);
+    if (responses.setFails) return Promise.reject(new Error(responses.setFails));
+    return Promise.resolve({ repo_id: 2, bytes: 0, path: "/n/r.md" });
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  calls.list = [];
+  responses.setFails = null;
+});
+
+const repo: Repo = {
+  id: 2, path: "/code/r", name: "r", added_at: "2026-07-27T00:00:00Z",
+  worktree_root_template: null, hidden: false,
+};
+
+function open(content = "", exists = true) {
+  responses.get = { repo_id: 2, name: "r", exists, content, path: "/notes/r.md" };
+  const onClose = vi.fn();
+  const view = render(() => <RepoNotesModal repo={repo} onClose={onClose} />);
+  return { onClose, ...view };
+}
+
+async function textarea() {
+  return (await screen.findByLabelText("Notes markdown for r")) as HTMLTextAreaElement;
+}
+
+describe("repo notes editor", () => {
+  it("loads the repo's notes and saves an edit", async () => {
+    const { onClose } = open("old notes\n");
+    const box = await textarea();
+    expect(box.value).toBe("old notes\n");
+
+    fireEvent.input(box, { target: { value: "use pnpm test\n" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(calls.list[calls.list.length - 1]).toEqual({
+      method: "repo.notes.set",
+      params: { repo_id: 2, content: "use pnpm test\n" },
+    });
+  });
+
+  it("will not save until something changed", async () => {
+    open("unchanged\n");
+    await textarea();
+    expect(screen.getByText("Save")).toBeDisabled();
+  });
+
+  it("counts bytes, not characters, and blocks a save over the cap", async () => {
+    open("");
+    const box = await textarea();
+
+    // Multi-byte content: a character count would under-read this and let a doomed save through,
+    // since the daemon caps on bytes.
+    fireEvent.input(box, { target: { value: "é".repeat(10) } });
+    expect(screen.getByText("20 / 8192 bytes")).toBeInTheDocument();
+
+    fireEvent.input(box, { target: { value: "x".repeat(8193) } });
+    expect(screen.getByText("8193 / 8192 bytes")).toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeDisabled();
+  });
+
+  it("surfaces a rejected save and stays open", async () => {
+    const { onClose } = open("a\n");
+    const box = await textarea();
+    responses.setFails = "notes are 9000 bytes; the cap is 8192 bytes";
+
+    fireEvent.input(box, { target: { value: "b\n" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(await screen.findByText(/the cap is 8192 bytes/)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("says so when the repo has no notes file yet", async () => {
+    open("", false);
+    expect(await screen.findByText(/not created yet/)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/RepoNotesModal.tsx
+++ b/apps/desktop/src/components/RepoNotesModal.tsx
@@ -1,0 +1,104 @@
+import { Show, createResource, createSignal } from "solid-js";
+
+import type { Repo } from "../bindings";
+import { daemonCall } from "../ipc/rpc";
+import Modal from "./Modal";
+
+/// Mirrors `repomon_core::notes::MAX_NOTES_BYTES`. The daemon rejects anything larger, so the
+/// editor counts down to the same number rather than letting you write a save that will bounce.
+const MAX_NOTES_BYTES = 8192;
+
+interface RepoNotesModalProps {
+  repo: Repo;
+  onClose: () => void;
+}
+
+function message(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+/// Per-repo notes: conventions, build and test commands, gotchas, "always tell workers X".
+///
+/// repomind reads these when it plans work and folds them into worker prompts, so this is the one
+/// place a human writes something the orchestrator will still know next week. The file is plain
+/// markdown on disk and editable outside the app, which is why the editor loads fresh on open
+/// rather than caching.
+export default function RepoNotesModal(props: RepoNotesModalProps) {
+  const [loaded] = createResource(
+    () => props.repo.id,
+    (repoId) => daemonCall("repo.notes.get", { repo_id: repoId }),
+  );
+  // `null` until the user types: it lets the textarea show the loaded content without a effect
+  // copying server state into a signal (which would clobber edits on any refetch).
+  const [draft, setDraft] = createSignal<string | null>(null);
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const content = () => draft() ?? loaded()?.content ?? "";
+  const bytes = () => new TextEncoder().encode(content()).length;
+  const overCap = () => bytes() > MAX_NOTES_BYTES;
+  const dirty = () => draft() !== null && draft() !== (loaded()?.content ?? "");
+
+  async function save() {
+    if (overCap()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await daemonCall("repo.notes.set", { repo_id: props.repo.id, content: content() });
+      props.onClose();
+    } catch (cause) {
+      setError(message(cause));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const footer = (
+    <>
+      <span
+        class={`mr-auto font-mono text-[0.58rem] ${overCap() ? "text-fault" : "text-muted"}`}
+        aria-live="polite"
+      >
+        {bytes()} / {MAX_NOTES_BYTES} bytes
+      </span>
+      <button
+        type="button"
+        class="focus-ring rounded-md border border-line bg-raised px-3 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.1em] text-muted hover:text-foreground"
+        onClick={props.onClose}
+      >Cancel</button>
+      <button
+        type="button"
+        class="focus-ring rounded-md border border-signal/40 bg-signal/10 px-3 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.1em] text-signal disabled:opacity-40"
+        disabled={saving() || overCap() || !dirty()}
+        onClick={() => void save()}
+      >{saving() ? "Saving…" : "Save"}</button>
+    </>
+  );
+
+  return (
+    <Modal
+      title={`Notes for ${props.repo.name}`}
+      subtitle="repomind reads these when planning and passes them to workers it spawns here."
+      onClose={props.onClose}
+      footer={footer}
+      width="42rem"
+    >
+      <Show when={!loaded.loading} fallback={<p class="text-xs text-muted">Loading notes…</p>}>
+        <textarea
+          class="focus-ring h-72 w-full resize-none rounded-md border border-line bg-background p-2 font-mono text-[0.68rem] leading-relaxed outline-none"
+          value={content()}
+          onInput={(event) => setDraft(event.currentTarget.value)}
+          placeholder={"# Conventions\n\n- Use `pnpm test`, never `npm test`.\n- Squash-merge only."}
+          spellcheck={false}
+          aria-label={`Notes markdown for ${props.repo.name}`}
+        />
+        <p class="mt-2 truncate font-mono text-[0.55rem] text-muted/70" title={loaded()?.path}>
+          {loaded()?.exists ? loaded()?.path : `${loaded()?.path} (not created yet)`}
+        </p>
+      </Show>
+      <Show when={error()}>
+        {(text) => <p class="mt-2 font-mono text-[0.6rem] text-fault">{text()}</p>}
+      </Show>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/ipc/rpc.ts
+++ b/apps/desktop/src/ipc/rpc.ts
@@ -84,6 +84,14 @@ interface RpcMap {
   "repo.add": { params: { path: string }; result: Repo };
   "repo.remove": { params: { repo_id: number }; result: null };
   "repo.set_hidden": { params: { repo_id: number; hidden: boolean }; result: null };
+  "repo.notes.get": {
+    params: { repo_id: number };
+    result: { repo_id: number; name: string; exists: boolean; content: string; path: string };
+  };
+  "repo.notes.set": {
+    params: { repo_id: number; content: string };
+    result: { repo_id: number; bytes: number; path: string };
+  };
   "repo.discover": { params: { root: string; max_depth?: number }; result: string[] };
   "lane.list": { params: undefined; result: Lane[] };
   "lane.create": {

--- a/apps/desktop/src/keymap.ts
+++ b/apps/desktop/src/keymap.ts
@@ -38,6 +38,7 @@ export const BINDINGS: Binding[] = [
   { id: "fleet.jumpUrgent", chord: "mod+g", label: "Jump to a lane needing attention", section: "Fleet" },
   // Not mod+h: Cmd+H hides the application on macOS and never reaches the app.
   { id: "fleet.hideRepo", chord: "mod+shift+h", label: "Hide the selected lane's project", section: "Fleet", when: "lane" },
+  { id: "fleet.repoNotes", chord: "mod+shift+b", label: "Edit the selected lane's project notes", section: "Fleet", when: "lane" },
 
   { id: "lane.spawn", chord: "mod+e", label: "Spawn agent", section: "Lane", when: "lane" },
   { id: "lane.terminal", chord: "mod+t", label: "Open terminal", section: "Lane", when: "lane" },

--- a/apps/desktop/src/stores/actions.ts
+++ b/apps/desktop/src/stores/actions.ts
@@ -21,6 +21,7 @@ export function createActionsStore(fleet: FleetStore) {
   const [newLaneOpen, setNewLaneOpen] = createSignal(false);
   const [newLaneRepoId, setNewLaneRepoId] = createSignal<number | null>(null);
   const [renameTarget, setRenameTarget] = createSignal<RenameTarget | null>(null);
+  const [notesRepo, setNotesRepo] = createSignal<Repo | null>(null);
   const [confirmOptions, setConfirmOptions] = createSignal<ConfirmOptions | null>(null);
   const [error, setError] = createSignal<string | null>(null);
 
@@ -47,6 +48,16 @@ export function createActionsStore(fleet: FleetStore) {
         await fleet.refresh();
       },
     });
+  }
+
+  /// Open the per-repo notes editor. repomind reads these when planning and folds them into the
+  /// prompts of workers it spawns in this repo.
+  function openRepoNotes(repo: Repo) {
+    setNotesRepo(repo);
+  }
+
+  function closeRepoNotes() {
+    setNotesRepo(null);
   }
 
   /// Hide or reveal a repo. No confirmation: unlike removeRepo this keeps the registration and
@@ -162,6 +173,9 @@ export function createActionsStore(fleet: FleetStore) {
     addRepo,
     removeRepo,
     setRepoHidden,
+    notesRepo,
+    openRepoNotes,
+    closeRepoNotes,
     pinLane,
     mergeLane,
     deleteLane,

--- a/crates/repomon-core/src/lib.rs
+++ b/crates/repomon-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod input;
 pub mod lane;
 pub mod launch;
 pub mod model;
+pub mod notes;
 pub mod notify;
 pub mod process;
 pub mod protocol;

--- a/crates/repomon-core/src/notes.rs
+++ b/crates/repomon-core/src/notes.rs
@@ -1,0 +1,249 @@
+//! Per-repo fleet memory: one human-editable markdown file per registered repo.
+//!
+//! The daemon owns a `repo-notes/` directory (under its data dir) holding durable per-repo
+//! knowledge — conventions, build/test commands, gotchas — that the orchestrator folds into
+//! worker prompts. Files are keyed by a sanitized repo name so a human can find and edit
+//! `myrepo.md` directly; repo names are not unique, so on a slug collision every collider
+//! resolves to `<slug>-<id>.md` instead (never the bare name, so notes can't bleed across
+//! repos). Removing a repo leaves its file: knowledge survives re-registration.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+use crate::model::Repo;
+
+/// Hard cap on a notes file, enforced on write and (defensively) on read — notes travel
+/// inside worker prompts, so an unbounded file would blow up token budgets.
+pub const MAX_NOTES_BYTES: usize = 8192;
+
+/// Marker appended when a hand-edited file over the cap is truncated on read.
+pub const TRUNCATION_MARKER: &str = "[notes truncated at 8 KB — edit the file to trim]";
+
+/// Reduce a repo name to a filesystem-safe slug: keep `[A-Za-z0-9._-]`, map runs of anything
+/// else to `-`, trim leading/trailing `.` and `-` (no dotfiles, no `..`), cap at 64 chars.
+/// Empty results fall back to `"repo"`.
+fn slug(name: &str) -> String {
+    let mut s = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            s.push(c);
+        } else if !s.ends_with('-') {
+            s.push('-');
+        }
+    }
+    let mut s: String = s.trim_matches(['.', '-']).chars().take(64).collect();
+    while s.ends_with(['.', '-']) {
+        s.pop();
+    }
+    if s.is_empty() {
+        s.push_str("repo");
+    }
+    s
+}
+
+/// The notes file path for `repo`, collision-aware against every registered repo in `all`:
+/// a unique slug gets `<slug>.md`; colliding slugs all get `<slug>-<id>.md`.
+pub fn notes_path(dir: &Path, repo: &Repo, all: &[Repo]) -> PathBuf {
+    let s = slug(&repo.name);
+    let collides = all.iter().any(|r| r.id != repo.id && slug(&r.name) == s);
+    if collides {
+        dir.join(format!("{s}-{}.md", repo.id))
+    } else {
+        dir.join(format!("{s}.md"))
+    }
+}
+
+/// Read the repo's notes. `Ok(None)` when no file exists. A hand-edited file larger than
+/// [`MAX_NOTES_BYTES`] is truncated at a char boundary with [`TRUNCATION_MARKER`] appended.
+pub fn read(dir: &Path, repo: &Repo, all: &[Repo]) -> Result<Option<String>> {
+    let path = notes_path(dir, repo, all);
+    let mut s = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Io(e)),
+    };
+    if s.len() > MAX_NOTES_BYTES {
+        let mut end = MAX_NOTES_BYTES;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+        s.push('\n');
+        s.push_str(TRUNCATION_MARKER);
+    }
+    Ok(Some(s))
+}
+
+/// Replace the repo's notes wholesale, atomically (temp file + fsync + rename, the
+/// [`crate::config::Config::save_to`] pattern). Rejects content over [`MAX_NOTES_BYTES`].
+/// The previous version, when different, is kept one generation in `<file>.bak`.
+/// Returns the path written.
+pub fn write(dir: &Path, repo: &Repo, all: &[Repo], content: &str) -> Result<PathBuf> {
+    use std::io::Write;
+    if content.len() > MAX_NOTES_BYTES {
+        return Err(Error::Config(format!(
+            "notes are {} bytes; the cap is {MAX_NOTES_BYTES} bytes — trim before writing",
+            content.len()
+        )));
+    }
+    std::fs::create_dir_all(dir)?;
+    let path = notes_path(dir, repo, all);
+
+    // One-generation backup: keep what we're about to overwrite, unless it's identical.
+    match std::fs::read_to_string(&path) {
+        Ok(prev) if prev != content => {
+            let bak = path.with_file_name(format!(
+                "{}.bak",
+                path.file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("notes.md")
+            ));
+            std::fs::write(&bak, prev)?;
+        }
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(Error::Io(e)),
+    }
+
+    // Unique temp name (pid + nanos) beside the target so the rename stays on one filesystem.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let base = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("notes.md");
+    let tmp = path.with_file_name(format!(".{base}.{}.{nanos}.tmp", std::process::id()));
+
+    let mut f = std::fs::File::create(&tmp)?;
+    f.write_all(content.as_bytes())?;
+    f.sync_all()?; // flush data to disk before it becomes the live file
+    drop(f);
+    std::fs::rename(&tmp, &path)?;
+    // Best-effort: fsync the directory so the rename itself survives a crash.
+    if let Ok(d) = std::fs::File::open(dir) {
+        let _ = d.sync_all();
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn repo(id: i64, name: &str) -> Repo {
+        Repo {
+            id,
+            path: PathBuf::from(format!("/tmp/{name}")),
+            name: name.to_string(),
+            added_at: Utc::now(),
+            worktree_root_template: None,
+            hidden: false,
+        }
+    }
+
+    #[test]
+    fn slug_sanitizes_hostile_names() {
+        assert_eq!(slug("my repo!"), "my-repo");
+        // Path traversal: no separators survive, no leading dot, never empty.
+        let s = slug("../../etc");
+        assert!(!s.contains('/'));
+        assert!(!s.starts_with('.'));
+        assert!(!s.is_empty());
+        assert_eq!(slug(""), "repo");
+        assert_eq!(slug("!!!"), "repo");
+        assert!(slug(&"x".repeat(200)).len() <= 64);
+    }
+
+    #[test]
+    fn unique_name_gets_bare_filename() {
+        let api = repo(1, "api");
+        let other = repo(2, "web");
+        let all = vec![api.clone(), other];
+        assert_eq!(
+            notes_path(Path::new("/notes"), &api, &all),
+            PathBuf::from("/notes/api.md")
+        );
+    }
+
+    #[test]
+    fn colliding_names_both_get_id_suffix() {
+        // Same basename registered from two parents; also collides post-slug ("api!" → "api").
+        let a = repo(3, "api");
+        let b = repo(7, "api!");
+        let all = vec![a.clone(), b.clone()];
+        assert_eq!(
+            notes_path(Path::new("/notes"), &a, &all),
+            PathBuf::from("/notes/api-3.md")
+        );
+        assert_eq!(
+            notes_path(Path::new("/notes"), &b, &all),
+            PathBuf::from("/notes/api-7.md")
+        );
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = repo(1, "api");
+        let all = vec![r.clone()];
+        assert!(read(dir.path(), &r, &all).unwrap().is_none());
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = repo(1, "api");
+        let all = vec![r.clone()];
+        let path = write(dir.path(), &r, &all, "use `pnpm test`, never `npm test`").unwrap();
+        // The human-editability contract: the file is where a human would look for it.
+        assert_eq!(path, dir.path().join("api.md"));
+        assert!(path.exists());
+        assert_eq!(
+            read(dir.path(), &r, &all).unwrap().as_deref(),
+            Some("use `pnpm test`, never `npm test`")
+        );
+    }
+
+    #[test]
+    fn write_rejects_over_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = repo(1, "api");
+        let all = vec![r.clone()];
+        let err = write(dir.path(), &r, &all, &"x".repeat(MAX_NOTES_BYTES + 1)).unwrap_err();
+        assert!(err.to_string().contains("8192"), "unhelpful error: {err}");
+        assert!(write(dir.path(), &r, &all, &"x".repeat(MAX_NOTES_BYTES)).is_ok());
+    }
+
+    #[test]
+    fn overwrite_keeps_previous_in_bak() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = repo(1, "api");
+        let all = vec![r.clone()];
+        write(dir.path(), &r, &all, "v1").unwrap();
+        write(dir.path(), &r, &all, "v2").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("api.md.bak")).unwrap(),
+            "v1"
+        );
+        assert_eq!(read(dir.path(), &r, &all).unwrap().as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn read_truncates_oversized_hand_edited_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = repo(1, "api");
+        let all = vec![r.clone()];
+        std::fs::write(dir.path().join("api.md"), "a".repeat(20_000)).unwrap();
+        let s = read(dir.path(), &r, &all).unwrap().unwrap();
+        assert!(s.ends_with(TRUNCATION_MARKER));
+        assert!(s.len() <= MAX_NOTES_BYTES + TRUNCATION_MARKER.len() + 2);
+
+        // Multibyte content must truncate on a char boundary, not panic mid-codepoint.
+        std::fs::write(dir.path().join("api.md"), "é".repeat(10_000)).unwrap();
+        let s = read(dir.path(), &r, &all).unwrap().unwrap();
+        assert!(s.ends_with(TRUNCATION_MARKER));
+    }
+}

--- a/crates/repomon-daemon/src/lib.rs
+++ b/crates/repomon-daemon/src/lib.rs
@@ -137,6 +137,9 @@ pub struct Ctx {
     /// Where [`Config::save`] writes — `config::config_path()` in prod, a tempdir in tests.
     pub config_path: PathBuf,
     pub backend: Arc<dyn SessionBackend>,
+    /// Where per-repo notes files live: `data_dir()/repo-notes` in prod, a tempdir in tests
+    /// (injected, not env-based: in-process daemon tests can't share process-global env safely).
+    pub notes_dir: PathBuf,
     pub started: Instant,
     pub db_path: Option<PathBuf>,
     pub events: pubsub::EventTx,
@@ -269,6 +272,24 @@ impl Ctx {
         db_path: Option<PathBuf>,
         config_path: PathBuf,
     ) -> Arc<Self> {
+        Self::new_with_paths(
+            store,
+            config,
+            db_path,
+            config_path,
+            config::data_dir().join("repo-notes"),
+        )
+    }
+
+    /// Like [`new_with_config_path`](Self::new_with_config_path) but also with an explicit
+    /// repo-notes directory (tests inject a tempdir so notes never touch the real data dir).
+    pub fn new_with_paths(
+        store: Store,
+        config: Config,
+        db_path: Option<PathBuf>,
+        config_path: PathBuf,
+        notes_dir: PathBuf,
+    ) -> Arc<Self> {
         let registry = Registry::new(store.clone());
         let lanes = Lanes::new(store.clone(), config.clone());
         #[cfg(unix)]
@@ -304,6 +325,7 @@ impl Ctx {
             config: RwLock::new(config),
             config_path,
             backend,
+            notes_dir,
             started: Instant::now(),
             db_path,
             events,

--- a/crates/repomon-daemon/src/remote.rs
+++ b/crates/repomon-daemon/src/remote.rs
@@ -622,6 +622,11 @@ mod tests {
             "repo.discover",
             "config.get",
             "config.set",
+            // per-repo notes stay local-only for now: the write side injects text into every
+            // future worker prompt for that repo, too much leverage for the bridge until a
+            // deliberate Phase 6 decision allowlists it.
+            "repo.notes.get",
+            "repo.notes.set",
             "terminal.open",
             "terminal.close",
             "terminal.target",

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -164,6 +164,15 @@ struct RepoSetHidden {
     hidden: bool,
 }
 #[derive(Deserialize)]
+struct RepoNotesGet {
+    repo_id: RepoId,
+}
+#[derive(Deserialize)]
+struct RepoNotesSet {
+    repo_id: RepoId,
+    content: String,
+}
+#[derive(Deserialize)]
 struct Discover {
     root: String,
     #[serde(default = "default_depth")]
@@ -833,6 +842,75 @@ pub async fn dispatch(
                 .map(|p| p.to_string_lossy().into_owned())
                 .collect();
             to_value(paths)
+        }
+        "repo.notes.get" => {
+            let p: RepoNotesGet = parse(params)?;
+            let repo = ctx
+                .store
+                .get_repo(p.repo_id)
+                .await
+                .map_err(|_| RpcError::invalid_params(format!("no repo {}", p.repo_id)))?;
+            let all = ctx.registry.list().await.map_err(internal)?;
+            let dir = ctx.notes_dir.clone();
+            let repo_name = repo.name.clone();
+            let (content, path) = tokio::task::spawn_blocking(move || {
+                let path = repomon_core::notes::notes_path(&dir, &repo, &all);
+                repomon_core::notes::read(&dir, &repo, &all).map(|c| (c, path))
+            })
+            .await
+            .map_err(internal)?
+            .map_err(internal)?;
+            to_value(json!({
+                "repo_id": p.repo_id,
+                "name": repo_name,
+                "exists": content.is_some(),
+                "content": content.unwrap_or_default(),
+                "path": path.to_string_lossy(),
+            }))
+        }
+        "repo.notes.set" => {
+            let p: RepoNotesSet = parse(params)?;
+            // Cap before any lookup: the error should name the limit, not depend on repo state.
+            if p.content.len() > repomon_core::notes::MAX_NOTES_BYTES {
+                return Err(RpcError::invalid_params(format!(
+                    "notes are {} bytes; the cap is {} bytes",
+                    p.content.len(),
+                    repomon_core::notes::MAX_NOTES_BYTES
+                )));
+            }
+            let repo = ctx
+                .store
+                .get_repo(p.repo_id)
+                .await
+                .map_err(|_| RpcError::invalid_params(format!("no repo {}", p.repo_id)))?;
+            let all = ctx.registry.list().await.map_err(internal)?;
+            let dir = ctx.notes_dir.clone();
+            let repo_name = repo.name.clone();
+            let content = p.content.clone();
+            let (old_bytes, path) = tokio::task::spawn_blocking(move || {
+                let old = repomon_core::notes::read(&dir, &repo, &all)
+                    .ok()
+                    .flatten()
+                    .map(|s| s.len());
+                repomon_core::notes::write(&dir, &repo, &all, &content).map(|p| (old, p))
+            })
+            .await
+            .map_err(internal)?
+            .map_err(internal)?;
+            tracing::info!(
+                repo = %repo_name,
+                repo_id = p.repo_id,
+                old_bytes = old_bytes.unwrap_or(0),
+                new_bytes = p.content.len(),
+                path = %path.display(),
+                conn = ?sess.kind,
+                "repo notes replaced"
+            );
+            to_value(json!({
+                "repo_id": p.repo_id,
+                "bytes": p.content.len(),
+                "path": path.to_string_lossy(),
+            }))
         }
 
         // ---- lanes ----

--- a/crates/repomon-daemon/tests/integration.rs
+++ b/crates/repomon-daemon/tests/integration.rs
@@ -1226,3 +1226,117 @@ async fn plugin_details_returns_cli_text_or_structured_error() {
     server.abort();
     let _ = std::fs::remove_file(&sock);
 }
+
+#[tokio::test]
+async fn repo_notes_get_set_round_trip() {
+    let store = Store::open_in_memory().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let notes_dir = tempfile::tempdir().unwrap();
+    let ctx = Ctx::new_with_paths(
+        store,
+        Config::default(),
+        None,
+        cfg_dir.path().join("config.toml"),
+        notes_dir.path().to_path_buf(),
+    );
+    let sock = std::env::temp_dir().join(format!("repomon-notes-it-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&sock);
+    let server = {
+        let ctx = ctx.clone();
+        let sock = sock.clone();
+        tokio::spawn(async move { serve(ctx, &sock).await })
+    };
+    let mut stream = connect_retry(&sock).await;
+
+    let repo_dir = tempfile::tempdir().unwrap();
+    git(repo_dir.path(), &["init", "-b", "main"]);
+    std::fs::write(repo_dir.path().join("README.md"), "hi\n").unwrap();
+    git(repo_dir.path(), &["add", "."]);
+    git(repo_dir.path(), &["commit", "-m", "init"]);
+    let r = call(
+        &mut stream,
+        1,
+        "repo.add",
+        Some(json!({ "path": repo_dir.path().to_string_lossy() })),
+    )
+    .await;
+    let repo = r.result.unwrap();
+    let repo_id = repo["id"].as_i64().unwrap();
+    let repo_name = repo["name"].as_str().unwrap().to_string();
+
+    // Fresh repo: no notes yet.
+    let r = call(
+        &mut stream,
+        2,
+        "repo.notes.get",
+        Some(json!({ "repo_id": repo_id })),
+    )
+    .await;
+    assert!(r.error.is_none(), "get errored: {:?}", r.error);
+    let got = r.result.unwrap();
+    assert_eq!(got["exists"], json!(false));
+    assert_eq!(got["content"], json!(""));
+    assert_eq!(got["repo_id"], json!(repo_id));
+    assert_eq!(got["name"], json!(repo_name));
+
+    // Set → get round-trips and reports the path inside the injected notes dir.
+    let r = call(
+        &mut stream,
+        3,
+        "repo.notes.set",
+        Some(json!({ "repo_id": repo_id, "content": "use `pnpm test`, never `npm test`" })),
+    )
+    .await;
+    assert!(r.error.is_none(), "set errored: {:?}", r.error);
+    let r = call(
+        &mut stream,
+        4,
+        "repo.notes.get",
+        Some(json!({ "repo_id": repo_id })),
+    )
+    .await;
+    let got = r.result.unwrap();
+    assert_eq!(got["exists"], json!(true));
+    assert_eq!(got["content"], json!("use `pnpm test`, never `npm test`"));
+    let path = std::path::PathBuf::from(got["path"].as_str().unwrap());
+    assert!(path.starts_with(notes_dir.path()), "path was {path:?}");
+
+    // Over the cap: rejected with an error that names the limit.
+    let r = call(
+        &mut stream,
+        5,
+        "repo.notes.set",
+        Some(json!({ "repo_id": repo_id, "content": "x".repeat(8193) })),
+    )
+    .await;
+    let err = r.error.expect("oversized set must error");
+    assert!(
+        err.message.contains("8192"),
+        "unhelpful error: {}",
+        err.message
+    );
+
+    // Unknown repo: not found.
+    let r = call(
+        &mut stream,
+        6,
+        "repo.notes.get",
+        Some(json!({ "repo_id": 999_999 })),
+    )
+    .await;
+    assert!(r.error.is_some(), "bogus repo_id must error");
+
+    // Hand-edited file (the human contract): get picks it up directly.
+    std::fs::write(&path, "hand-edited\n").unwrap();
+    let r = call(
+        &mut stream,
+        7,
+        "repo.notes.get",
+        Some(json!({ "repo_id": repo_id })),
+    )
+    .await;
+    assert_eq!(r.result.unwrap()["content"], json!("hand-edited\n"));
+
+    server.abort();
+    let _ = std::fs::remove_file(&sock);
+}

--- a/crates/repomon-daemon/tests/mcp_stdio.rs
+++ b/crates/repomon-daemon/tests/mcp_stdio.rs
@@ -67,9 +67,18 @@ async fn daemon_call(
 
 /// Boot an in-process daemon on a short temp socket path (macOS caps UDS paths at ~104 chars),
 /// exactly like tests/integration.rs, and return a connected control stream for seeding state.
-async fn boot_daemon(tag: &str) -> (PathBuf, IpcStream) {
+/// Config and repo-notes paths live in the returned tempdir (kept alive by the caller) so the
+/// daemon under test never touches the real `~/.config` / data dir.
+async fn boot_daemon(tag: &str) -> (PathBuf, IpcStream, tempfile::TempDir) {
     let store = Store::open_in_memory().unwrap();
-    let ctx = Ctx::new(store, Config::default(), None);
+    let state_dir = tempfile::tempdir().unwrap();
+    let ctx = Ctx::new_with_paths(
+        store,
+        Config::default(),
+        None,
+        state_dir.path().join("config.toml"),
+        state_dir.path().join("repo-notes"),
+    );
 
     let sock =
         std::env::temp_dir().join(format!("repomon-mcpit-{tag}-{}.sock", std::process::id()));
@@ -79,7 +88,7 @@ async fn boot_daemon(tag: &str) -> (PathBuf, IpcStream) {
     tokio::spawn(async move { serve(ctx, &server_sock).await });
 
     let stream = connect_retry(&sock).await;
-    (sock, stream)
+    (sock, stream, state_dir)
 }
 
 /// Register a repo with one commit and return its (tempdir, main lane id).
@@ -181,7 +190,7 @@ async fn shutdown_mcp_child(mut child: Child, stdin: ChildStdin) {
 
 #[tokio::test]
 async fn mcp_stdio_end_to_end() {
-    let (sock, mut control) = boot_daemon("e2e").await;
+    let (sock, mut control, _state_dir) = boot_daemon("e2e").await;
     let (repo_dir, lane_id) = seed_repo_lane(&mut control).await;
 
     let mut child = spawn_mcp_child(&sock, &[]);
@@ -206,11 +215,11 @@ async fn mcp_stdio_end_to_end() {
 
     mcp_notify(&mut stdin, "notifications/initialized").await;
 
-    // 2. tools/list -> exactly the 13 v1 tools.
+    // 2. tools/list -> exactly the 15 tools (13 v1 + the repo-notes pair).
     mcp_request(&mut stdin, 2, "tools/list", json!({})).await;
     let resp = mcp_read(&mut lines).await;
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 13, "tools/list returned: {tools:?}");
+    assert_eq!(tools.len(), 15, "tools/list returned: {tools:?}");
     let names: BTreeSet<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     let expected: BTreeSet<&str> = [
         "fleet_status",
@@ -226,6 +235,8 @@ async fn mcp_stdio_end_to_end() {
         "lane_diff",
         "list_repos",
         "wait_for_change",
+        "repo_notes",
+        "repo_notes_write",
     ]
     .into_iter()
     .collect();
@@ -322,7 +333,7 @@ async fn mcp_stdio_end_to_end() {
 
 #[tokio::test]
 async fn mcp_stdio_read_only_denies_spawn_agent() {
-    let (sock, mut control) = boot_daemon("readonly").await;
+    let (sock, mut control, _state_dir) = boot_daemon("readonly").await;
     let (_repo_dir, lane_id) = seed_repo_lane(&mut control).await;
 
     let mut child = spawn_mcp_child(&sock, &[("REPOMON_MCP_AUTONOMY", "read-only")]);
@@ -359,6 +370,158 @@ async fn mcp_stdio_read_only_denies_spawn_agent() {
         text.contains("read-only") && text.contains("this tool only observes"),
         "unexpected error text: {text}"
     );
+
+    // repo_notes_write is a mutation: refused. The repo_notes read stays available.
+    mcp_request(
+        &mut stdin,
+        3,
+        "tools/call",
+        json!({
+            "name": "repo_notes_write",
+            "arguments": { "repo": "whatever", "content": "x" },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(
+        is_error && text.contains("read-only"),
+        "repo_notes_write should be refused under read-only autonomy, got: {text}"
+    );
+
+    let repo_name = _repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    mcp_request(
+        &mut stdin,
+        4,
+        "tools/call",
+        json!({ "name": "repo_notes", "arguments": { "repo": repo_name } }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(
+        !is_error,
+        "repo_notes (read) must work under read-only autonomy, got: {text}"
+    );
+
+    shutdown_mcp_child(child, stdin).await;
+    let _ = std::fs::remove_file(&sock);
+}
+
+#[tokio::test]
+async fn mcp_stdio_repo_notes_round_trip() {
+    let (sock, mut control, state_dir) = boot_daemon("notes").await;
+    let (repo_dir, _lane_id) = seed_repo_lane(&mut control).await;
+    let repo_name = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+
+    let mut child = spawn_mcp_child(&sock, &[]);
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let mut lines = BufReader::new(child.stdout.take().expect("child stdout")).lines();
+
+    mcp_request(
+        &mut stdin,
+        1,
+        "initialize",
+        json!({ "protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": { "name": "repomon-it", "version": "0.0.0" } }),
+    )
+    .await;
+    let _ = mcp_read(&mut lines).await;
+
+    // Empty notes: not an error, and a hint tells the orchestrator how to seed them.
+    mcp_request(
+        &mut stdin,
+        2,
+        "tools/call",
+        json!({ "name": "repo_notes", "arguments": { "repo": repo_name } }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "repo_notes on empty errored: {text}");
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed["content"], json!(""));
+    assert!(parsed["hint"].is_string(), "expected a hint, got: {parsed}");
+
+    // Write by repo *name* (the orchestrator's handle), then read back.
+    mcp_request(
+        &mut stdin,
+        3,
+        "tools/call",
+        json!({
+            "name": "repo_notes_write",
+            "arguments": { "repo": repo_name, "content": "use `pnpm test`, never `npm test`" },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "repo_notes_write errored: {text}");
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed["ok"], json!(true));
+    let path = PathBuf::from(parsed["path"].as_str().unwrap());
+    assert!(
+        path.starts_with(state_dir.path().join("repo-notes")),
+        "notes path {path:?} escaped the injected dir"
+    );
+
+    mcp_request(
+        &mut stdin,
+        4,
+        "tools/call",
+        json!({ "name": "repo_notes", "arguments": { "repo": repo_name } }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "repo_notes errored: {text}");
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        parsed["content"],
+        json!("use `pnpm test`, never `npm test`")
+    );
+    assert!(
+        parsed["hint"].is_null(),
+        "no hint once notes exist: {parsed}"
+    );
+
+    // Unknown repo: error that points at list_repos.
+    mcp_request(
+        &mut stdin,
+        5,
+        "tools/call",
+        json!({ "name": "repo_notes", "arguments": { "repo": "no-such-repo" } }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(is_error, "unknown repo should error, got: {text}");
+    assert!(text.contains("list_repos"), "unhelpful error: {text}");
+
+    // Over the cap: rejected with an error naming the limit.
+    mcp_request(
+        &mut stdin,
+        6,
+        "tools/call",
+        json!({
+            "name": "repo_notes_write",
+            "arguments": { "repo": repo_name, "content": "x".repeat(8193) },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(is_error, "oversized write should error, got: {text}");
+    assert!(text.contains("8192"), "unhelpful error: {text}");
 
     shutdown_mcp_child(child, stdin).await;
     let _ = std::fs::remove_file(&sock);

--- a/crates/repomon-daemon/tests/mcp_stdio.rs
+++ b/crates/repomon-daemon/tests/mcp_stdio.rs
@@ -70,11 +70,19 @@ async fn daemon_call(
 /// Config and repo-notes paths live in the returned tempdir (kept alive by the caller) so the
 /// daemon under test never touches the real `~/.config` / data dir.
 async fn boot_daemon(tag: &str) -> (PathBuf, IpcStream, tempfile::TempDir) {
+    boot_daemon_cfg(tag, Config::default()).await
+}
+
+/// [`boot_daemon`] with a caller-shaped config (custom tmux session, agents, ...). The worktree
+/// template is always redirected into the state tempdir so an MCP `create_lane` (which takes no
+/// path) can never land a worktree in the real `~/code`.
+async fn boot_daemon_cfg(tag: &str, mut config: Config) -> (PathBuf, IpcStream, tempfile::TempDir) {
     let store = Store::open_in_memory().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
+    config.worktree_template = format!("{}/wt/{{repo}}/{{branch}}", state_dir.path().display());
     let ctx = Ctx::new_with_paths(
         store,
-        Config::default(),
+        config,
         None,
         state_dir.path().join("config.toml"),
         state_dir.path().join("repo-notes"),
@@ -523,6 +531,108 @@ async fn mcp_stdio_repo_notes_round_trip() {
     assert!(is_error, "oversized write should error, got: {text}");
     assert!(text.contains("8192"), "unhelpful error: {text}");
 
+    // create_lane embeds the repo's notes in its own result — the orchestrator gets them with
+    // no extra tool call, ready to fold into the worker's task.
+    mcp_request(
+        &mut stdin,
+        7,
+        "tools/call",
+        json!({
+            "name": "create_lane",
+            "arguments": { "repo": repo_name, "branch": "feat/notes-embed" },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "create_lane errored: {text}");
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        parsed["repo_notes"],
+        json!("use `pnpm test`, never `npm test`"),
+        "create_lane result must embed the notes: {parsed}"
+    );
+
     shutdown_mcp_child(child, stdin).await;
     let _ = std::fs::remove_file(&sock);
+}
+
+#[tokio::test]
+async fn mcp_stdio_spawn_agent_embeds_repo_notes() {
+    if !repomon_core::TmuxRuntime::available() {
+        eprintln!("tmux not available; skipping spawn_agent notes-embed test");
+        return;
+    }
+    // A unique tmux session (name doubles as the `-L` socket) so parallel CI runs never collide
+    // and we never touch the user's real `repomon` session.
+    let session = format!("repomon-notes-embed-it-{}", std::process::id());
+    let mut config = Config {
+        tmux_session: session.clone(),
+        ..Default::default()
+    };
+    // A harmless custom "agent" instead of real `claude`: `true` ignores its arguments and
+    // exits 0, exercising the real spawn path without launching an autonomous session.
+    config.agents.insert("noop".to_string(), "true".to_string());
+
+    let (sock, mut control, _state_dir) = boot_daemon_cfg("spawn-embed", config).await;
+    let (repo_dir, lane_id) = seed_repo_lane(&mut control).await;
+    let repo_name = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+
+    let mut child = spawn_mcp_child(&sock, &[]);
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let mut lines = BufReader::new(child.stdout.take().expect("child stdout")).lines();
+
+    mcp_request(
+        &mut stdin,
+        1,
+        "initialize",
+        json!({ "protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": { "name": "repomon-it", "version": "0.0.0" } }),
+    )
+    .await;
+    let _ = mcp_read(&mut lines).await;
+
+    mcp_request(
+        &mut stdin,
+        2,
+        "tools/call",
+        json!({
+            "name": "repo_notes_write",
+            "arguments": { "repo": repo_name, "content": "use `pnpm test`, never `npm test`" },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "repo_notes_write errored: {text}");
+
+    mcp_request(
+        &mut stdin,
+        3,
+        "tools/call",
+        json!({
+            "name": "spawn_agent",
+            "arguments": { "lane_id": lane_id, "agent": "noop", "task": "run the tests" },
+        }),
+    )
+    .await;
+    let resp = mcp_read(&mut lines).await;
+    let (text, is_error) = tool_result(&resp);
+    assert!(!is_error, "spawn_agent errored: {text}");
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        parsed["repo_notes"],
+        json!("use `pnpm test`, never `npm test`"),
+        "spawn_agent result must embed the notes: {parsed}"
+    );
+
+    shutdown_mcp_child(child, stdin).await;
+    let _ = std::fs::remove_file(&sock);
+    let _ = StdCommand::new("tmux")
+        .args(["-L", &session, "kill-server"])
+        .output();
 }

--- a/crates/repomon-mcp/assets/repomind.md
+++ b/crates/repomon-mcp/assets/repomind.md
@@ -23,12 +23,15 @@ team, not an IC.
 
 ## Operating loop
 
-1. **Orient.** At session start you have no history: call `fleet_status` first, then
-   `read_agent` on any lane whose state you can't explain. Do this before acting on any turn,
-   not just the first — don't act on stale assumptions. `read_agent`'s defaults are cheap;
-   raise `transcript_limit`/`max_chars` or set `include_pane` only when you're actually
-   debugging a stuck or crashed worker.
-2. **Decide.** Turn the human's goal into concrete per-lane work.
+1. **Orient.** At session start you have no *session* history, but every repo has durable
+   notes: call `fleet_status` first, then `read_agent` on any lane whose state you can't
+   explain, and check the notes of any repo you're about to plan work in (they arrive embedded
+   in `create_lane`/`spawn_agent` results, or on demand via `repo_notes`). Do this before
+   acting on any turn, not just the first — don't act on stale assumptions. `read_agent`'s
+   defaults are cheap; raise `transcript_limit`/`max_chars` or set `include_pane` only when
+   you're actually debugging a stuck or crashed worker.
+2. **Decide.** Turn the human's goal into concrete per-lane work. Fold the repo's notes into
+   every worker task.
 3. **Act.** `create_lane` / `spawn_agent` / `send_to_agent` / `approve_agent` /
    `interrupt_agent`.
 4. **Verify.** Don't take a worker's word for it. When a worker says it's done, run `lane_diff`
@@ -76,17 +79,29 @@ flowing. The server enforces hard caps (max concurrent agents, a per-session act
 15-second duplicate-message suppression on identical sends); if a tool refuses, respect it and
 check in with the human rather than working around it.
 
-## Memory (mnemind)
+## Repo notes (fleet memory)
 
-If `basic-memory` tools are available, treat them as the team's long-term memory:
+Every repo has durable notes — build/test commands, conventions, gotchas, standing
+instructions — owned by the daemon and always available, no external memory required. They're
+your cure for cold-start amnesia:
 
-- **Before** spawning into a repo, search memory for that project's conventions, gotchas, and
-  the human's preferences, and fold them into the task you give the worker.
-- **After** meaningful decisions, write them back: the plan, per-lane assignments, and
-  outcomes. Search-before-write; edit an existing note rather than duplicating.
+- **Use them.** They arrive embedded in `create_lane`/`spawn_agent` results (or via
+  `repo_notes`). Fold them into every worker task — a worker never sees them unless you put
+  them in its prompt.
+- **Write lessons back.** After a merge, a corrected mistake, or a human-stated preference,
+  record the durable lesson with `repo_notes_write`. It's a full replace: read the current
+  notes, integrate, and rewrite concisely — edit, don't append forever; stay well under the
+  8 KB cap. The human can also edit the notes file directly.
 
-Memory is for durable knowledge. Live fleet state always comes from the `repomon` tools, never
-from memory.
+Notes are advice, not state. Live fleet truth always comes from `fleet_status`/`read_agent`,
+never from notes.
+
+## Additional memory (mnemind)
+
+If `basic-memory` tools are available, use them only for cross-tool or cross-project
+knowledge (the human's global preferences, facts shared with other assistants). Per-repo
+facts belong in repo notes, not there. Search-before-write; edit an existing note rather
+than duplicating.
 
 ## Style
 

--- a/crates/repomon-mcp/src/server.rs
+++ b/crates/repomon-mcp/src/server.rs
@@ -188,7 +188,7 @@ impl Server {
             Some(name) => name,
             None => self.default_agent().await,
         };
-        let res: Value = self
+        let mut res: Value = self
             .client
             .call(
                 "agent.spawn",
@@ -196,6 +196,20 @@ impl Server {
             )
             .await
             .map_err(rpc_err)?;
+        // Piggyback the repo's notes so the orchestrator can fold them into follow-up
+        // instructions without another tool call. Every step is best-effort: the spawn already
+        // happened, so a notes failure must not turn this result into an error.
+        if let Ok(lane) = self
+            .client
+            .call_typed::<Lane>("lane.get", Some(json!({ "lane_id": a.lane_id })))
+            .await
+        {
+            if let Some(notes) = self.fetch_repo_notes(lane.repo.id).await {
+                if let Some(obj) = res.as_object_mut() {
+                    obj.insert("repo_notes".into(), json!(notes));
+                }
+            }
+        }
         Ok(res)
     }
 
@@ -355,12 +369,18 @@ impl Server {
             )
             .await
             .map_err(rpc_err)?;
-        Ok(json!({
+        let mut out = json!({
             "lane_id": lane.id,
             "path": lane.worktree.path,
             "branch": a.branch,
             "repo": repo.name,
-        }))
+        });
+        // Piggyback the repo's notes (best-effort) so the orchestrator writes the worker's task
+        // with them already in hand.
+        if let Some(notes) = self.fetch_repo_notes(repo.id).await {
+            out["repo_notes"] = json!(notes);
+        }
+        Ok(out)
     }
 
     /// Two-phase destructive delete: no `confirm` mints an impact summary + token (a normal,
@@ -556,6 +576,27 @@ impl Server {
                 _ = tokio::time::sleep(remaining) => {}
             }
         }
+    }
+
+    /// The repo's notes for embedding into a tool result, best-effort: `None` on any failure
+    /// or when the notes are empty, so callers can unconditionally `if let Some` — a notes
+    /// hiccup must never fail the spawn/create it piggybacks on.
+    async fn fetch_repo_notes(&self, repo_id: i64) -> Option<String> {
+        let res: Value = match self
+            .client
+            .call("repo.notes.get", Some(json!({ "repo_id": repo_id })))
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!("repo.notes.get failed for repo {repo_id}: {e}");
+                return None;
+            }
+        };
+        res["content"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
     }
 
     /// Resolve a repo by the orchestrator's handle: registered name, or id as a string.
@@ -1032,9 +1073,11 @@ fn tool_catalog() -> Vec<ToolDef> {
         },
         ToolDef {
             name: "spawn_agent",
-            description: "Start a coding agent working on a lane with a concrete task. Counts \
-                against the concurrent-agent cap. Omit 'agent' to use the configured default \
-                (usually claude-code).",
+            description: "Start a coding agent working on a lane with a concrete task. Fold the \
+                repo's notes (from create_lane/repo_notes) into the task text. Counts against \
+                the concurrent-agent cap. Omit 'agent' to use the configured default (usually \
+                claude-code). The result embeds repo_notes (the repo's durable notes) when any \
+                exist — use them in follow-up instructions too.",
             input_schema: obj(
                 json!({
                     "lane_id": { "type": "integer", "description": "The lane (worktree) to work in." },
@@ -1102,7 +1145,9 @@ fn tool_catalog() -> Vec<ToolDef> {
         ToolDef {
             name: "create_lane",
             description: "Create a new branch + worktree (a lane) in a repo, ready to spawn an \
-                agent into. In supervised mode this asks for human confirmation first.",
+                agent into. In supervised mode this asks for human confirmation first. The \
+                result embeds repo_notes (the repo's durable notes) when any exist — fold them \
+                into the task you give the worker you spawn here.",
             input_schema: obj(
                 json!({
                     "repo": { "type": "string", "description": "Repo name or id (see list_repos)." },

--- a/crates/repomon-mcp/src/server.rs
+++ b/crates/repomon-mcp/src/server.rs
@@ -55,6 +55,8 @@ impl ToolHandler for Server {
             "lane_diff" => self.lane_diff(args).await,
             "list_repos" => self.list_repos(args).await,
             "wait_for_change" => self.wait_for_change(args).await,
+            "repo_notes" => self.repo_notes(args).await,
+            "repo_notes_write" => self.repo_notes_write(args).await,
             other => Err(format!("unknown tool: {other}")),
         };
         match out {
@@ -339,15 +341,7 @@ impl Server {
                     .into(),
             );
         }
-        let repos: Vec<Repo> = self
-            .client
-            .call_typed("repo.list", None)
-            .await
-            .map_err(rpc_err)?;
-        let repo = repos
-            .iter()
-            .find(|r| r.name == a.repo || r.id.to_string() == a.repo)
-            .ok_or_else(|| format!("no registered repo matching '{}'. Try list_repos.", a.repo))?;
+        let repo = self.resolve_repo(&a.repo).await?;
         let lane: Lane = self
             .client
             .call_typed(
@@ -564,6 +558,61 @@ impl Server {
         }
     }
 
+    /// Resolve a repo by the orchestrator's handle: registered name, or id as a string.
+    async fn resolve_repo(&self, name_or_id: &str) -> Result<Repo, String> {
+        let repos: Vec<Repo> = self
+            .client
+            .call_typed("repo.list", None)
+            .await
+            .map_err(rpc_err)?;
+        repos
+            .into_iter()
+            .find(|r| r.name == name_or_id || r.id.to_string() == name_or_id)
+            .ok_or_else(|| format!("no registered repo matching '{name_or_id}'. Try list_repos."))
+    }
+
+    async fn repo_notes(&self, args: Value) -> Result<Value, String> {
+        let a: RepoNotesArgs = parse(args)?;
+        let repo = self.resolve_repo(&a.repo).await?;
+        let res: Value = self
+            .client
+            .call("repo.notes.get", Some(json!({ "repo_id": repo.id })))
+            .await
+            .map_err(rpc_err)?;
+        let mut out = json!({
+            "repo": repo.name,
+            "content": res["content"],
+            "path": res["path"],
+        });
+        if res["content"].as_str().unwrap_or_default().is_empty() {
+            out["hint"] = json!(
+                "no notes yet. When you learn something durable about this repo (build/test \
+                 commands, conventions, gotchas), record it with repo_notes_write."
+            );
+        }
+        Ok(out)
+    }
+
+    async fn repo_notes_write(&self, args: Value) -> Result<Value, String> {
+        let a: RepoNotesWriteArgs = parse(args)?;
+        self.policy.record_mutation()?;
+        let repo = self.resolve_repo(&a.repo).await?;
+        let res: Value = self
+            .client
+            .call(
+                "repo.notes.set",
+                Some(json!({ "repo_id": repo.id, "content": a.content })),
+            )
+            .await
+            .map_err(rpc_err)?;
+        Ok(json!({
+            "ok": true,
+            "repo": repo.name,
+            "bytes": res["bytes"],
+            "path": res["path"],
+        }))
+    }
+
     async fn default_agent(&self) -> String {
         match self
             .client
@@ -677,6 +726,15 @@ struct LaneDiffArgs {
 }
 fn default_max_patch_chars() -> usize {
     8000
+}
+#[derive(Deserialize)]
+struct RepoNotesArgs {
+    repo: String,
+}
+#[derive(Deserialize)]
+struct RepoNotesWriteArgs {
+    repo: String,
+    content: String,
 }
 #[derive(Deserialize)]
 struct WaitForChangeArgs {
@@ -1106,6 +1164,35 @@ fn tool_catalog() -> Vec<ToolDef> {
             name: "list_repos",
             description: "List the repositories registered with repomon (id, name, path).",
             input_schema: obj(json!({}), &[]),
+        },
+        ToolDef {
+            name: "repo_notes",
+            description: "Read a repo's durable notes (the fleet's per-repo memory): build/test \
+                commands, conventions, gotchas, standing instructions — recorded across sessions \
+                and hand-editable by the human. Check them before planning work in a repo, and \
+                fold them into every worker task. Also embedded automatically in \
+                create_lane/spawn_agent results as repo_notes.",
+            input_schema: obj(
+                json!({
+                    "repo": { "type": "string", "description": "Repo name or id (see list_repos)." }
+                }),
+                &["repo"],
+            ),
+        },
+        ToolDef {
+            name: "repo_notes_write",
+            description: "Replace a repo's durable notes wholesale (full replace, max 8192 \
+                bytes). Read repo_notes first, integrate the new lesson, and rewrite concisely — \
+                edit, don't append forever. Record durable lessons here after a merge, a \
+                corrected mistake, or a human-stated preference; don't store live fleet state \
+                (that comes from fleet_status).",
+            input_schema: obj(
+                json!({
+                    "repo": { "type": "string", "description": "Repo name or id (see list_repos)." },
+                    "content": { "type": "string", "description": "The complete new notes (markdown). Replaces the previous notes entirely." }
+                }),
+                &["repo", "content"],
+            ),
         },
         ToolDef {
             name: "wait_for_change",

--- a/crates/repomon-mcp/src/server.rs
+++ b/crates/repomon-mcp/src/server.rs
@@ -1262,6 +1262,24 @@ mod tests {
     use super::*;
     use crate::fleet::AgentDigest;
 
+    /// The persona must teach the repo-notes loop (read at Orient, fold into tasks, write
+    /// lessons back) and must no longer present mnemind as the primary team memory.
+    #[test]
+    fn persona_documents_repo_notes() {
+        assert!(
+            crate::PERSONA.contains("repo_notes"),
+            "persona never mentions repo_notes"
+        );
+        assert!(
+            crate::PERSONA.contains("repo_notes_write"),
+            "persona never mentions repo_notes_write"
+        );
+        assert!(
+            !crate::PERSONA.contains("treat them as the team's long-term memory"),
+            "mnemind must be secondary to repo notes now"
+        );
+    }
+
     fn lane(id: i64, repo: &str, status: &str, attention: Attention) -> LaneDigest {
         LaneDigest {
             lane_id: id,

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -90,6 +90,7 @@ macOS** and **Ctrl elsewhere**.
 | `mod+shift+n` | Add repository |
 | `mod+g` | Jump to a lane needing attention |
 | `mod+shift+h` | Hide the selected lane's project |
+| `mod+shift+b` | Edit the selected lane's project notes |
 
 ### Lane
 
@@ -152,6 +153,19 @@ running totals, and a **Hidden (N)** list at the bottom of the sidebar brings an
 
 The flag lives in the daemon, so the TUI honors it too and it survives a restart. The TUI has no
 unhide view of its own, so a project hidden there stays hidden until you restore it here.
+
+## Repo notes
+
+Every registered project has a notes file: conventions, build and test commands, merge
+preferences, gotchas, anything worth telling a worker every time. repomind reads them when it
+plans and folds them into the prompts of agents it spawns there, so this is where you write
+something the orchestrator will still know next week.
+
+Open them from `mod+shift+b`, or right-click a project header in the sidebar and choose **Repo
+notes**. They are plain markdown on disk under the daemon's data directory and stay editable
+outside the app, so the editor loads fresh each time rather than caching. The 8 KB cap is enforced
+by the daemon; the editor counts bytes (not characters) against it so a doomed save is refused
+before it is sent.
 
 ## Extensions
 


### PR DESCRIPTION
## What

Cures repomind's cold-start amnesia: the daemon now owns one human-editable markdown notes file per repo, served through two new MCP tools and embedded automatically into `create_lane`/`spawn_agent` results so the orchestrator folds per-repo knowledge (build/test commands, conventions, gotchas) into every worker prompt with no extra tool call.

- **repomon-core**: `notes` module. Files live at `data_dir()/repo-notes/<slug>.md`, keyed by sanitized repo name; on a slug collision every collider gets `<slug>-<id>.md` so notes never bleed across repos. 8192-byte cap on write; oversized hand-edited files truncate on read (char-boundary safe) with a marker. Atomic temp+fsync+rename writes, one-generation `.bak` on overwrite.
- **repomon-daemon**: `repo.notes.get` / `repo.notes.set` RPCs; `Ctx` gains an injectable `notes_dir` (new `new_with_paths` constructor, existing constructors unchanged). The cap is enforced daemon-side and every set emits a structured audit line (repo, old/new bytes, path, connection kind).
- **repomon-mcp**: `repo_notes` (read, ungated) and `repo_notes_write` (gated by `record_mutation()`: action cap + read-only refusal, but deliberately NOT `allows_structural()`, so a supervised repomind can still record lessons). `create_lane` and `spawn_agent` results embed `repo_notes` best-effort. Persona rewritten: Orient reads notes, Decide folds them into every worker task, and repo notes are now the primary memory with mnemind demoted to cross-tool knowledge only (guarded by a persona test).

The daemon-to-iOS wire protocol is untouched: embedding is an MCP-side daemon-local call, not a daemon response change.

## Acceptance (verified live)

Isolated instance, notes written once via the tool and once by hand-editing the file, notes said "use `pnpm test`, never `npm test`" plus a hand-added linter rule. A real claude-powered repomind, given only "spawn one worker to run the test suite", produced a worker task containing both instructions unprompted.

## Testing

- TDD throughout; new coverage: core notes unit tests (slug hostility, collisions, cap, `.bak`, truncation incl. multibyte), daemon `repo_notes` integration round-trip, remote-allowlist lock-in, `mcp_stdio` catalog/round-trip/read-only/embed tests (incl. a tmux-guarded `spawn_agent` embed test).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`: all green (378 tests).

## Deferred / follow-ups

- TUI notes view (roadmap marks it nice-to-have; files are human-editable and both tools return the path).
- `repo.notes.*` stays OFF the remote allowlist (local socket only); iOS access can ride Phase 6.
- Phase 2 should journal `repo.notes.set` into `orchestration_log` once that table exists (today: tracing audit line + `.bak`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)