### PR TITLE
Keyboard-first GUI, in-app shortcut reference, and rebuilt settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
+      # The env var goes through `env:` rather than a `VAR=value cmd` prefix: Windows runners
+      # default to PowerShell, which reads that prefix as a command name and fails the step.
       - name: Check generated desktop bindings
-        run: >-
-          TS_RS_EXPORT_DIR=../../apps/desktop/src/bindings
-          cargo test -p repomon-core --features ts export_bindings --locked
+        env:
+          TS_RS_EXPORT_DIR: ../../apps/desktop/src/bindings
+        run: cargo test -p repomon-core --features ts export_bindings --locked
       - run: git diff --exit-code -- apps/desktop/src/bindings
 
   frontend:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ Or grab a tarball from the [latest release](https://github.com/AliHamzaAzam/repo
 per-arch (`aarch64`/`x86_64`) or the `universal` build, then extract, and put `repomon` and `repomond`
 on your `PATH`.
 
+**Mission Control** (the desktop app) ships separately, for macOS, Windows, and Linux, from the
+[`desktop-preview`](https://github.com/AliHamzaAzam/repomon/releases/tag/desktop-preview) release:
+
+| Platform | File |
+|---|---|
+| macOS (Apple silicon and Intel) | `Repomon_<version>_universal.dmg` |
+| Windows | `Repomon_<version>_x64-setup.exe` |
+| Linux | `Repomon_<version>_amd64.AppImage`, `.deb`, or `.rpm` |
+
+The bundle carries its own daemon, so it needs no separate `repomond`, and it updates itself after
+the first download. It drives the same fleet as the TUI and can be run entirely from the keyboard.
+See [docs/desktop.md](docs/desktop.md) for the shortcut reference and settings.
+
 **From source**: any platform with the Rust toolchain (anywhere without a prebuilt binary):
 
 ```sh
@@ -303,6 +316,7 @@ Manage it with `repomon remote status` (shows the bind and a masked token),
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md): how the daemon, TUI, and core fit together.
+- [docs/desktop.md](docs/desktop.md): Mission Control, its keyboard shortcuts, and settings.
 - [docs/protocol.md](docs/protocol.md): the JSON-RPC socket reference.
 - [docs/agents.md](docs/agents.md): how agents run and how status is detected.
 - [docs/windows-validation.md](docs/windows-validation.md): the manual Windows 11 end-to-end validation gate.

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "dialog:default",
     "notification:default",
     "opener:allow-open-url",
+    "opener:allow-default-urls",
     "process:allow-restart",
     "updater:default"
   ]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Repomon",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "identifier": "com.repomon.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Repomon",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "identifier": "com.repomon.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import App from "./App";
 import type { ConnectionSnapshot, ConnectionSource } from "./ipc/connection";
@@ -13,6 +13,15 @@ function sourceFor(snapshot: ConnectionSnapshot): ConnectionSource {
 }
 
 describe("Repomon desktop shell", () => {
+  beforeAll(() => {
+    // App.tsx's shortcut handler resolves "mod" from navigator.platform when no explicit
+    // platform is passed in (the real, unmocked path the app uses at runtime). jsdom reports an
+    // empty platform string, so pin it to macOS here: the fixtures below fire metaKey to mean
+    // "mod", matching how the app actually runs on macOS.
+    Object.defineProperty(navigator, "platform", { value: "MacIntel", configurable: true });
+  });
+
+
   it("renders the mission control frame and connection rail", () => {
     render(() => <App connectionSource={sourceFor({
       phase: "starting",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { describe, expect, it } from "vitest";
 
 import App from "./App";
@@ -77,5 +77,30 @@ describe("Repomon desktop shell", () => {
     })} fleetSource={fleetSource} />);
 
     expect(await screen.findByText("fleet sync failed")).toBeInTheDocument();
+  });
+
+  it("drives the Extensions panel from the keymap table, not a bare digit", async () => {
+    // Scoped to this render's container: earlier tests in this file leave their DOM mounted
+    // (no cleanup wired up), so an unscoped query would see every prior "Extensions" button too.
+    const { container } = render(() => <App connectionSource={sourceFor({
+      phase: "starting",
+      endpoint: "Resolving local daemon endpoint",
+      message: null,
+      daemon: null,
+    })} />);
+
+    const extensions = within(container).getByRole("button", { name: "Extensions" });
+    expect(extensions).toHaveAttribute("aria-pressed", "false");
+
+    // The old ad-hoc listener toggled Extensions on a bare "6"; that would steal a keystroke
+    // meant for a focused agent terminal. The keymap-driven handler ignores unmodified keys.
+    fireEvent.keyDown(window, { key: "6", code: "Digit6" });
+    expect(extensions).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.keyDown(window, { key: "4", code: "Digit4", metaKey: true });
+    await waitFor(() => expect(extensions).toHaveAttribute("aria-pressed", "true"));
+
+    fireEvent.keyDown(window, { key: "4", code: "Digit4", metaKey: true });
+    await waitFor(() => expect(extensions).toHaveAttribute("aria-pressed", "false"));
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -101,7 +101,13 @@ function App(props: AppProps) {
 
     const lane = fleet.selectedLane();
     if (binding.when && !lane) return;
-    const agent = lane?.agent_sessions.find((session) => session.tmux_window) ?? null;
+    // Prefer the agent whose terminal is actually focused: on a multi-agent lane the first
+    // windowed session is not necessarily the one the user is looking at, and lane.stop must
+    // never guess.
+    const active = workspace.activeWindow();
+    const agent = lane?.agent_sessions.find((session) => session.tmux_window === active)
+      ?? lane?.agent_sessions.find((session) => session.tmux_window)
+      ?? null;
     if (binding.when === "agent" && !agent) return;
 
     event.preventDefault();
@@ -120,7 +126,7 @@ function App(props: AppProps) {
       case "fleet.addRepo": void actions.addRepo(); break;
       case "fleet.jumpUrgent": fleet.moveSelection(1, true); break;
       case "lane.spawn": if (lane) actions.spawn(lane); break;
-      case "lane.terminal": void workspace.openShell(); break;
+      case "lane.terminal": void workspace.openShell(actions.reportError); break;
       case "lane.pin": if (lane) void actions.pinLane(lane); break;
       case "lane.delete": if (lane) actions.deleteLane(lane); break;
       case "lane.merge": if (lane) actions.mergeLane(lane); break;
@@ -128,6 +134,10 @@ function App(props: AppProps) {
       case "agents.prev": workspace.cycleTab(-1, workspace.laneTargets()); break;
       case "agents.next": workspace.cycleTab(1, workspace.laneTargets()); break;
       case "help.open": actions.openSettingsTab("keyboard"); break;
+      default:
+        // A binding exists in the table with no handler. Warn rather than silently eating the key.
+        console.warn(`No handler for keyboard binding: ${binding.id}`);
+        break;
     }
   };
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -17,6 +17,7 @@ import {
   type ConnectionSource,
 } from "./ipc/connection";
 import { daemonCall } from "./ipc/rpc";
+import { matchChord } from "./keymap";
 import { applyAccent, applyTheme, nextTheme, readTheme, themeLabel } from "./theme";
 import { createExtensionsStore } from "./stores/extensions";
 import { createFleetStore, type FleetSource } from "./stores/fleet";
@@ -88,23 +89,51 @@ function App(props: AppProps) {
     }
   });
 
-  const onSettingsShortcut = (event: KeyboardEvent) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === ",") {
-      event.preventDefault();
-      actions.openSettings();
+  /// One listener for every shortcut. Registered in bubble phase so an open Modal (which listens
+  /// in capture phase and stops propagation on Escape) still closes first.
+  const onShortcut = (event: KeyboardEvent) => {
+    const binding = matchChord(event);
+    if (!binding) return;
+
+    // A modal owns the keyboard while it is open. ControlCenter keeps its own Cmd+K listener.
+    if (actions.settingsOpen() || actions.spawnLane() || actions.newLaneOpen()
+      || actions.renameTarget() || actions.confirmOptions()) return;
+
+    const lane = fleet.selectedLane();
+    if (binding.when && !lane) return;
+    const agent = lane?.agent_sessions.find((session) => session.tmux_window) ?? null;
+    if (binding.when === "agent" && !agent) return;
+
+    event.preventDefault();
+    switch (binding.id) {
+      case "panel.extensions": setExtensionsOpen((open) => !open); break;
+      case "panel.repomind": setRepomindOpen((open) => !open); break;
+      case "panel.theme": cycleTheme(); break;
+      case "layout.focused": workspace.chooseLayout("focused"); break;
+      case "layout.split": workspace.chooseLayout("split"); break;
+      case "layout.grid": workspace.chooseLayout("grid"); break;
+      case "fleet.filter": searchInput?.focus(); break;
+      case "fleet.urgent": fleet.setUrgentOnly(!fleet.urgentOnly()); break;
+      case "fleet.refresh": void fleet.refresh(); break;
+      case "fleet.newLane": actions.newLane(); break;
+      case "fleet.addRepo": void actions.addRepo(); break;
+      case "fleet.jumpUrgent": fleet.moveSelection(1, true); break;
+      case "lane.spawn": if (lane) actions.spawn(lane); break;
+      case "lane.terminal": void workspace.openShell(); break;
+      case "lane.pin": if (lane) void actions.pinLane(lane); break;
+      case "lane.delete": if (lane) actions.deleteLane(lane); break;
+      case "lane.merge": if (lane) actions.mergeLane(lane); break;
+      case "lane.stop": if (lane) actions.stopAgent(lane, agent); break;
+      case "agents.prev": workspace.cycleTab(-1, workspace.laneTargets()); break;
+      case "agents.next": workspace.cycleTab(1, workspace.laneTargets()); break;
+      // TODO(task 5): once actions.openSettingsTab(tab) exists, switch this to
+      // actions.openSettingsTab("keyboard") so Cmd+? opens Settings on the Keyboard tab.
+      case "help.open": actions.openSettings(); break;
     }
   };
 
-  const onExtensionsShortcut = (event: KeyboardEvent) => {
-    if (event.key !== "6" || event.metaKey || event.ctrlKey || event.altKey) return;
-    const target = event.target as HTMLElement | null;
-    if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) return;
-    setExtensionsOpen((open) => !open);
-  };
-
   onMount(() => {
-    window.addEventListener("keydown", onSettingsShortcut);
-    window.addEventListener("keydown", onExtensionsShortcut);
+    window.addEventListener("keydown", onShortcut);
     void getVersion().then(setAppVersion).catch(() => undefined);
 
     // Check for a newer build once on launch; silent if current or if not a Tauri build.
@@ -140,8 +169,7 @@ function App(props: AppProps) {
 
   onCleanup(() => {
     active = false;
-    window.removeEventListener("keydown", onSettingsShortcut);
-    window.removeEventListener("keydown", onExtensionsShortcut);
+    window.removeEventListener("keydown", onShortcut);
     stopListening?.();
     fleet.stop();
     notifications.stop();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -106,6 +106,7 @@ function App(props: AppProps) {
 
     event.preventDefault();
     switch (binding.id) {
+      case "panel.settings": actions.openSettings(); break;
       case "panel.extensions": setExtensionsOpen((open) => !open); break;
       case "panel.repomind": setRepomindOpen((open) => !open); break;
       case "panel.theme": cycleTheme(); break;
@@ -241,7 +242,7 @@ function App(props: AppProps) {
             class={`focus-ring rounded-md border px-2.5 py-1.5 font-mono text-[0.58rem] uppercase tracking-[0.1em] ${extensionsOpen() ? "border-signal/40 bg-signal/10 text-signal" : "border-line bg-raised text-muted"}`}
             onClick={() => setExtensionsOpen(!extensionsOpen())}
             aria-pressed={extensionsOpen()}
-            title="Extensions (6)"
+            title="Extensions (⌘4)"
           >Extensions</button>
           <button
             type="button"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { applyAccent, applyTheme, nextTheme, readTheme, themeLabel } from "./the
 import { createExtensionsStore } from "./stores/extensions";
 import { createFleetStore, type FleetSource } from "./stores/fleet";
 import { createNotificationStore } from "./stores/notifications";
+import { createWorkspaceStore } from "./stores/workspace";
 
 interface AppProps {
   connectionSource?: ConnectionSource;
@@ -57,6 +58,7 @@ function App(props: AppProps) {
   const source = props.connectionSource ?? tauriConnectionSource;
   const fleet = createFleetStore(props.fleetSource);
   const actions = createActionsStore(fleet);
+  const workspace = createWorkspaceStore(fleet);
   const ext = createExtensionsStore();
   const notifications = createNotificationStore((laneId) => fleet.setSelectedLaneId(laneId));
   let stopListening: (() => void) | undefined;
@@ -260,7 +262,7 @@ function App(props: AppProps) {
             aria-hidden={extensionsOpen() ? "true" : undefined}
             inert={extensionsOpen()}
           >
-            <TerminalWorkspace fleet={fleet} actions={actions} />
+            <TerminalWorkspace fleet={fleet} actions={actions} workspace={workspace} />
           </div>
           <Show when={extensionsOpen()}>
             <div class="absolute inset-0 z-10 bg-background">

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -127,9 +127,7 @@ function App(props: AppProps) {
       case "lane.stop": if (lane) actions.stopAgent(lane, agent); break;
       case "agents.prev": workspace.cycleTab(-1, workspace.laneTargets()); break;
       case "agents.next": workspace.cycleTab(1, workspace.laneTargets()); break;
-      // TODO(task 5): once actions.openSettingsTab(tab) exists, switch this to
-      // actions.openSettingsTab("keyboard") so Cmd+? opens Settings on the Keyboard tab.
-      case "help.open": actions.openSettings(); break;
+      case "help.open": actions.openSettingsTab("keyboard"); break;
     }
   };
 

--- a/apps/desktop/src/components/ActionModals.tsx
+++ b/apps/desktop/src/components/ActionModals.tsx
@@ -13,7 +13,7 @@ export default function ActionModals(props: { actions: ActionsStore }) {
   return (
     <>
       <Show when={actions.settingsOpen()}>
-        <SettingsModal onClose={actions.closeSettings} />
+        <SettingsModal onClose={actions.closeSettings} initialTab={actions.settingsTab()} />
       </Show>
       <Show when={actions.spawnLane()}>
         {(lane) => <SpawnModal lane={lane()} onClose={actions.closeSpawn} onDone={() => actions.fleet.refresh()} />}

--- a/apps/desktop/src/components/ControlCenter.tsx
+++ b/apps/desktop/src/components/ControlCenter.tsx
@@ -2,6 +2,7 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount }
 
 import type { AgentSession, BrowseResult, Commit, PendingDialog, TimelineData, WorkSession } from "../bindings";
 import { DaemonRpcError, daemonCall } from "../ipc/rpc";
+import { isMac } from "../keymap";
 import { laneIndicator, type FleetStore } from "../stores/fleet";
 import type { NotificationStore } from "../stores/notifications";
 import type { ActionsStore } from "../stores/actions";
@@ -75,7 +76,10 @@ export default function ControlCenter(props: ControlCenterProps) {
   }
 
   const onKey = (event: KeyboardEvent) => {
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+    // Same platform gate as keymap.ts: Cmd is mod on macOS and a held Ctrl there is a terminal
+    // chord meant for the agent, not this shortcut. Elsewhere mod is Ctrl.
+    const mod = isMac() ? event.metaKey && !event.ctrlKey : event.ctrlKey;
+    if (mod && event.key.toLowerCase() === "k") {
       event.preventDefault();
       if (open()) closeControl();
       else openControl();

--- a/apps/desktop/src/components/ControlCenter.tsx
+++ b/apps/desktop/src/components/ControlCenter.tsx
@@ -148,11 +148,6 @@ export default function ControlCenter(props: ControlCenterProps) {
     closeControl(false);
   }
 
-  function confirmAction(options: Parameters<ActionsStore["confirm"]>[0]) {
-    props.actions.confirm(options);
-    closeControl(false);
-  }
-
   async function answer(choice: number) {
     const lane = selectedLane();
     const agent = pendingAgent();
@@ -308,15 +303,15 @@ export default function ControlCenter(props: ControlCenterProps) {
                     </Show>
                     <div class="action-grid">
                       <button onClick={() => spawnAgent()} disabled={!selectedLane()}>Spawn agent</button>
-                      <button onClick={() => void run("adopt", () => daemonCall("agent.adopt", { lane_id: selectedLane()!.id, session_id: selectedAgent()?.session_id ?? undefined }))} disabled={!selectedLane() || !selectedAgent()?.external}>Adopt external</button>
+                      <button onClick={() => void run("adopt", () => props.actions.adoptAgent(selectedLane()!, selectedAgent()))} disabled={!selectedLane() || !selectedAgent()?.external}>Adopt external</button>
                       <button onClick={() => renameSession()} disabled={!selectedAgent()?.session_id}>Rename session</button>
-                      <button onClick={() => void run("pin", () => daemonCall("agent.pin", { lane_id: selectedLane()!.id, pinned: !selectedLane()!.pinned }))} disabled={!selectedLane()}>{selectedLane()?.pinned ? "Unpin lane" : "Pin lane"}</button>
+                      <button onClick={() => void run("pin", () => props.actions.pinLane(selectedLane()!))} disabled={!selectedLane()}>{selectedLane()?.pinned ? "Unpin lane" : "Pin lane"}</button>
                       <button onClick={() => void run("continue", () => daemonCall("agent.auto_continue", { lane_id: selectedLane()!.id, enabled: true }))} disabled={!selectedLane()}>Arm auto-continue</button>
                       <button class="is-danger" onClick={() => {
                         const lane = selectedLane();
-                        const agent = selectedAgent();
                         if (!lane) return;
-                        confirmAction({ title: "Stop agent?", message: "Stop this managed agent. Its terminal session ends.", confirmLabel: "Stop", danger: true, onConfirm: async () => { await daemonCall("agent.stop", { lane_id: lane.id, window: agent?.tmux_window ?? undefined }); await props.fleet.refresh(); } });
+                        props.actions.stopAgent(lane, selectedAgent());
+                        closeControl(false);
                       }} disabled={!selectedLane() || !selectedAgent()?.tmux_window}>Stop agent</button>
                     </div>
                   </section>
@@ -329,14 +324,16 @@ export default function ControlCenter(props: ControlCenterProps) {
                       <button onClick={() => {
                         const lane = selectedLane();
                         if (!lane) return;
-                        confirmAction({ title: "Merge lane?", message: `Merge ${lane.worktree.branch ?? lane.worktree.name} into the repository base branch.`, confirmLabel: "Merge", onConfirm: async () => { await daemonCall("lane.merge", { lane_id: lane.id }); await props.fleet.refresh(); } });
+                        props.actions.mergeLane(lane);
+                        closeControl(false);
                       }} disabled={!selectedLane() || selectedLane()?.worktree.is_main}>Merge lane</button>
                       <button onClick={() => addRepo()}>Add repository</button>
                       <button onClick={() => void browse(browser()?.path)}>Browse filesystem</button>
                       <button class="is-danger" onClick={() => {
                         const lane = selectedLane();
                         if (!lane || lane.worktree.is_main) return;
-                        confirmAction({ title: "Delete lane?", message: `Delete the worktree lane ${lane.worktree.branch ?? lane.worktree.name}. The branch is kept.`, confirmLabel: "Delete", danger: true, onConfirm: async () => { await daemonCall("lane.delete", { lane_id: lane.id, also_delete_branch: false }); await props.fleet.refresh(); } });
+                        props.actions.deleteLane(lane);
+                        closeControl(false);
                       }} disabled={!selectedLane() || selectedLane()?.worktree.is_main}>Delete lane</button>
                       <button class="is-danger" onClick={() => {
                         const repo = selectedLane()?.repo;

--- a/apps/desktop/src/components/KeyboardHelp.test.tsx
+++ b/apps/desktop/src/components/KeyboardHelp.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BINDINGS } from "../keymap";
+import KeyboardHelp from "./KeyboardHelp";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("keyboard reference", () => {
+  it("lists every binding so help can never omit one", () => {
+    render(() => <KeyboardHelp />);
+    for (const binding of BINDINGS) {
+      expect(screen.getByText(binding.label)).toBeInTheDocument();
+    }
+  });
+
+  it("filters on the search box", () => {
+    render(() => <KeyboardHelp />);
+    fireEvent.input(screen.getByPlaceholderText("Search shortcuts"), { target: { value: "merge" } });
+    expect(screen.getByText("Merge lane")).toBeInTheDocument();
+    expect(screen.queryByText("Refresh")).not.toBeInTheDocument();
+  });
+
+  it("lists the two shortcuts that live outside BINDINGS", () => {
+    render(() => <KeyboardHelp />);
+    expect(screen.getByText("Open the control center")).toBeInTheDocument();
+    expect(screen.getByText("Leave the terminal")).toBeInTheDocument();
+  });
+
+  it("filters the control center row on search", () => {
+    render(() => <KeyboardHelp />);
+    fireEvent.input(screen.getByPlaceholderText("Search shortcuts"), { target: { value: "control center" } });
+    expect(screen.getByText("Open the control center")).toBeInTheDocument();
+    expect(screen.queryByText("Leave the terminal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Merge lane")).not.toBeInTheDocument();
+  });
+
+  it("filters the leave-terminal row on search", () => {
+    render(() => <KeyboardHelp />);
+    fireEvent.input(screen.getByPlaceholderText("Search shortcuts"), { target: { value: "leave" } });
+    expect(screen.getByText("Leave the terminal")).toBeInTheDocument();
+    expect(screen.queryByText("Open the control center")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/KeyboardHelp.tsx
+++ b/apps/desktop/src/components/KeyboardHelp.tsx
@@ -1,0 +1,77 @@
+import { For, Show, createMemo, createSignal } from "solid-js";
+
+import { BINDINGS, formatChord, type KeymapSection } from "../keymap";
+
+const SECTIONS: KeymapSection[] = ["Panels", "Layout", "Fleet", "Lane", "Agents", "Help"];
+
+/// Two real shortcuts live outside BINDINGS and must still appear here, or the reference lies by
+/// omission. Neither belongs in the shared table:
+/// - Cmd+K / Ctrl+K opens the control center via ControlCenter.tsx's own listener. Putting it in
+///   BINDINGS would make the global handler in App.tsx call preventDefault and swallow the key
+///   before ControlCenter ever saw it.
+/// - Shift+Escape leaves a focused terminal. It has no Cmd/Ctrl modifier, unlike every BINDINGS
+///   entry, so it gets a literal chord label instead of formatChord, which always assumes a mod
+///   key is present.
+const STATIC_ROWS: Array<{ id: string; label: string; chord: string }> = [
+  { id: "static.controlCenter", label: "Open the control center", chord: formatChord("mod+k") },
+  { id: "static.leaveTerminal", label: "Leave the terminal", chord: "Shift+Esc" },
+];
+
+export default function KeyboardHelp() {
+  const [query, setQuery] = createSignal("");
+
+  const matches = createMemo(() => {
+    const needle = query().trim().toLowerCase();
+    if (!needle) return BINDINGS;
+    return BINDINGS.filter((binding) =>
+      binding.label.toLowerCase().includes(needle) || formatChord(binding.chord).toLowerCase().includes(needle));
+  });
+
+  const staticMatches = createMemo(() => {
+    const needle = query().trim().toLowerCase();
+    if (!needle) return STATIC_ROWS;
+    return STATIC_ROWS.filter((row) => row.label.toLowerCase().includes(needle) || row.chord.toLowerCase().includes(needle));
+  });
+
+  return (
+    <div class="space-y-4">
+      <input
+        class="settings-input mt-0"
+        placeholder="Search shortcuts"
+        value={query()}
+        onInput={(event) => setQuery(event.currentTarget.value)}
+      />
+      <For each={SECTIONS}>
+        {(section) => {
+          const rows = createMemo(() => matches().filter((binding) => binding.section === section));
+          // The Help section also carries the two rows above; every other section only shows
+          // table-driven rows.
+          const extraRows = createMemo(() => (section === "Help" ? staticMatches() : []));
+          return (
+            <Show when={rows().length > 0 || extraRows().length > 0}>
+              <section class="space-y-1">
+                <p class="section-label text-signal">{section}</p>
+                <For each={rows()}>
+                  {(binding) => (
+                    <div class="flex items-center justify-between rounded border border-line px-3 py-1.5 text-xs">
+                      <span>{binding.label}</span>
+                      <span class="lane-badge font-mono">{formatChord(binding.chord)}</span>
+                    </div>
+                  )}
+                </For>
+                <For each={extraRows()}>
+                  {(row) => (
+                    <div class="flex items-center justify-between rounded border border-line px-3 py-1.5 text-xs">
+                      <span>{row.label}</span>
+                      <span class="lane-badge font-mono">{row.chord}</span>
+                    </div>
+                  )}
+                </For>
+              </section>
+            </Show>
+          );
+        }}
+      </For>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal, onMount, type JSX } from "solid-js";
+import { For, Show, createEffect, createSignal, onMount, type JSX } from "solid-js";
 
 import type { AgentChoice } from "../bindings";
 import { daemonCall, type ConfigView } from "../ipc/rpc";
@@ -7,6 +7,7 @@ import { applyAccent } from "../theme";
 import ColorField from "./controls/ColorField";
 import Select from "./controls/Select";
 import Switch from "./controls/Switch";
+import KeyboardHelp from "./KeyboardHelp";
 import Modal from "./Modal";
 
 export type SettingsTab = "general" | "notifications" | "appearance" | "keyboard";
@@ -76,6 +77,14 @@ function TextField(props: {
 
 export default function SettingsModal(props: SettingsModalProps) {
   const [tab, setTab] = createSignal<SettingsTab>(props.initialTab ?? "general");
+
+  // Keep the visible tab in sync if the opener changes it. Today the shortcut handler cannot
+  // fire while a modal is open, so this only matters if that guard ever relaxes, but a tab
+  // signal that silently ignores its own prop is a trap worth closing.
+  createEffect(() => {
+    const requested = props.initialTab;
+    if (requested) setTab(requested);
+  });
   const [config, setConfig] = createSignal<ConfigView | null>(null);
   const [agents, setAgents] = createSignal<AgentChoice[]>([]);
   const [error, setError] = createSignal<string | null>(null);
@@ -266,7 +275,7 @@ export default function SettingsModal(props: SettingsModalProps) {
             <Show when={tab() === "keyboard"}>
               <section class="space-y-3">
                 <p class="section-label text-signal">Keyboard</p>
-                <p class="text-xs text-muted">Keyboard reference arrives with the help component.</p>
+                <KeyboardHelp />
               </section>
             </Show>
           </div>

--- a/apps/desktop/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/components/SettingsModal.tsx
@@ -4,11 +4,24 @@ import type { AgentChoice } from "../bindings";
 import { daemonCall, type ConfigView } from "../ipc/rpc";
 import { checkForUpdate, type AvailableUpdate, type UpdateProgress } from "../ipc/updater";
 import { applyAccent } from "../theme";
+import ColorField from "./controls/ColorField";
+import Select from "./controls/Select";
+import Switch from "./controls/Switch";
 import Modal from "./Modal";
+
+export type SettingsTab = "general" | "notifications" | "appearance" | "keyboard";
 
 interface SettingsModalProps {
   onClose: () => void;
+  initialTab?: SettingsTab;
 }
+
+const TABS: Array<{ id: SettingsTab; label: string }> = [
+  { id: "general", label: "General" },
+  { id: "notifications", label: "Notifications" },
+  { id: "appearance", label: "Appearance" },
+  { id: "keyboard", label: "Keyboard" },
+];
 
 const NOTIFY_TOGGLES: Array<[keyof ConfigView, string]> = [
   ["notify_needs_you", "Needs you"],
@@ -30,19 +43,16 @@ const GENERAL_TOGGLES: Array<[keyof ConfigView, string]> = [
   ["embedded_pty", "Embedded terminal renderer"],
 ];
 
-function Toggle(props: { label: string; checked: boolean; disabled?: boolean; onChange: (value: boolean) => void }) {
-  return (
-    <label class="flex items-center justify-between rounded border border-line px-3 py-2 text-xs" classList={{ "opacity-50": props.disabled }}>
-      <span>{props.label}</span>
-      <input
-        type="checkbox"
-        class="accent-signal"
-        checked={props.checked}
-        disabled={props.disabled}
-        onChange={(event) => props.onChange(event.currentTarget.checked)}
-      />
-    </label>
-  );
+/// Builds Select options from the detected agents, plus a "Default" empty option and, if the
+/// currently configured value is not among the detected agents (a custom name entered before
+/// this control existed, or one no longer on PATH), a fallback option that preserves it.
+function agentSelectOptions(agents: AgentChoice[], current: string | null | undefined): Array<{ value: string; label: string }> {
+  const options = [{ value: "", label: "Default" }, ...agents.map((choice) => ({ value: choice.name, label: choice.name }))];
+  const value = current ?? "";
+  if (value && !options.some((option) => option.value === value)) {
+    options.push({ value, label: value });
+  }
+  return options;
 }
 
 function TextField(props: {
@@ -50,7 +60,6 @@ function TextField(props: {
   value: string;
   onInput: (value: string) => void;
   placeholder?: string;
-  list?: string;
 }) {
   return (
     <label class="block">
@@ -59,7 +68,6 @@ function TextField(props: {
         class="settings-input"
         value={props.value}
         placeholder={props.placeholder}
-        list={props.list}
         onInput={(event) => props.onInput(event.currentTarget.value)}
       />
     </label>
@@ -67,6 +75,7 @@ function TextField(props: {
 }
 
 export default function SettingsModal(props: SettingsModalProps) {
+  const [tab, setTab] = createSignal<SettingsTab>(props.initialTab ?? "general");
   const [config, setConfig] = createSignal<ConfigView | null>(null);
   const [agents, setAgents] = createSignal<AgentChoice[]>([]);
   const [error, setError] = createSignal<string | null>(null);
@@ -163,67 +172,103 @@ export default function SettingsModal(props: SettingsModalProps) {
 
   return (
     <Modal title="Settings" subtitle="Preferences are stored by the daemon and shared with the TUI." width="min(44rem, 95vw)" onClose={props.onClose} footer={footer()}>
+      {/* The Modal body scrolls (overflow-y-auto with px-5 py-4 padding); this strip cancels that
+          padding and sticks to the top of the scrollport so the tabs stay reachable while the
+          section below scrolls, without changing Modal.tsx's shared layout. */}
+      <div class="sticky -top-4 z-10 -mx-5 -mt-4 mb-4 border-b border-line bg-surface px-5 pt-4 pb-2">
+        <div class="flex items-center gap-1" role="tablist" aria-label="Settings sections">
+          <For each={TABS}>
+            {(item) => (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab() === item.id}
+                class={`focus-ring rounded px-2 py-1 font-mono text-[0.52rem] uppercase ${tab() === item.id ? "bg-signal/10 text-signal" : "text-muted"}`}
+                onClick={() => setTab(item.id)}
+              >
+                {item.label}
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+
       <Show when={error()}>
         <p class="mb-4 rounded-md border border-fault/40 bg-fault/8 p-2 text-xs text-fault">{error()}</p>
       </Show>
       <Show when={config()} fallback={<p class="text-sm text-muted">Loading settings…</p>}>
         {(settings) => (
           <div class="space-y-6">
-            <datalist id="agent-choices">
-              <For each={agents()}>{(choice) => <option value={choice.name} />}</For>
-            </datalist>
+            <Show when={tab() === "general"}>
+              <section class="space-y-3">
+                <p class="section-label text-signal">General</p>
+                <Select
+                  label="Default agent"
+                  value={String(settings().default_agent ?? "")}
+                  options={agentSelectOptions(agents(), settings().default_agent)}
+                  onChange={(value) => patch({ default_agent: value || null })}
+                />
+                <TextField label="Worktree template" value={settings().worktree_template} onInput={(value) => patch({ worktree_template: value })} />
+                <TextField label="Auto-continue message" value={settings().auto_continue_message} onInput={(value) => patch({ auto_continue_message: value })} />
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <For each={GENERAL_TOGGLES}>
+                    {([key, label]) => <Switch label={label} checked={Boolean(settings()[key])} onChange={(value) => patch({ [key]: value } as Partial<ConfigView>)} />}
+                  </For>
+                </div>
+              </section>
 
-            <section class="space-y-3">
-              <p class="section-label text-signal">General</p>
-              <div class="grid gap-3 sm:grid-cols-2">
-                <TextField label="Accent" value={String(settings().accent ?? "")} placeholder="cyan or #rrggbb or mono" onInput={(value) => patch({ accent: value })} />
-                <TextField label="Default agent" value={String(settings().default_agent ?? "")} list="agent-choices" placeholder="claude-code" onInput={(value) => patch({ default_agent: value || null })} />
-              </div>
-              <TextField label="Worktree template" value={settings().worktree_template} onInput={(value) => patch({ worktree_template: value })} />
-              <TextField label="Auto-continue message" value={settings().auto_continue_message} onInput={(value) => patch({ auto_continue_message: value })} />
-              <div class="grid gap-2 sm:grid-cols-2">
-                <For each={GENERAL_TOGGLES}>
-                  {([key, label]) => <Toggle label={label} checked={Boolean(settings()[key])} onChange={(value) => patch({ [key]: value } as Partial<ConfigView>)} />}
-                </For>
-              </div>
-            </section>
+              <section class="space-y-3 border-t border-line pt-4">
+                <p class="section-label text-signal">Updates</p>
+                <div class="flex items-center gap-3">
+                  <button type="button" class="focus-ring rounded border border-line px-3 py-2 font-mono text-[0.58rem] uppercase text-muted disabled:opacity-50" disabled={checking()} onClick={() => void checkForUpdates()}>
+                    {checking() ? "Checking…" : "Check for updates"}
+                  </button>
+                  <Show when={availableUpdate()}>
+                    {(update) => (
+                      <button type="button" class="focus-ring rounded bg-signal px-3 py-2 font-mono text-[0.58rem] font-semibold uppercase text-background disabled:opacity-50" disabled={checking()} onClick={() => void installUpdate()}>
+                        Install {update().version} and restart
+                      </button>
+                    )}
+                  </Show>
+                  <Show when={progress()?.total}>
+                    <progress class="h-1.5 flex-1 accent-signal" max={progress()!.total} value={progress()!.downloaded} />
+                  </Show>
+                </div>
+              </section>
+            </Show>
 
-            <section class="space-y-3">
-              <p class="section-label text-signal">Notifications</p>
-              <Toggle label="Enable notifications" checked={settings().notify_enabled} onChange={(value) => patch({ notify_enabled: value })} />
-              <div class="grid gap-2 sm:grid-cols-2">
-                <For each={NOTIFY_TOGGLES}>
-                  {([key, label]) => <Toggle label={label} checked={Boolean(settings()[key])} disabled={!settings().notify_enabled} onChange={(value) => patch({ [key]: value } as Partial<ConfigView>)} />}
-                </For>
-              </div>
-            </section>
+            <Show when={tab() === "notifications"}>
+              <section class="space-y-3">
+                <p class="section-label text-signal">Notifications</p>
+                <Switch label="Enable notifications" checked={settings().notify_enabled} onChange={(value) => patch({ notify_enabled: value })} />
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <For each={NOTIFY_TOGGLES}>
+                    {([key, label]) => <Switch label={label} checked={Boolean(settings()[key])} disabled={!settings().notify_enabled} onChange={(value) => patch({ [key]: value } as Partial<ConfigView>)} />}
+                  </For>
+                </div>
+              </section>
+            </Show>
 
-            <section class="space-y-3">
-              <p class="section-label text-signal">Orchestrator</p>
-              <div class="grid gap-3 sm:grid-cols-2">
-                <TextField label="Repomind agent" value={String(settings().orchestrator_agent ?? "")} list="agent-choices" placeholder="claude" onInput={(value) => patch({ orchestrator_agent: value || null })} />
+            <Show when={tab() === "appearance"}>
+              <section class="space-y-3">
+                <p class="section-label text-signal">Appearance</p>
+                <ColorField label="Accent" value={String(settings().accent ?? "")} onChange={(value) => patch({ accent: value })} />
+                <Select
+                  label="Repomind agent"
+                  value={String(settings().orchestrator_agent ?? "")}
+                  options={agentSelectOptions(agents(), settings().orchestrator_agent)}
+                  onChange={(value) => patch({ orchestrator_agent: value || null })}
+                />
                 <TextField label="Repomind model" value={String(settings().orchestrator_model ?? "")} placeholder="opus / sonnet" onInput={(value) => patch({ orchestrator_model: value || null })} />
-              </div>
-            </section>
+              </section>
+            </Show>
 
-            <section class="space-y-3 border-t border-line pt-4">
-              <p class="section-label text-signal">Updates</p>
-              <div class="flex items-center gap-3">
-                <button type="button" class="focus-ring rounded border border-line px-3 py-2 font-mono text-[0.58rem] uppercase text-muted disabled:opacity-50" disabled={checking()} onClick={() => void checkForUpdates()}>
-                  {checking() ? "Checking…" : "Check for updates"}
-                </button>
-                <Show when={availableUpdate()}>
-                  {(update) => (
-                    <button type="button" class="focus-ring rounded bg-signal px-3 py-2 font-mono text-[0.58rem] font-semibold uppercase text-background disabled:opacity-50" disabled={checking()} onClick={() => void installUpdate()}>
-                      Install {update().version} and restart
-                    </button>
-                  )}
-                </Show>
-                <Show when={progress()?.total}>
-                  <progress class="h-1.5 flex-1 accent-signal" max={progress()!.total} value={progress()!.downloaded} />
-                </Show>
-              </div>
-            </section>
+            <Show when={tab() === "keyboard"}>
+              <section class="space-y-3">
+                <p class="section-label text-signal">Keyboard</p>
+                <p class="text-xs text-muted">Keyboard reference arrives with the help component.</p>
+              </section>
+            </Show>
           </div>
         )}
       </Show>

--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -216,6 +216,14 @@ export default function TerminalPane(props: TerminalPaneProps) {
           openFind();
           return false;
         }
+        // Shift+Escape hands focus back to the app shell so the fleet list can be driven by
+        // keyboard. Plain Escape still goes to the agent: Claude Code uses it to interrupt.
+        if (event.key === "Escape" && event.shiftKey) {
+          event.preventDefault();
+          terminal?.blur();
+          document.querySelector<HTMLElement>('nav[aria-label="Fleet"]')?.focus();
+          return false;
+        }
         const translated = translateKeyboardKey(event);
         if (!translated) return true;
         event.preventDefault();

--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -10,6 +10,7 @@ import { Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import { daemonCall } from "../ipc/rpc";
 import {
   createInputCoalescer,
+  isTerminalReleaseChord,
   takeWheelBatch,
   terminalPointerCell,
   translateKeyboardKey,
@@ -218,7 +219,7 @@ export default function TerminalPane(props: TerminalPaneProps) {
         }
         // Shift+Escape hands focus back to the app shell so the fleet list can be driven by
         // keyboard. Plain Escape still goes to the agent: Claude Code uses it to interrupt.
-        if (event.key === "Escape" && event.shiftKey) {
+        if (isTerminalReleaseChord(event)) {
           event.preventDefault();
           terminal?.blur();
           document.querySelector<HTMLElement>('nav[aria-label="Fleet"]')?.focus();

--- a/apps/desktop/src/components/TerminalWorkspace.tsx
+++ b/apps/desktop/src/components/TerminalWorkspace.tsx
@@ -102,9 +102,7 @@ export default function TerminalWorkspace(props: TerminalWorkspaceProps) {
     setOpeningShell(true);
     setWorkspaceError(null);
     try {
-      await props.workspace.openShell();
-    } catch (error) {
-      setWorkspaceError(error instanceof Error ? error.message : String(error));
+      await props.workspace.openShell(setWorkspaceError);
     } finally {
       setOpeningShell(false);
     }

--- a/apps/desktop/src/components/TerminalWorkspace.tsx
+++ b/apps/desktop/src/components/TerminalWorkspace.tsx
@@ -4,71 +4,32 @@ import { daemonCall } from "../ipc/rpc";
 import type { TerminalRenderer } from "../ipc/term";
 import type { ActionsStore } from "../stores/actions";
 import type { FleetStore } from "../stores/fleet";
+import type { WorkspaceLayout, WorkspaceStore } from "../stores/workspace";
 import {
-  dedupe,
-  stabilizeTargets,
   warmTargetWindows,
   type PaneTarget,
 } from "./terminalTargets";
 
 const TerminalPane = lazy(() => import("./TerminalPane"));
 
-export type WorkspaceLayout = "focused" | "split" | "grid";
-
 interface TerminalWorkspaceProps {
   fleet: FleetStore;
   actions: ActionsStore;
-}
-
-function readLayout(): WorkspaceLayout {
-  const value = localStorage.getItem("repomon.workspace.layout");
-  return value === "split" || value === "grid" ? value : "focused";
-}
-
-function readRenderer(): TerminalRenderer {
-  const value = localStorage.getItem("repomon.terminal.renderer");
-  // Default to "auto" (WebGL with automatic DOM fallback on context loss/failure): the DOM
-  // renderer re-lays-out on every frame and is by far the slowest way to run a busy terminal.
-  return value === "webgl" || value === "dom" ? value : "auto";
+  workspace: WorkspaceStore;
 }
 
 export default function TerminalWorkspace(props: TerminalWorkspaceProps) {
-  const [layout, setLayout] = createSignal<WorkspaceLayout>(readLayout());
-  const [renderer, setRenderer] = createSignal<TerminalRenderer>(readRenderer());
-  const [activeWindow, setActiveWindow] = createSignal<string | null>(null);
   const [openingShell, setOpeningShell] = createSignal(false);
   const [closingShell, setClosingShell] = createSignal<string | null>(null);
   const [workspaceError, setWorkspaceError] = createSignal<string | null>(null);
   const [warmWindows, setWarmWindows] = createSignal<string[]>([]);
 
-  // Fleet polls every second and hands us a brand-new lanes array each time. Reconcile the
-  // rebuilt targets against this cache so each window keeps a stable object reference, and the
-  // reference-keyed <For> below keeps its TerminalPane (and its byte watch) mounted instead of
-  // tearing it down every poll.
-  const targetCache = new Map<string, PaneTarget>();
-  // `equals` keeps the previous array when the window set is unchanged (stabilizeTargets
-  // reuses object refs), so the 2s fleet poll stops cascading through laneTargets /
-  // visibleTargets / the viewport.set effect when nothing actually changed.
-  const sameTargets = (a: PaneTarget[], b: PaneTarget[]) =>
-    a.length === b.length && a.every((target, index) => target === b[index]);
-  const targets = createMemo(() => stabilizeTargets(targetCache, dedupe(props.fleet.lanes().flatMap((lane) => [
-    ...lane.agent_sessions.flatMap((agent, index): PaneTarget[] => agent.tmux_window ? [{
-      laneId: lane.id,
-      window: agent.tmux_window,
-      label: agent.custom_label ?? agent.title ?? `${agent.agent} ${index + 1}`,
-      shell: false,
-      sessionId: agent.session_id,
-    }] : []),
-    ...props.fleet.terminals()
-      .filter((terminal) => terminal.lane_id === lane.id)
-      .map((terminal): PaneTarget => ({
-        laneId: lane.id,
-        window: terminal.id,
-        label: `shell ${terminal.id.split("-").slice(-1)[0]}`,
-        shell: true,
-        sessionId: null,
-      })),
-  ]))), undefined, { equals: sameTargets });
+  const layout = () => props.workspace.layout();
+  const renderer = () => props.workspace.renderer();
+  const activeWindow = () => props.workspace.activeWindow();
+  const setActiveWindow = props.workspace.setActiveWindow;
+  const targets = () => props.workspace.targets();
+  const laneTargets = () => props.workspace.laneTargets();
 
   // Labels read reactively from the fleet store: pane targets deliberately keep stable object
   // identity across polls (so mounted panes never remount), which means a mutated target.label
@@ -85,8 +46,6 @@ export default function TerminalWorkspace(props: TerminalWorkspaceProps) {
     return map;
   });
   const labelOf = (target: PaneTarget) => labelByWindow().get(target.window) ?? target.label;
-
-  const laneTargets = createMemo(() => targets().filter((target) => target.laneId === props.fleet.selectedLaneId()));
 
   createEffect(() => {
     const available = laneTargets();
@@ -135,25 +94,15 @@ export default function TerminalWorkspace(props: TerminalWorkspaceProps) {
     }).catch(() => undefined);
   });
 
-  function chooseLayout(next: WorkspaceLayout) {
-    setLayout(next);
-    localStorage.setItem("repomon.workspace.layout", next);
-  }
-
-  function chooseRenderer(next: TerminalRenderer) {
-    setRenderer(next);
-    localStorage.setItem("repomon.terminal.renderer", next);
-  }
+  const chooseLayout = props.workspace.chooseLayout;
+  const chooseRenderer = props.workspace.chooseRenderer;
 
   async function openShell() {
-    const laneId = props.fleet.selectedLaneId();
-    if (laneId === null) return;
+    if (props.fleet.selectedLaneId() === null) return;
     setOpeningShell(true);
     setWorkspaceError(null);
     try {
-      const terminal = await daemonCall("terminal.open", { lane_id: laneId });
-      await props.fleet.refresh();
-      setActiveWindow(terminal.id);
+      await props.workspace.openShell();
     } catch (error) {
       setWorkspaceError(error instanceof Error ? error.message : String(error));
     } finally {

--- a/apps/desktop/src/components/controls/ColorField.test.tsx
+++ b/apps/desktop/src/components/controls/ColorField.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import ColorField from "./ColorField";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ColorField", () => {
+  it("calls onChange with the preset name when a swatch button is activated", () => {
+    const [value, setValue] = createSignal("cyan");
+    render(() => <ColorField label="Accent" value={value()} onChange={setValue} />);
+
+    const cyan = screen.getByRole("button", { name: "cyan" });
+    expect(cyan).toHaveAttribute("aria-pressed", "true");
+
+    const violet = screen.getByRole("button", { name: "violet" });
+    expect(violet).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(violet);
+    expect(value()).toBe("violet");
+  });
+
+  it("calls onChange with mono when the mono swatch is activated", () => {
+    const [value, setValue] = createSignal("cyan");
+    render(() => <ColorField label="Accent" value={value()} onChange={setValue} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "mono" }));
+    expect(value()).toBe("mono");
+  });
+
+  it("calls onChange with typed text from the custom accent input", () => {
+    const [value, setValue] = createSignal("cyan");
+    render(() => <ColorField label="Accent" value={value()} onChange={setValue} />);
+
+    const custom = screen.getByLabelText("Custom accent");
+    fireEvent.input(custom, { target: { value: "#ff00aa" } });
+    expect(value()).toBe("#ff00aa");
+  });
+});

--- a/apps/desktop/src/components/controls/ColorField.tsx
+++ b/apps/desktop/src/components/controls/ColorField.tsx
@@ -1,0 +1,47 @@
+import { For } from "solid-js";
+
+import { ACCENTS } from "../../theme";
+
+export default function ColorField(props: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div class="block">
+      <span class="section-label">{props.label}</span>
+      <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
+        <For each={Object.entries(ACCENTS)}>
+          {([name, color]) => (
+            <button
+              type="button"
+              aria-label={name}
+              aria-pressed={props.value === name}
+              title={name}
+              class="focus-ring h-5 w-5 rounded-full border"
+              classList={{ "border-foreground": props.value === name, "border-line": props.value !== name }}
+              style={{ background: color }}
+              onClick={() => props.onChange(name)}
+            />
+          )}
+        </For>
+        <button
+          type="button"
+          aria-label="mono"
+          aria-pressed={props.value === "mono"}
+          title="mono"
+          class="focus-ring h-5 w-5 rounded-full border bg-raised"
+          classList={{ "border-foreground": props.value === "mono", "border-line": props.value !== "mono" }}
+          onClick={() => props.onChange("mono")}
+        />
+        <input
+          class="settings-input mt-0 ml-1 w-28"
+          value={props.value}
+          placeholder="#rrggbb"
+          aria-label="Custom accent"
+          onInput={(event) => props.onChange(event.currentTarget.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/controls/Select.test.tsx
+++ b/apps/desktop/src/components/controls/Select.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import Select from "./Select";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Select", () => {
+  it("calls onChange with the chosen option's value when the user picks it", () => {
+    const [value, setValue] = createSignal("claude-code");
+    render(() => (
+      <Select
+        label="Default agent"
+        value={value()}
+        options={[
+          { value: "claude-code", label: "claude-code" },
+          { value: "codex", label: "codex" },
+        ]}
+        onChange={setValue}
+      />
+    ));
+
+    const control = screen.getByRole("combobox", { name: "Default agent" });
+    fireEvent.change(control, { target: { value: "codex" } });
+    expect(value()).toBe("codex");
+  });
+});

--- a/apps/desktop/src/components/controls/Select.tsx
+++ b/apps/desktop/src/components/controls/Select.tsx
@@ -1,0 +1,17 @@
+import { For } from "solid-js";
+
+export default function Select(props: {
+  label: string;
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label class="block">
+      <span class="section-label">{props.label}</span>
+      <select class="settings-input" value={props.value} onChange={(event) => props.onChange(event.currentTarget.value)}>
+        <For each={props.options}>{(option) => <option value={option.value}>{option.label}</option>}</For>
+      </select>
+    </label>
+  );
+}

--- a/apps/desktop/src/components/controls/Switch.test.tsx
+++ b/apps/desktop/src/components/controls/Switch.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import Switch from "./Switch";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Switch", () => {
+  it("is reachable as a role=switch control and calls onChange with the inverted value", () => {
+    const [checked, setChecked] = createSignal(false);
+    render(() => <Switch label="Enable notifications" checked={checked()} onChange={setChecked} />);
+
+    const control = screen.getByRole("switch", { name: "Enable notifications" });
+    expect(control).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(control);
+    expect(checked()).toBe(true);
+  });
+
+  it("toggles back off on a second activation", () => {
+    const [checked, setChecked] = createSignal(true);
+    render(() => <Switch label="Play sound" checked={checked()} onChange={setChecked} />);
+
+    const control = screen.getByRole("switch", { name: "Play sound" });
+    expect(control).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(control);
+    expect(checked()).toBe(false);
+  });
+
+  it("does not fire onChange when disabled", () => {
+    let calls = 0;
+    render(() => <Switch label="Locked" checked={false} disabled onChange={() => { calls += 1; }} />);
+
+    const control = screen.getByRole("switch", { name: "Locked" });
+    expect(control).toBeDisabled();
+    fireEvent.click(control);
+    expect(calls).toBe(0);
+  });
+});

--- a/apps/desktop/src/components/controls/Switch.tsx
+++ b/apps/desktop/src/components/controls/Switch.tsx
@@ -1,0 +1,27 @@
+export default function Switch(props: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div class="flex items-center justify-between rounded border border-line px-3 py-2 text-xs" classList={{ "opacity-50": props.disabled }}>
+      <span>{props.label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.checked}
+        aria-label={props.label}
+        disabled={props.disabled}
+        class="focus-ring relative h-4 w-8 shrink-0 rounded-full border border-line transition-colors"
+        classList={{ "bg-signal/70": props.checked, "bg-raised": !props.checked }}
+        onClick={() => props.onChange(!props.checked)}
+      >
+        <span
+          class="absolute top-0.5 h-2.5 w-2.5 rounded-full bg-foreground transition-all"
+          classList={{ "left-4": props.checked, "left-0.5": !props.checked }}
+        />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/ipc/term.test.ts
+++ b/apps/desktop/src/ipc/term.test.ts
@@ -4,6 +4,7 @@ import { DaemonRpcError } from "./rpc";
 import {
   asTransportError,
   createTerminalFrameGate,
+  isTerminalReleaseChord,
   takeWheelBatch,
   terminalPointerCell,
   translateKeyboardKey,
@@ -63,6 +64,20 @@ describe("terminal key translation", () => {
     expect(translateKeyboardKey(key("ArrowLeft", { altKey: true }))).toEqual({ key: "M-Left", literal: false });
     expect(translateKeyboardKey(key("Tab", { shiftKey: true }))).toEqual({ key: "BTab", literal: false });
     expect(translateKeyboardKey(key("Escape"))).toEqual({ key: "Escape", literal: false });
+  });
+});
+
+describe("isTerminalReleaseChord", () => {
+  it("releases on shift+escape", () => {
+    expect(isTerminalReleaseChord(new KeyboardEvent("keydown", { key: "Escape", shiftKey: true }))).toBe(true);
+  });
+
+  it("leaves a plain escape for the agent, which uses it to interrupt", () => {
+    expect(isTerminalReleaseChord(new KeyboardEvent("keydown", { key: "Escape" }))).toBe(false);
+  });
+
+  it("ignores other shifted keys", () => {
+    expect(isTerminalReleaseChord(new KeyboardEvent("keydown", { key: "Enter", shiftKey: true }))).toBe(false);
   });
 });
 

--- a/apps/desktop/src/ipc/term.ts
+++ b/apps/desktop/src/ipc/term.ts
@@ -51,6 +51,13 @@ export function translateKeyboardKey(event: KeyboardEvent): TranslatedKey | null
   return { key: `${control ? "C-" : alt ? "M-" : ""}${base}`, literal: false };
 }
 
+/// True when a key event should release focus from the terminal back to the app shell.
+/// Shift is required: plain Escape must keep reaching the agent, since Claude Code uses it to
+/// interrupt its own work.
+export function isTerminalReleaseChord(event: KeyboardEvent): boolean {
+  return event.key === "Escape" && event.shiftKey;
+}
+
 /// Convert one wheel event's delta into a SIGNED, fractional number of terminal lines (positive =
 /// scroll down). The caller accumulates this across events and only emits whole lines, so a
 /// trackpad gesture (many tiny pixel deltas) scrolls proportionally instead of one line per event

--- a/apps/desktop/src/keymap.test.ts
+++ b/apps/desktop/src/keymap.test.ts
@@ -29,33 +29,45 @@ describe("matchChord", () => {
     expect(matchChord(key({ key: "?", shiftKey: true }))).toBeNull();
   });
 
-  it("matches a modifier chord on either platform modifier", () => {
-    expect(matchChord(key({ key: "e", metaKey: true }))?.id).toBe("lane.spawn");
-    expect(matchChord(key({ key: "e", ctrlKey: true }))?.id).toBe("lane.spawn");
+  it("requires Cmd on macOS and rejects a Ctrl chord there", () => {
+    expect(matchChord(key({ key: "e", metaKey: true }), "mac")?.id).toBe("lane.spawn");
+    expect(matchChord(key({ key: "e", ctrlKey: true }), "mac")).toBeNull();
+  });
+
+  it("requires Ctrl on non-macOS platforms", () => {
+    expect(matchChord(key({ key: "e", ctrlKey: true }), "other")?.id).toBe("lane.spawn");
+    expect(matchChord(key({ key: "e", metaKey: true }), "other")).toBeNull();
+  });
+
+  it("never lets a Ctrl chord reach a destructive binding on macOS", () => {
+    // Ctrl+D sends EOF to a focused terminal. On mac it must not also match lane.delete, or
+    // every agent session that reads EOF would also pop a destructive confirm dialog.
+    expect(matchChord(key({ key: "d", ctrlKey: true }), "mac")).toBeNull();
   });
 
   it("distinguishes shifted chords from their unshifted twin", () => {
-    expect(matchChord(key({ key: "n", metaKey: true }))?.id).toBe("fleet.newLane");
-    expect(matchChord(key({ key: "N", metaKey: true, shiftKey: true }))?.id).toBe("fleet.addRepo");
+    expect(matchChord(key({ key: "n", metaKey: true }), "mac")?.id).toBe("fleet.newLane");
+    expect(matchChord(key({ key: "N", metaKey: true, shiftKey: true }), "mac")?.id).toBe("fleet.addRepo");
   });
 
   it("returns null for an unbound chord", () => {
-    expect(matchChord(key({ key: "z", metaKey: true }))).toBeNull();
+    expect(matchChord(key({ key: "z", metaKey: true }), "mac")).toBeNull();
   });
 
   it("matches the settings chord, whose ad-hoc listener was removed", () => {
-    expect(matchChord(key({ key: ",", metaKey: true }))?.id).toBe("panel.settings");
+    expect(matchChord(key({ key: ",", metaKey: true }), "mac")?.id).toBe("panel.settings");
   });
 
   it("matches shifted digit chords, which report a symbol in event.key", () => {
     // Cmd+Shift+1 on a US layout delivers key "!" — only event.code still says Digit1.
-    expect(matchChord(key({ key: "!", code: "Digit1", metaKey: true, shiftKey: true }))?.id).toBe("layout.focused");
-    expect(matchChord(key({ key: "@", code: "Digit2", metaKey: true, shiftKey: true }))?.id).toBe("layout.split");
-    expect(matchChord(key({ key: "#", code: "Digit3", metaKey: true, shiftKey: true }))?.id).toBe("layout.grid");
+    expect(matchChord(key({ key: "!", code: "Digit1", metaKey: true, shiftKey: true }), "mac")?.id).toBe("layout.focused");
+    expect(matchChord(key({ key: "@", code: "Digit2", metaKey: true, shiftKey: true }), "mac")?.id).toBe("layout.split");
+    // Grid uses mod+shift+0, not mod+shift+3: that chord is the macOS screenshot shortcut.
+    expect(matchChord(key({ key: ")", code: "Digit0", metaKey: true, shiftKey: true }), "mac")?.id).toBe("layout.grid");
   });
 
   it("still matches unshifted digit chords", () => {
-    expect(matchChord(key({ key: "4", code: "Digit4", metaKey: true }))?.id).toBe("panel.extensions");
+    expect(matchChord(key({ key: "4", code: "Digit4", metaKey: true }), "mac")?.id).toBe("panel.extensions");
   });
 });
 

--- a/apps/desktop/src/keymap.test.ts
+++ b/apps/desktop/src/keymap.test.ts
@@ -26,6 +26,7 @@ describe("matchChord", () => {
     expect(matchChord(key({ key: "e" }))).toBeNull();
     expect(matchChord(key({ key: "6" }))).toBeNull();
     expect(matchChord(key({ key: "/" }))).toBeNull();
+    expect(matchChord(key({ key: "?", shiftKey: true }))).toBeNull();
   });
 
   it("matches a modifier chord on either platform modifier", () => {
@@ -40,6 +41,17 @@ describe("matchChord", () => {
 
   it("returns null for an unbound chord", () => {
     expect(matchChord(key({ key: "z", metaKey: true }))).toBeNull();
+  });
+
+  it("matches shifted digit chords, which report a symbol in event.key", () => {
+    // Cmd+Shift+1 on a US layout delivers key "!" — only event.code still says Digit1.
+    expect(matchChord(key({ key: "!", code: "Digit1", metaKey: true, shiftKey: true }))?.id).toBe("layout.focused");
+    expect(matchChord(key({ key: "@", code: "Digit2", metaKey: true, shiftKey: true }))?.id).toBe("layout.split");
+    expect(matchChord(key({ key: "#", code: "Digit3", metaKey: true, shiftKey: true }))?.id).toBe("layout.grid");
+  });
+
+  it("still matches unshifted digit chords", () => {
+    expect(matchChord(key({ key: "4", code: "Digit4", metaKey: true }))?.id).toBe("panel.extensions");
   });
 });
 

--- a/apps/desktop/src/keymap.test.ts
+++ b/apps/desktop/src/keymap.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { BINDINGS, formatChord, matchChord } from "./keymap";
+
+function key(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, ...init });
+}
+
+describe("keymap table", () => {
+  it("has no duplicate chords", () => {
+    const chords = BINDINGS.map((binding) => binding.chord);
+    expect(new Set(chords).size).toBe(chords.length);
+  });
+
+  it("every binding has an id, a label, and a section", () => {
+    for (const binding of BINDINGS) {
+      expect(binding.id.length).toBeGreaterThan(0);
+      expect(binding.label.length).toBeGreaterThan(0);
+      expect(binding.section.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("matchChord", () => {
+  it("ignores unmodified keys so typing is never intercepted", () => {
+    expect(matchChord(key({ key: "e" }))).toBeNull();
+    expect(matchChord(key({ key: "6" }))).toBeNull();
+    expect(matchChord(key({ key: "/" }))).toBeNull();
+  });
+
+  it("matches a modifier chord on either platform modifier", () => {
+    expect(matchChord(key({ key: "e", metaKey: true }))?.id).toBe("lane.spawn");
+    expect(matchChord(key({ key: "e", ctrlKey: true }))?.id).toBe("lane.spawn");
+  });
+
+  it("distinguishes shifted chords from their unshifted twin", () => {
+    expect(matchChord(key({ key: "n", metaKey: true }))?.id).toBe("fleet.newLane");
+    expect(matchChord(key({ key: "N", metaKey: true, shiftKey: true }))?.id).toBe("fleet.addRepo");
+  });
+
+  it("returns null for an unbound chord", () => {
+    expect(matchChord(key({ key: "z", metaKey: true }))).toBeNull();
+  });
+});
+
+describe("formatChord", () => {
+  it("renders platform symbols", () => {
+    expect(formatChord("mod+e", "mac")).toBe("⌘E");
+    expect(formatChord("mod+shift+m", "mac")).toBe("⌘⇧M");
+    expect(formatChord("mod+e", "other")).toBe("Ctrl+E");
+    expect(formatChord("mod+shift+m", "other")).toBe("Ctrl+Shift+M");
+  });
+});

--- a/apps/desktop/src/keymap.test.ts
+++ b/apps/desktop/src/keymap.test.ts
@@ -43,6 +43,10 @@ describe("matchChord", () => {
     expect(matchChord(key({ key: "z", metaKey: true }))).toBeNull();
   });
 
+  it("matches the settings chord, whose ad-hoc listener was removed", () => {
+    expect(matchChord(key({ key: ",", metaKey: true }))?.id).toBe("panel.settings");
+  });
+
   it("matches shifted digit chords, which report a symbol in event.key", () => {
     // Cmd+Shift+1 on a US layout delivers key "!" — only event.code still says Digit1.
     expect(matchChord(key({ key: "!", code: "Digit1", metaKey: true, shiftKey: true }))?.id).toBe("layout.focused");

--- a/apps/desktop/src/keymap.ts
+++ b/apps/desktop/src/keymap.ts
@@ -20,6 +20,7 @@ export interface Binding {
 }
 
 export const BINDINGS: Binding[] = [
+  { id: "panel.settings", chord: "mod+,", label: "Open settings", section: "Panels" },
   { id: "panel.extensions", chord: "mod+4", label: "Toggle extensions", section: "Panels" },
   { id: "panel.repomind", chord: "mod+5", label: "Toggle repomind", section: "Panels" },
   { id: "panel.theme", chord: "mod+6", label: "Cycle theme", section: "Panels" },

--- a/apps/desktop/src/keymap.ts
+++ b/apps/desktop/src/keymap.ts
@@ -1,0 +1,84 @@
+/// The single source of truth for keyboard shortcuts. The global handler in App.tsx and the
+/// Settings keyboard reference both read this table, so a new binding appears in help for free.
+///
+/// Chords are modifier-based on purpose: a focused terminal forwards every bare keystroke to the
+/// agent, so an unmodified shortcut would steal input from a running session.
+
+export type KeymapSection = "Panels" | "Layout" | "Fleet" | "Lane" | "Agents" | "Help";
+
+/// A guard the handler checks before dispatching. "lane" needs a selected lane; "agent" also
+/// needs that lane to have a managed agent.
+export type Guard = "lane" | "agent";
+
+export interface Binding {
+  id: string;
+  /// Normalized chord, e.g. "mod+e", "mod+shift+m". "mod" is Cmd on macOS, Ctrl elsewhere.
+  chord: string;
+  label: string;
+  section: KeymapSection;
+  when?: Guard;
+}
+
+export const BINDINGS: Binding[] = [
+  { id: "panel.extensions", chord: "mod+4", label: "Toggle extensions", section: "Panels" },
+  { id: "panel.repomind", chord: "mod+5", label: "Toggle repomind", section: "Panels" },
+  { id: "panel.theme", chord: "mod+6", label: "Cycle theme", section: "Panels" },
+
+  { id: "layout.focused", chord: "mod+shift+1", label: "Focused layout", section: "Layout" },
+  { id: "layout.split", chord: "mod+shift+2", label: "Split layout", section: "Layout" },
+  { id: "layout.grid", chord: "mod+shift+3", label: "Grid layout", section: "Layout" },
+
+  { id: "fleet.filter", chord: "mod+/", label: "Filter the fleet", section: "Fleet" },
+  { id: "fleet.urgent", chord: "mod+u", label: "Show only lanes needing attention", section: "Fleet" },
+  { id: "fleet.refresh", chord: "mod+r", label: "Refresh", section: "Fleet" },
+  { id: "fleet.newLane", chord: "mod+n", label: "New lane", section: "Fleet" },
+  { id: "fleet.addRepo", chord: "mod+shift+n", label: "Add repository", section: "Fleet" },
+  { id: "fleet.jumpUrgent", chord: "mod+g", label: "Jump to a lane needing attention", section: "Fleet" },
+
+  { id: "lane.spawn", chord: "mod+e", label: "Spawn agent", section: "Lane", when: "lane" },
+  { id: "lane.terminal", chord: "mod+t", label: "Open terminal", section: "Lane", when: "lane" },
+  { id: "lane.pin", chord: "mod+p", label: "Pin or unpin lane", section: "Lane", when: "lane" },
+  { id: "lane.delete", chord: "mod+d", label: "Delete lane", section: "Lane", when: "lane" },
+  { id: "lane.merge", chord: "mod+shift+m", label: "Merge lane", section: "Lane", when: "lane" },
+  { id: "lane.stop", chord: "mod+.", label: "Stop agent", section: "Lane", when: "agent" },
+
+  { id: "agents.prev", chord: "mod+[", label: "Previous agent tab", section: "Agents", when: "lane" },
+  { id: "agents.next", chord: "mod+]", label: "Next agent tab", section: "Agents", when: "lane" },
+
+  { id: "help.open", chord: "mod+?", label: "Keyboard shortcuts", section: "Help" },
+];
+
+const BY_CHORD = new Map(BINDINGS.map((binding) => [binding.chord, binding]));
+
+function isMac(platform?: string): boolean {
+  if (platform) return platform === "mac";
+  return typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+}
+
+/// Normalize an event to a chord string, or null when no platform modifier is held. Returning
+/// null for unmodified keys is what keeps ordinary typing (and a focused terminal) untouched.
+export function chordOf(event: KeyboardEvent): string | null {
+  if (!event.metaKey && !event.ctrlKey) return null;
+  // "?" already implies shift on most layouts, so do not double-encode it.
+  const key = event.key === "?" ? "?" : event.key.toLowerCase();
+  const shift = event.shiftKey && key !== "?" ? "shift+" : "";
+  return `mod+${shift}${key}`;
+}
+
+export function matchChord(event: KeyboardEvent): Binding | null {
+  const chord = chordOf(event);
+  return chord ? BY_CHORD.get(chord) ?? null : null;
+}
+
+const SYMBOLS: Record<string, string> = { "[": "[", "]": "]", "/": "/", ".": ".", "?": "?" };
+
+/// Render a chord for display: "mod+shift+m" becomes "⌘⇧M" on macOS, "Ctrl+Shift+M" elsewhere.
+export function formatChord(chord: string, platform?: string): string {
+  const parts = chord.split("+");
+  const key = parts[parts.length - 1];
+  const shift = parts.includes("shift");
+  const label = SYMBOLS[key] ?? key.toUpperCase();
+  return isMac(platform)
+    ? `⌘${shift ? "⇧" : ""}${label}`
+    : `Ctrl+${shift ? "Shift+" : ""}${label}`;
+}

--- a/apps/desktop/src/keymap.ts
+++ b/apps/desktop/src/keymap.ts
@@ -59,8 +59,12 @@ function isMac(platform?: string): boolean {
 /// null for unmodified keys is what keeps ordinary typing (and a focused terminal) untouched.
 export function chordOf(event: KeyboardEvent): string | null {
   if (!event.metaKey && !event.ctrlKey) return null;
+  // Digits come from `code`, not `key`: shift turns "1" into "!" (and non-US layouts move the
+  // number row entirely), so keying off `event.key` would make every shifted digit chord
+  // unreachable while still rendering as available in the help reference.
+  const digit = event.code.startsWith("Digit") ? event.code.slice(5) : null;
   // "?" already implies shift on most layouts, so do not double-encode it.
-  const key = event.key === "?" ? "?" : event.key.toLowerCase();
+  const key = digit ?? (event.key === "?" ? "?" : event.key.toLowerCase());
   const shift = event.shiftKey && key !== "?" ? "shift+" : "";
   return `mod+${shift}${key}`;
 }

--- a/apps/desktop/src/keymap.ts
+++ b/apps/desktop/src/keymap.ts
@@ -27,7 +27,8 @@ export const BINDINGS: Binding[] = [
 
   { id: "layout.focused", chord: "mod+shift+1", label: "Focused layout", section: "Layout" },
   { id: "layout.split", chord: "mod+shift+2", label: "Split layout", section: "Layout" },
-  { id: "layout.grid", chord: "mod+shift+3", label: "Grid layout", section: "Layout" },
+  // Not mod+shift+3: that chord is the macOS system screenshot shortcut and never reaches the app.
+  { id: "layout.grid", chord: "mod+shift+0", label: "Grid layout", section: "Layout" },
 
   { id: "fleet.filter", chord: "mod+/", label: "Filter the fleet", section: "Fleet" },
   { id: "fleet.urgent", chord: "mod+u", label: "Show only lanes needing attention", section: "Fleet" },
@@ -51,15 +52,23 @@ export const BINDINGS: Binding[] = [
 
 const BY_CHORD = new Map(BINDINGS.map((binding) => [binding.chord, binding]));
 
-function isMac(platform?: string): boolean {
+export function isMac(platform?: string): boolean {
   if (platform) return platform === "mac";
   return typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
 }
 
-/// Normalize an event to a chord string, or null when no platform modifier is held. Returning
-/// null for unmodified keys is what keeps ordinary typing (and a focused terminal) untouched.
-export function chordOf(event: KeyboardEvent): string | null {
-  if (!event.metaKey && !event.ctrlKey) return null;
+/// Normalize an event to a chord string, or null when the platform modifier is not held. Mod is
+/// Cmd on macOS and Ctrl elsewhere; the two are never interchangeable. A focused terminal
+/// forwards Ctrl chords straight to the agent (EOF, text navigation, and so on), so on macOS a
+/// held Ctrl must never also satisfy "mod", or the same keystroke would fire a GUI action in
+/// addition to reaching the agent. Returning null for unmodified keys is what keeps ordinary
+/// typing untouched.
+export function chordOf(event: KeyboardEvent, platform?: string): string | null {
+  if (isMac(platform)) {
+    if (!event.metaKey || event.ctrlKey) return null;
+  } else if (!event.ctrlKey) {
+    return null;
+  }
   // Digits come from `code`, not `key`: shift turns "1" into "!" (and non-US layouts move the
   // number row entirely), so keying off `event.key` would make every shifted digit chord
   // unreachable while still rendering as available in the help reference.
@@ -70,8 +79,8 @@ export function chordOf(event: KeyboardEvent): string | null {
   return `mod+${shift}${key}`;
 }
 
-export function matchChord(event: KeyboardEvent): Binding | null {
-  const chord = chordOf(event);
+export function matchChord(event: KeyboardEvent, platform?: string): Binding | null {
+  const chord = chordOf(event, platform);
   return chord ? BY_CHORD.get(chord) ?? null : null;
 }
 

--- a/apps/desktop/src/stores/actions.test.ts
+++ b/apps/desktop/src/stores/actions.test.ts
@@ -1,0 +1,81 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { AgentSession, Lane } from "../bindings";
+import { createActionsStore } from "./actions";
+import type { FleetStore } from "./fleet";
+
+const calls = vi.hoisted(() => ({ list: [] as Array<{ method: string; params: unknown }> }));
+
+vi.mock("../ipc/rpc", () => ({
+  daemonCall: (method: string, params: unknown) => {
+    calls.list.push({ method, params });
+    return Promise.resolve(null);
+  },
+}));
+
+function lane(overrides: Partial<Lane> = {}): Lane {
+  return {
+    id: 7,
+    repo: { id: 2, path: "/code/r", name: "r", added_at: "2026-07-26T00:00:00Z", worktree_root_template: null },
+    worktree: { id: 3, repo_id: 2, path: "/code/r-wt", branch: "feat/x", head: "abc", is_main: false, name: "x" },
+    state: { worktree_id: 3, head: "abc", branch: "feat/x", upstream: null, ahead: 0, behind: 0, dirty: { staged: 0, unstaged: 0, untracked: 0 }, last_commit_at: null, locked: false, prunable: false, last_change_at: null },
+    agent_sessions: [],
+    last_activity_at: "2026-07-26T00:00:00Z",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+function fleetStub(): FleetStore {
+  return { refresh: vi.fn().mockResolvedValue(undefined) } as unknown as FleetStore;
+}
+
+beforeEach(() => {
+  calls.list = [];
+});
+
+describe("lane operations", () => {
+  it("pin toggles the current pinned state and refreshes", async () => {
+    await createRoot(async (dispose) => {
+      const fleet = fleetStub();
+      const actions = createActionsStore(fleet);
+      await actions.pinLane(lane({ pinned: false }));
+      expect(calls.list[0]).toEqual({ method: "agent.pin", params: { lane_id: 7, pinned: true } });
+      expect(fleet.refresh).toHaveBeenCalled();
+      dispose();
+    });
+  });
+
+  it("delete and merge go through confirm rather than firing immediately", async () => {
+    await createRoot(async (dispose) => {
+      const actions = createActionsStore(fleetStub());
+
+      actions.deleteLane(lane());
+      const del = actions.confirmOptions();
+      expect(del?.danger).toBe(true);
+      expect(calls.list).toHaveLength(0); // nothing sent until confirmed
+      await del?.onConfirm();
+      expect(calls.list[0].method).toBe("lane.delete");
+
+      calls.list = [];
+      actions.mergeLane(lane());
+      const merge = actions.confirmOptions();
+      expect(calls.list).toHaveLength(0);
+      await merge?.onConfirm();
+      expect(calls.list[0].method).toBe("lane.merge");
+      dispose();
+    });
+  });
+
+  it("stop targets the agent's tmux window", async () => {
+    await createRoot(async (dispose) => {
+      const actions = createActionsStore(fleetStub());
+      const agent = { tmux_window: "lane-7" } as AgentSession;
+      actions.stopAgent(lane(), agent);
+      await actions.confirmOptions()?.onConfirm();
+      expect(calls.list[0]).toEqual({ method: "agent.stop", params: { lane_id: 7, window: "lane-7" } });
+      dispose();
+    });
+  });
+});

--- a/apps/desktop/src/stores/actions.test.ts
+++ b/apps/desktop/src/stores/actions.test.ts
@@ -79,3 +79,31 @@ describe("lane operations", () => {
     });
   });
 });
+
+describe("settings modal tab", () => {
+  it("openSettingsTab opens the modal on the requested tab", () => {
+    createRoot((dispose) => {
+      const actions = createActionsStore(fleetStub());
+      expect(actions.settingsOpen()).toBe(false);
+
+      actions.openSettingsTab("keyboard");
+      expect(actions.settingsOpen()).toBe(true);
+      expect(actions.settingsTab()).toBe("keyboard");
+      dispose();
+    });
+  });
+
+  it("openSettings resets to the general tab even after a prior keyboard-tab open", () => {
+    createRoot((dispose) => {
+      const actions = createActionsStore(fleetStub());
+      actions.openSettingsTab("keyboard");
+      actions.closeSettings();
+      expect(actions.settingsTab()).toBe("keyboard");
+
+      actions.openSettings();
+      expect(actions.settingsOpen()).toBe(true);
+      expect(actions.settingsTab()).toBe("general");
+      dispose();
+    });
+  });
+});

--- a/apps/desktop/src/stores/actions.test.ts
+++ b/apps/desktop/src/stores/actions.test.ts
@@ -68,6 +68,22 @@ describe("lane operations", () => {
     });
   });
 
+  it("delete and merge on a main worktree raise no confirm and send no RPC", async () => {
+    await createRoot(async (dispose) => {
+      const actions = createActionsStore(fleetStub());
+      const main = lane({ worktree: { id: 3, repo_id: 2, path: "/code/r", branch: "main", head: "abc", is_main: true, name: "r" } });
+
+      actions.deleteLane(main);
+      expect(actions.confirmOptions()).toBeNull();
+      expect(calls.list).toHaveLength(0);
+
+      actions.mergeLane(main);
+      expect(actions.confirmOptions()).toBeNull();
+      expect(calls.list).toHaveLength(0);
+      dispose();
+    });
+  });
+
   it("stop targets the agent's tmux window", async () => {
     await createRoot(async (dispose) => {
       const actions = createActionsStore(fleetStub());

--- a/apps/desktop/src/stores/actions.ts
+++ b/apps/desktop/src/stores/actions.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 
 import type { AgentSession, Lane, Repo } from "../bindings";
 import type { ConfirmOptions } from "../components/ConfirmDialog";
+import type { SettingsTab } from "../components/SettingsModal";
 import { pickDirectory } from "../ipc/dialog";
 import { daemonCall } from "../ipc/rpc";
 import type { FleetStore } from "./fleet";
@@ -15,6 +16,7 @@ export interface RenameTarget {
 /// header) can open one without threading callbacks. The matching <ActionModals> renders them.
 export function createActionsStore(fleet: FleetStore) {
   const [settingsOpen, setSettingsOpen] = createSignal(false);
+  const [settingsTab, setSettingsTab] = createSignal<SettingsTab>("general");
   const [spawnLane, setSpawnLane] = createSignal<Lane | null>(null);
   const [newLaneOpen, setNewLaneOpen] = createSignal(false);
   const [newLaneRepoId, setNewLaneRepoId] = createSignal<number | null>(null);
@@ -111,7 +113,15 @@ export function createActionsStore(fleet: FleetStore) {
     error,
     dismissError: () => setError(null),
     settingsOpen,
-    openSettings: () => setSettingsOpen(true),
+    settingsTab,
+    openSettings: () => {
+      setSettingsTab("general");
+      setSettingsOpen(true);
+    },
+    openSettingsTab: (tab: SettingsTab) => {
+      setSettingsTab(tab);
+      setSettingsOpen(true);
+    },
     closeSettings: () => setSettingsOpen(false),
     spawnLane,
     spawn: (lane: Lane) => setSpawnLane(lane),

--- a/apps/desktop/src/stores/actions.ts
+++ b/apps/desktop/src/stores/actions.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js";
 
-import type { Lane, Repo } from "../bindings";
+import type { AgentSession, Lane, Repo } from "../bindings";
 import type { ConfirmOptions } from "../components/ConfirmDialog";
 import { pickDirectory } from "../ipc/dialog";
 import { daemonCall } from "../ipc/rpc";
@@ -47,6 +47,65 @@ export function createActionsStore(fleet: FleetStore) {
     });
   }
 
+  /// Pin or unpin the lane. Pinning is not destructive, so it applies immediately.
+  async function pinLane(lane: Lane) {
+    setError(null);
+    try {
+      await daemonCall("agent.pin", { lane_id: lane.id, pinned: !lane.pinned });
+      await fleet.refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }
+
+  function mergeLane(lane: Lane) {
+    setConfirmOptions({
+      title: "Merge lane?",
+      message: `Merge ${lane.worktree.branch ?? lane.worktree.name} into the repository base branch.`,
+      confirmLabel: "Merge",
+      onConfirm: async () => {
+        await daemonCall("lane.merge", { lane_id: lane.id });
+        await fleet.refresh();
+      },
+    });
+  }
+
+  function deleteLane(lane: Lane) {
+    setConfirmOptions({
+      title: "Delete lane?",
+      message: `Remove the ${lane.worktree.name} worktree. The branch is kept.`,
+      confirmLabel: "Delete",
+      danger: true,
+      onConfirm: async () => {
+        await daemonCall("lane.delete", { lane_id: lane.id, also_delete_branch: false });
+        await fleet.refresh();
+      },
+    });
+  }
+
+  function stopAgent(lane: Lane, agent: AgentSession | null) {
+    setConfirmOptions({
+      title: "Stop agent?",
+      message: "Stop this managed agent. Its terminal session ends.",
+      confirmLabel: "Stop",
+      danger: true,
+      onConfirm: async () => {
+        await daemonCall("agent.stop", { lane_id: lane.id, window: agent?.tmux_window ?? undefined });
+        await fleet.refresh();
+      },
+    });
+  }
+
+  async function adoptAgent(lane: Lane, agent: AgentSession | null) {
+    setError(null);
+    try {
+      await daemonCall("agent.adopt", { lane_id: lane.id, session_id: agent?.session_id ?? undefined });
+      await fleet.refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }
+
   return {
     fleet,
     error,
@@ -72,6 +131,11 @@ export function createActionsStore(fleet: FleetStore) {
     closeConfirm: () => setConfirmOptions(null),
     addRepo,
     removeRepo,
+    pinLane,
+    mergeLane,
+    deleteLane,
+    stopAgent,
+    adoptAgent,
   };
 }
 

--- a/apps/desktop/src/stores/actions.ts
+++ b/apps/desktop/src/stores/actions.ts
@@ -61,6 +61,9 @@ export function createActionsStore(fleet: FleetStore) {
   }
 
   function mergeLane(lane: Lane) {
+    // The daemon refuses to delete or merge a main worktree, so do not raise a destructive
+    // prompt for an operation that cannot succeed.
+    if (lane.worktree.is_main) return;
     setConfirmOptions({
       title: "Merge lane?",
       message: `Merge ${lane.worktree.branch ?? lane.worktree.name} into the repository base branch.`,
@@ -73,9 +76,12 @@ export function createActionsStore(fleet: FleetStore) {
   }
 
   function deleteLane(lane: Lane) {
+    // The daemon refuses to delete or merge a main worktree, so do not raise a destructive
+    // prompt for an operation that cannot succeed.
+    if (lane.worktree.is_main) return;
     setConfirmOptions({
       title: "Delete lane?",
-      message: `Remove the ${lane.worktree.name} worktree. The branch is kept.`,
+      message: `Remove the ${lane.worktree.branch ?? lane.worktree.name} worktree. The branch is kept.`,
       confirmLabel: "Delete",
       danger: true,
       onConfirm: async () => {
@@ -86,9 +92,10 @@ export function createActionsStore(fleet: FleetStore) {
   }
 
   function stopAgent(lane: Lane, agent: AgentSession | null) {
+    const name = agent?.custom_label ?? agent?.title ?? agent?.agent;
     setConfirmOptions({
       title: "Stop agent?",
-      message: "Stop this managed agent. Its terminal session ends.",
+      message: name ? `Stop ${name}. Its terminal session ends.` : "Stop this managed agent. Its terminal session ends.",
       confirmLabel: "Stop",
       danger: true,
       onConfirm: async () => {
@@ -112,6 +119,7 @@ export function createActionsStore(fleet: FleetStore) {
     fleet,
     error,
     dismissError: () => setError(null),
+    reportError: (message: string) => setError(message),
     settingsOpen,
     settingsTab,
     openSettings: () => {

--- a/apps/desktop/src/stores/workspace.test.ts
+++ b/apps/desktop/src/stores/workspace.test.ts
@@ -12,7 +12,12 @@ function target(window: string): PaneTarget {
 }
 
 function fleetStub(): FleetStore {
-  return { refresh: vi.fn().mockResolvedValue(undefined), selectedLaneId: () => 7 } as unknown as FleetStore;
+  return {
+    refresh: vi.fn().mockResolvedValue(undefined),
+    selectedLaneId: () => 7,
+    lanes: () => [],
+    terminals: () => [],
+  } as unknown as FleetStore;
 }
 
 describe("workspace store", () => {

--- a/apps/desktop/src/stores/workspace.test.ts
+++ b/apps/desktop/src/stores/workspace.test.ts
@@ -1,0 +1,61 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PaneTarget } from "../components/terminalTargets";
+import { createWorkspaceStore } from "./workspace";
+import type { FleetStore } from "./fleet";
+
+vi.mock("../ipc/rpc", () => ({ daemonCall: vi.fn().mockResolvedValue({ id: "term-1" }) }));
+
+function target(window: string): PaneTarget {
+  return { laneId: 7, window, label: window, shell: false, sessionId: null };
+}
+
+function fleetStub(): FleetStore {
+  return { refresh: vi.fn().mockResolvedValue(undefined), selectedLaneId: () => 7 } as unknown as FleetStore;
+}
+
+describe("workspace store", () => {
+  it("cycles tabs with wraparound in both directions", () => {
+    createRoot((dispose) => {
+      const ws = createWorkspaceStore(fleetStub());
+      const tabs = [target("a"), target("b"), target("c")];
+
+      ws.setActiveWindow("a");
+      ws.cycleTab(1, tabs);
+      expect(ws.activeWindow()).toBe("b");
+
+      ws.cycleTab(-1, tabs);
+      expect(ws.activeWindow()).toBe("a");
+
+      // Wraps backwards off the front, and forwards off the end.
+      ws.cycleTab(-1, tabs);
+      expect(ws.activeWindow()).toBe("c");
+      ws.cycleTab(1, tabs);
+      expect(ws.activeWindow()).toBe("a");
+      dispose();
+    });
+  });
+
+  it("cycling is inert with no tabs and starts at the first when nothing is active", () => {
+    createRoot((dispose) => {
+      const ws = createWorkspaceStore(fleetStub());
+      ws.cycleTab(1, []);
+      expect(ws.activeWindow()).toBeNull();
+
+      ws.cycleTab(1, [target("a"), target("b")]);
+      expect(ws.activeWindow()).toBe("a");
+      dispose();
+    });
+  });
+
+  it("layout persists to localStorage", () => {
+    createRoot((dispose) => {
+      const ws = createWorkspaceStore(fleetStub());
+      ws.chooseLayout("grid");
+      expect(ws.layout()).toBe("grid");
+      expect(localStorage.getItem("repomon.workspace.layout")).toBe("grid");
+      dispose();
+    });
+  });
+});

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -1,0 +1,113 @@
+import { createMemo, createSignal } from "solid-js";
+
+import { daemonCall } from "../ipc/rpc";
+import type { TerminalRenderer } from "../ipc/term";
+import {
+  dedupe,
+  stabilizeTargets,
+  type PaneTarget,
+} from "../components/terminalTargets";
+import type { FleetStore } from "./fleet";
+
+export type WorkspaceLayout = "focused" | "split" | "grid";
+
+function readLayout(): WorkspaceLayout {
+  const value = localStorage.getItem("repomon.workspace.layout");
+  return value === "split" || value === "grid" ? value : "focused";
+}
+
+function readRenderer(): TerminalRenderer {
+  const value = localStorage.getItem("repomon.terminal.renderer");
+  // Default to "auto" (WebGL with automatic DOM fallback on context loss/failure): the DOM
+  // renderer re-lays-out on every frame and is by far the slowest way to run a busy terminal.
+  return value === "webgl" || value === "dom" ? value : "auto";
+}
+
+/// Owns workspace-level state that spans the terminal bay: layout mode, renderer choice, the
+/// active tab, and the derived pane target lists. Created once in App.tsx and handed down so the
+/// keyboard shortcut handlers (layout and tab cycling) have something to call.
+export function createWorkspaceStore(fleet: FleetStore) {
+  const [layout, setLayout] = createSignal<WorkspaceLayout>(readLayout());
+  const [renderer, setRenderer] = createSignal<TerminalRenderer>(readRenderer());
+  const [activeWindow, setActiveWindow] = createSignal<string | null>(null);
+
+  // Fleet polls every second and hands us a brand-new lanes array each time. Reconcile the
+  // rebuilt targets against this cache so each window keeps a stable object reference, and the
+  // reference-keyed <For> in the component keeps its TerminalPane (and its byte watch) mounted
+  // instead of tearing it down every poll.
+  const targetCache = new Map<string, PaneTarget>();
+  // `equals` keeps the previous array when the window set is unchanged (stabilizeTargets
+  // reuses object refs), so the 2s fleet poll stops cascading through laneTargets /
+  // visibleTargets / the viewport.set effect when nothing actually changed.
+  const sameTargets = (a: PaneTarget[], b: PaneTarget[]) =>
+    a.length === b.length && a.every((target, index) => target === b[index]);
+  // `createMemo` runs its computation once immediately (not lazily on first read), so guard the
+  // fleet reads with a fallback: unit tests that only stub the store methods they exercise
+  // (`refresh`, `selectedLaneId`) would otherwise throw the moment the store is constructed. The
+  // real FleetStore from `createFleetStore` always provides both accessors.
+  const lanes = () => fleet.lanes?.() ?? [];
+  const terminals = () => fleet.terminals?.() ?? [];
+  const targets = createMemo(() => stabilizeTargets(targetCache, dedupe(lanes().flatMap((lane) => [
+    ...lane.agent_sessions.flatMap((agent, index): PaneTarget[] => agent.tmux_window ? [{
+      laneId: lane.id,
+      window: agent.tmux_window,
+      label: agent.custom_label ?? agent.title ?? `${agent.agent} ${index + 1}`,
+      shell: false,
+      sessionId: agent.session_id,
+    }] : []),
+    ...terminals()
+      .filter((terminal) => terminal.lane_id === lane.id)
+      .map((terminal): PaneTarget => ({
+        laneId: lane.id,
+        window: terminal.id,
+        label: `shell ${terminal.id.split("-").slice(-1)[0]}`,
+        shell: true,
+        sessionId: null,
+      })),
+  ]))), undefined, { equals: sameTargets });
+
+  const laneTargets = createMemo(() => targets().filter((target) => target.laneId === fleet.selectedLaneId()));
+
+  function chooseLayout(next: WorkspaceLayout) {
+    setLayout(next);
+    localStorage.setItem("repomon.workspace.layout", next);
+  }
+
+  function chooseRenderer(next: TerminalRenderer) {
+    setRenderer(next);
+    localStorage.setItem("repomon.terminal.renderer", next);
+  }
+
+  /// Move to the next or previous tab, wrapping at both ends. `targets` is the lane's tab strip
+  /// in render order, passed in by the component so the store does not duplicate that memo.
+  function cycleTab(delta: number, targets: PaneTarget[]) {
+    if (targets.length === 0) return;
+    const index = targets.findIndex((target) => target.window === activeWindow());
+    // Nothing active yet: step in from the start rather than jumping to the end.
+    const next = index < 0 ? 0 : (index + delta + targets.length) % targets.length;
+    setActiveWindow(targets[next].window);
+  }
+
+  async function openShell() {
+    const laneId = fleet.selectedLaneId();
+    if (laneId === null) return;
+    const terminal = await daemonCall("terminal.open", { lane_id: laneId });
+    await fleet.refresh();
+    setActiveWindow(terminal.id);
+  }
+
+  return {
+    layout,
+    chooseLayout,
+    renderer,
+    chooseRenderer,
+    activeWindow,
+    setActiveWindow,
+    targets,
+    laneTargets,
+    cycleTab,
+    openShell,
+  };
+}
+
+export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>;

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -41,12 +41,8 @@ export function createWorkspaceStore(fleet: FleetStore) {
   // visibleTargets / the viewport.set effect when nothing actually changed.
   const sameTargets = (a: PaneTarget[], b: PaneTarget[]) =>
     a.length === b.length && a.every((target, index) => target === b[index]);
-  // `createMemo` runs its computation once immediately (not lazily on first read), so guard the
-  // fleet reads with a fallback: unit tests that only stub the store methods they exercise
-  // (`refresh`, `selectedLaneId`) would otherwise throw the moment the store is constructed. The
-  // real FleetStore from `createFleetStore` always provides both accessors.
-  const lanes = () => fleet.lanes?.() ?? [];
-  const terminals = () => fleet.terminals?.() ?? [];
+  const lanes = () => fleet.lanes();
+  const terminals = () => fleet.terminals();
   const targets = createMemo(() => stabilizeTargets(targetCache, dedupe(lanes().flatMap((lane) => [
     ...lane.agent_sessions.flatMap((agent, index): PaneTarget[] => agent.tmux_window ? [{
       laneId: lane.id,

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -84,12 +84,19 @@ export function createWorkspaceStore(fleet: FleetStore) {
     setActiveWindow(targets[next].window);
   }
 
-  async function openShell() {
+  /// Opens a shell terminal for the selected lane. Never rejects: a caller that does not pass
+  /// `onError` (the keyboard shortcut path, unlike the toolbar) would otherwise turn a daemon
+  /// failure into an unhandled rejection with no feedback for the user.
+  async function openShell(onError?: (message: string) => void) {
     const laneId = fleet.selectedLaneId();
     if (laneId === null) return;
-    const terminal = await daemonCall("terminal.open", { lane_id: laneId });
-    await fleet.refresh();
-    setActiveWindow(terminal.id);
+    try {
+      const terminal = await daemonCall("terminal.open", { lane_id: laneId });
+      await fleet.refresh();
+      setActiveWindow(terminal.id);
+    } catch (cause) {
+      onError?.(cause instanceof Error ? cause.message : String(cause));
+    }
   }
 
   return {

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -2,7 +2,7 @@ export type Theme = "light" | "dark" | "system";
 
 const storageKey = "repomon-theme";
 const themes: Theme[] = ["system", "dark", "light"];
-const accents: Record<string, string> = {
+export const ACCENTS: Record<string, string> = {
   cyan: "hsl(169 61% 49%)",
   green: "hsl(145 56% 45%)",
   magenta: "hsl(300 55% 52%)",
@@ -45,6 +45,6 @@ export function applyAccent(accent?: string | null): void {
     ? value
     : value === "mono" || value === "none" || value === "off"
       ? "var(--muted)"
-      : accents[value ?? "cyan"] ?? accents.cyan;
+      : ACCENTS[value ?? "cyan"] ?? ACCENTS.cyan;
   document.documentElement.style.setProperty("--signal", color);
 }

--- a/crates/repomon-core/src/agent/windows.rs
+++ b/crates/repomon-core/src/agent/windows.rs
@@ -400,6 +400,13 @@ mod host_backend {
         });
     }
 
+    /// The last registry scan with the instant it was taken, shared across overlay passes.
+    type ScanCache = Arc<Mutex<Option<(Instant, Vec<LiveHost>)>>>;
+
+    /// One pooled control connection slot per window. The outer lock guards the map, the inner
+    /// one serializes requests to a single window without blocking the others.
+    type ControlPool = Arc<Mutex<HashMap<String, Arc<Mutex<Option<ControlConn>>>>>>;
+
     /// The Windows [`SessionBackend`]: drives per-window `repomon-agent-host.exe` processes
     /// over their control pipes. Cheap to construct; all state is on disk (registry) or in the
     /// hosts themselves, so a new daemon re-adopts everything by scanning.
@@ -416,11 +423,11 @@ mod host_backend {
         /// times (`list_windows` + `live_agent_cwds`), and the GUI's fleet refresh adds
         /// `terminal.list_all` — without this, each call re-reads the registry dir and does a
         /// fresh pipe connect + hello roundtrip to EVERY live host, several times per 2s.
-        scan_cache: Arc<Mutex<Option<(Instant, Vec<LiveHost>)>>>,
+        scan_cache: ScanCache,
         /// Pooled control connections, one slot per window. Requests to one window serialize
         /// on the slot (roundtrips are sub-ms on a local pipe); different windows don't block
         /// each other.
-        control: Arc<Mutex<HashMap<String, Arc<Mutex<Option<ControlConn>>>>>>,
+        control: ControlPool,
     }
 
     /// How long a cached registry scan stays valid. Long enough to collapse the calls within

--- a/crates/repomon-daemon/src/path_env.rs
+++ b/crates/repomon-daemon/src/path_env.rs
@@ -46,12 +46,11 @@ fn login_shell_path() -> Option<String> {
 /// Existing well-known tool directories not already on `path`, in the order they should be added.
 fn fallback_dirs(path: &str) -> Vec<String> {
     let home = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf());
-    let candidates = FALLBACK_ABSOLUTE
-        .iter()
-        .map(PathBuf::from)
-        .chain(FALLBACK_HOME_RELATIVE.iter().filter_map(|rel| {
-            home.as_ref().map(|home| home.join(rel))
-        }));
+    let candidates = FALLBACK_ABSOLUTE.iter().map(PathBuf::from).chain(
+        FALLBACK_HOME_RELATIVE
+            .iter()
+            .filter_map(|rel| home.as_ref().map(|home| home.join(rel))),
+    );
     let mut dirs = Vec::new();
     for dir in candidates {
         if !dir.is_dir() {
@@ -101,7 +100,9 @@ mod tests {
         assert!(looks_minimal("/usr/bin:/bin:/usr/sbin:/sbin"));
         assert!(looks_minimal("  /usr/bin:/bin:/usr/sbin:/sbin  "));
         // A real user PATH, or any deliberate one, is left alone.
-        assert!(!looks_minimal("/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"));
+        assert!(!looks_minimal(
+            "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        ));
         assert!(!looks_minimal("/usr/bin:/bin"));
         assert!(!looks_minimal(""));
     }

--- a/crates/repomon-daemon/src/rpc.rs
+++ b/crates/repomon-daemon/src/rpc.rs
@@ -1052,7 +1052,13 @@ pub async fn dispatch(
             if let Some(id) = p.id {
                 args.push(id)
             }
-            run_cli_op(ctx, p.account.as_deref(), args, json!({ "scope": "global" })).await
+            run_cli_op(
+                ctx,
+                p.account.as_deref(),
+                args,
+                json!({ "scope": "global" }),
+            )
+            .await
         }
         "plugin.details" => {
             let p: IdOnly = parse(params)?;
@@ -1061,9 +1067,9 @@ pub async fn dispatch(
             let text = tokio::task::spawn_blocking(move || {
                 cli.run_for(config_dir.as_deref(), &["plugin", "details", &p.id])
             })
-                .await
-                .map_err(internal)?
-                .map_err(cli_error)?;
+            .await
+            .map_err(internal)?
+            .map_err(cli_error)?;
             Ok(json!({ "text": text }))
         }
         "marketplace.add" => {
@@ -1102,7 +1108,13 @@ pub async fn dispatch(
             if let Some(name) = p.name {
                 args.push(name)
             }
-            run_cli_op(ctx, p.account.as_deref(), args, json!({ "scope": "global" })).await
+            run_cli_op(
+                ctx,
+                p.account.as_deref(),
+                args,
+                json!({ "scope": "global" }),
+            )
+            .await
         }
 
         // ---- skills (create/read/write/delete SKILL.md, path-guarded) ----

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,0 +1,130 @@
+# Mission Control (desktop app)
+
+Mission Control is repomon's desktop client: the same fleet the TUI drives, in a window, with
+embedded terminals for every agent. It talks to the same daemon over the same socket, so the TUI,
+the desktop app, and the iOS client can all watch one fleet at once.
+
+## Install
+
+Preview builds are published to the moving
+[`desktop-preview`](https://github.com/AliHamzaAzam/repomon/releases/tag/desktop-preview) release
+for macOS, Windows, and Linux:
+
+| Platform | File |
+|---|---|
+| macOS (Apple silicon and Intel) | `Repomon_<version>_universal.dmg` |
+| Windows | `Repomon_<version>_x64-setup.exe` |
+| Linux | `Repomon_<version>_amd64.AppImage`, `.deb`, or `.rpm` |
+
+The app updates itself: it checks the same release on launch and from **Settings > General >
+Check for updates**, so you only download by hand once.
+
+The daemon ships inside the bundle, so the desktop app needs no separate `repomond`. It does still
+need `tmux` on macOS and Linux (`brew install tmux`, `sudo apt install tmux`). If you launch the
+app from the Dock or Finder rather than a terminal, it resolves your login shell's `PATH` at
+startup, so tools installed in `~/.local/bin` or `/opt/homebrew/bin` are found.
+
+## Keyboard control
+
+Everything the app does can be driven from the keyboard. Press `⌘?` (Ctrl+? elsewhere) to open the
+reference inside the app: it is generated from the same table that dispatches the shortcuts, so it
+cannot drift from what actually works.
+
+Shortcuts use a modifier on purpose. A focused terminal forwards every bare keystroke to the agent
+running in it, so an unmodified shortcut would steal the agent's input. `mod` below is **Cmd on
+macOS** and **Ctrl elsewhere**.
+
+### Panels
+
+| Chord | Action |
+|---|---|
+| `mod+,` | Open settings |
+| `mod+4` | Toggle extensions |
+| `mod+5` | Toggle repomind |
+| `mod+6` | Cycle theme (system, dark, light) |
+| `mod+k` | Open the control center |
+
+### Layout
+
+| Chord | Action |
+|---|---|
+| `mod+shift+1` | Focused layout, one pane |
+| `mod+shift+2` | Split layout, active pane plus its peer |
+| `mod+shift+0` | Grid layout, up to six panes |
+
+### Fleet
+
+| Chord | Action |
+|---|---|
+| `mod+/` | Filter the fleet |
+| `mod+u` | Show only lanes needing attention |
+| `mod+r` | Refresh |
+| `mod+n` | New lane |
+| `mod+shift+n` | Add repository |
+| `mod+g` | Jump to a lane needing attention |
+
+### Lane
+
+These need a selected lane. With nothing selected they do nothing.
+
+| Chord | Action |
+|---|---|
+| `mod+e` | Spawn agent |
+| `mod+t` | Open terminal |
+| `mod+p` | Pin or unpin lane |
+| `mod+d` | Delete lane (asks first) |
+| `mod+shift+m` | Merge lane (asks first) |
+| `mod+.` | Stop the agent in the visible pane (asks first) |
+
+### Agents
+
+| Chord | Action |
+|---|---|
+| `mod+[` | Previous agent tab |
+| `mod+]` | Next agent tab |
+
+### Terminals
+
+| Chord | Action |
+|---|---|
+| `shift+escape` | Leave the terminal, back to the fleet list |
+| `mod+shift+f` | Find in the terminal |
+
+`shift+escape` rather than plain Escape is deliberate: Claude Code uses Escape to interrupt its own
+work, so the terminal keeps it. Once focus is on the fleet list, `j`/`k` and the arrow keys move the
+selection and `/` jumps to the filter.
+
+## Settings
+
+**Settings > General** holds the default agent, the worktree path template, the auto-continue
+message, and the behavior toggles (auto-continue rate-limited agents, prompt on spawn, probe
+account usage, expand multi-agent lanes, embedded terminal renderer). The updater lives at the
+bottom.
+
+**Notifications** has a master switch plus one toggle per event: needs-you, rate-limited, resumed,
+idle, sound, show-why, coalescing, click-to-focus, and whether subagents count.
+
+**Appearance** sets the accent from a swatch or a custom hex value, and picks the repomind agent
+and model.
+
+**Keyboard** is the shortcut reference, with search.
+
+Settings are stored by the daemon and shared with the TUI, so a change here shows up there too.
+Nothing saves until you press **Save**.
+
+## Extensions
+
+The Extensions view manages Claude Code marketplaces, plugins, and skills, either globally or
+scoped to one repository.
+
+It is account-aware. If you run more than one Claude account (a default `~/.claude` plus a variant
+such as `~/.claude-work`), an account picker appears and every listing and action targets the
+account you choose. Codex is listed too, but it uses a different extension model, so it shows an
+empty state rather than pretending to have Claude-style plugins.
+
+## Known gaps
+
+- On Windows and Linux, `mod` is Ctrl, which is also the terminal's own control modifier. A bound
+  Ctrl chord pressed while a terminal is focused currently fires the GUI action **and** reaches the
+  agent. macOS is unaffected, since Cmd is not a terminal control key.
+- The iOS companion app is built but unreleased.


### PR DESCRIPTION
Makes the desktop GUI fully operable from the keyboard, documents every binding inside the app, and rebuilds Settings with real controls.

The TUI has driven everything from the keyboard since day one (`crates/repomon-tui/src/keybinds.rs`, about 35 actions). The GUI had roughly six shortcuts, and Settings rendered 14 booleans as raw checkboxes with free-text fields where pickers belong.

## What is in here

**Keyboard control.** A single table in `apps/desktop/src/keymap.ts` is the only source of truth for shortcuts. One `keydown` listener in `App.tsx` dispatches from it, replacing two ad-hoc listeners. Chords are modifier-based on purpose: a focused terminal forwards every bare keystroke to a live agent, so an unmodified shortcut would steal input.

**In-app reference.** `KeyboardHelp.tsx` renders that same table on a new Settings tab, with search. A test iterates `BINDINGS` and asserts each one appears, so help cannot drift from behavior.

**Settings.** Tabbed (General / Notifications / Appearance / Keyboard) with new `Switch`, `Select`, and `ColorField` controls. Same 21 settings as before, none added or removed, and Save remains an explicit button rather than save-on-change.

**Two refactors that had to come first.** Pin, merge, delete, stop, and adopt existed only as inline closures inside `ControlCenter.tsx`, and layout, the active agent tab, and open-shell were private to `TerminalWorkspace.tsx`. A shortcut had nothing to call, so they moved into `stores/actions.ts` and a new `stores/workspace.ts`. `ControlCenter` now shares one implementation instead of duplicating it.

## Bindings

`mod` is Cmd on macOS, Ctrl elsewhere. `mod+k` stays owned by `ControlCenter` and is documented as a static row.

| Section | Chord | Action |
|---|---|---|
| Panels | `mod+,` `mod+4` `mod+5` `mod+6` | Settings, Extensions, Repomind, cycle theme |
| Layout | `mod+shift+1` `mod+shift+2` `mod+shift+0` | Focused, Split, Grid |
| Fleet | `mod+/` `mod+u` `mod+r` `mod+n` `mod+shift+n` `mod+g` | Filter, urgent only, refresh, new lane, add repo, jump to needs-you |
| Lane | `mod+e` `mod+t` `mod+p` `mod+d` `mod+shift+m` `mod+.` | Spawn, terminal, pin, delete, merge, stop |
| Agents | `mod+[` `mod+]` | Previous / next agent tab |
| Help | `mod+?` | Keyboard reference |
| Terminal | `shift+escape` | Leave the terminal, back to the fleet list |

`shift+escape` rather than plain Escape is deliberate: Claude Code uses Escape to interrupt itself, so taking it would break a running agent. `isTerminalReleaseChord` is a pure, unit-tested predicate with a test asserting a plain Escape still reaches the agent.

## Review findings worth calling out

Each task was implemented and reviewed independently, then the whole branch was reviewed. Several defects were caught that would have shipped:

- **`chordOf` accepted Ctrl as well as Cmd on every platform.** On macOS that meant `Ctrl+D` sent EOF to the agent *and* opened a "Delete lane?" confirm which then stole focus. `Ctrl+R`, `Ctrl+U`, `Ctrl+E`, `Ctrl+T`, `Ctrl+[` all double-fired. Now platform-gated and tested.
- **`mod+shift+1/2/3` could never fire.** Shifted digits report `!`/`@`/`#` in `event.key`, so those chords matched nothing while help advertised them. Digits now match on `event.code`, which also fixes non-US layouts.
- **`mod+shift+3` collided with the macOS screenshot shortcut**, so Grid moved to `mod+shift+0`.
- **Deleting the old `Cmd+,` listener killed the Settings shortcut** with nothing replacing it. It is a table entry now, so it also appears in help.
- **Destructive chords on a main worktree** raised a confirm for an operation the daemon rejects. `deleteLane` and `mergeLane` now early-return on `is_main`.
- **`mod+.` could stop the wrong agent** on a multi-agent lane. It now prefers the visible pane's session and names it in the confirm.

## Known issue, not fixed here

On Windows and Linux, `mod` is Ctrl by design, and `TerminalPane` calls `preventDefault()` without `stopPropagation()`, so a bound Ctrl chord in a focused terminal fires the GUI action *and* reaches the agent. macOS is unaffected. Fixing it is a design decision (terminal wins while focused, or a different modifier on those platforms) rather than a one-line change, so it is tracked separately.

## Verification

87 frontend tests, 86 daemon tests, `tsc --noEmit` clean, `npm run build` clean, `cargo fmt --check` clean.

Not yet done: a live click-through in a running app. The checks that matter most are that chords fire while an agent terminal is focused without stealing the agent's typing, `mod+?` lands on the Keyboard tab, `shift+escape` then `j`/`k` moves the fleet selection, and that the Settings tab strip stays pinned while the body scrolls.

Ships as 0.5.14 preview.
